### PR TITLE
Remove OMOD-Framework as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "OMOD-Framework"]
-	path = OMOD-Framework
-	url = https://github.com/erri120/OMOD-Framework.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,9 +42,8 @@ The installer may have selected other options as well but these are the most imp
 ### Starting development
 
 1) **Fork and clone the project:** go to the Github repo page, click the fork button, copy the url from the forked repo, navigate to your project folder, open Git Bash or normal command prompt and type `git clone url name` and replace url with the copied url and name with the folder name
-2) **Initialize the submodules** using `git submodule init` and `git submodule update`
-3) **Open Wabbajack.sln** in Visual Studio 2019
-4) **Download NuGet Packages** by selecting the solution and *Right Click*->*Restore NuGet Packages*
+2) **Open Wabbajack.sln** in Visual Studio 2019
+3) **Download NuGet Packages** by selecting the solution and *Right Click*->*Restore NuGet Packages*
 
 It may take a while for Visual Studio to download all packages and update all References so be patience. Once all packages are downloaded go and try building Wabbajack. If the build is successful than good job, if not head over to the *#wabbajack-development* channel on the discord and talk about your build error.
 

--- a/Wabbajack.Common/Wabbajack.Common.csproj
+++ b/Wabbajack.Common/Wabbajack.Common.csproj
@@ -53,8 +53,11 @@
     <Reference Include="AlphaFS, Version=2.2.0.0, Culture=neutral, PublicKeyToken=4d31a58f7d7ad5c9, processorArchitecture=MSIL">
       <HintPath>..\packages\AlphaFS.2.2.6\lib\net452\AlphaFS.dll</HintPath>
     </Reference>
-    <Reference Include="ICSharpCode.SharpZipLib, Version=1.1.0.145, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpZipLib.1.1.0\lib\net45\ICSharpCode.SharpZipLib.dll</HintPath>
+    <Reference Include="erri120.OMODFramework, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\erri120.OMODFramework.1.0.0\lib\net472\erri120.OMODFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="ICSharpCode.SharpZipLib, Version=1.2.0.246, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpZipLib.1.2.0\lib\net45\ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>
     <Reference Include="INIFileParser, Version=2.5.2.0, Culture=neutral, PublicKeyToken=79af7b307b65cf3c, processorArchitecture=MSIL">
       <HintPath>..\packages\ini-parser.2.5.2\lib\net20\INIFileParser.dll</HintPath>
@@ -70,6 +73,9 @@
     </Reference>
     <Reference Include="protobuf-net, Version=2.4.0.0, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
       <HintPath>..\packages\protobuf-net.2.4.0\lib\net40\protobuf-net.dll</HintPath>
+    </Reference>
+    <Reference Include="SevenZip, Version=19.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SevenZip.19.0.0\lib\net20\SevenZip.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
@@ -106,10 +112,6 @@
     <ProjectReference Include="..\Compression.BSA\Compression.BSA.csproj">
       <Project>{ff5d892f-8ff4-44fc-8f7f-cd58f307ad1b}</Project>
       <Name>Compression.BSA</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\OMOD-Framework\OMOD-Framework\OMOD-Framework.csproj">
-      <Project>{1b2576a1-0208-485f-8e79-38551e4593b4}</Project>
-      <Name>OMOD-Framework</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/Wabbajack.Common/packages.config
+++ b/Wabbajack.Common/packages.config
@@ -1,12 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <packages>
   <package id="AlphaFS" version="2.2.6" targetFramework="net472" />
+  <package id="erri120.OMODFramework" version="1.0.0" targetFramework="net472" />
   <package id="ini-parser" version="2.5.2" targetFramework="net472" />
   <package id="murmurhash" version="1.0.3" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net472" />
   <package id="Newtonsoft.Json.Bson" version="1.0.2" targetFramework="net472" />
   <package id="protobuf-net" version="2.4.0" targetFramework="net472" />
-  <package id="SharpZipLib" version="1.1.0" targetFramework="net472" />
+  <package id="SevenZip" version="19.0.0" targetFramework="net472" />
+  <package id="SharpZipLib" version="1.2.0" targetFramework="net472" />
   <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net472" />
 </packages>

--- a/Wabbajack.sln
+++ b/Wabbajack.sln
@@ -30,8 +30,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wabbajack.WebAutomation.Tes
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wabbajack.Test", "Wabbajack.Test\Wabbajack.Test.csproj", "{A47FFF32-782B-4D9F-8704-C98FB32FA8CC}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OMOD-Framework", "OMOD-Framework\OMOD-Framework\OMOD-Framework.csproj", "{1B2576A1-0208-485F-8E79-38551E4593B4}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug (no commandargs)|Any CPU = Debug (no commandargs)|Any CPU
@@ -150,18 +148,6 @@ Global
 		{A47FFF32-782B-4D9F-8704-C98FB32FA8CC}.Release|Any CPU.Build.0 = Release|Any CPU
 		{A47FFF32-782B-4D9F-8704-C98FB32FA8CC}.Release|x64.ActiveCfg = Release|Any CPU
 		{A47FFF32-782B-4D9F-8704-C98FB32FA8CC}.Release|x64.Build.0 = Release|Any CPU
-		{1B2576A1-0208-485F-8E79-38551E4593B4}.Debug (no commandargs)|Any CPU.ActiveCfg = Release|Any CPU
-		{1B2576A1-0208-485F-8E79-38551E4593B4}.Debug (no commandargs)|Any CPU.Build.0 = Release|Any CPU
-		{1B2576A1-0208-485F-8E79-38551E4593B4}.Debug (no commandargs)|x64.ActiveCfg = Release|Any CPU
-		{1B2576A1-0208-485F-8E79-38551E4593B4}.Debug (no commandargs)|x64.Build.0 = Release|Any CPU
-		{1B2576A1-0208-485F-8E79-38551E4593B4}.Debug|Any CPU.ActiveCfg = Release|Any CPU
-		{1B2576A1-0208-485F-8E79-38551E4593B4}.Debug|Any CPU.Build.0 = Release|Any CPU
-		{1B2576A1-0208-485F-8E79-38551E4593B4}.Debug|x64.ActiveCfg = Release|Any CPU
-		{1B2576A1-0208-485F-8E79-38551E4593B4}.Debug|x64.Build.0 = Release|Any CPU
-		{1B2576A1-0208-485F-8E79-38551E4593B4}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{1B2576A1-0208-485F-8E79-38551E4593B4}.Release|Any CPU.Build.0 = Release|Any CPU
-		{1B2576A1-0208-485F-8E79-38551E4593B4}.Release|x64.ActiveCfg = Release|Any CPU
-		{1B2576A1-0208-485F-8E79-38551E4593B4}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
I published the framework as a NuGet package for use inside MO2. This also means that we can stop using the repo as a submodule and just use the package.