### PR TITLE
Update Changelog with changes made by #73

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Remove nexus timeout for login, it's pointless.
 * Force slides to load before displaying
 * Supress slide load failures
+* UI is now resizeable
 * Setup Crash handling at the very start of the app
 * Add BA2 support
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ### Changelog
 
 #### Version 0.9.5 - ???
+* New Property system for chaning Modlist Name, Author, Description, Website, custom Banner and custom Readme
+* Slideshow can now be disabled
+* NSFW mods can be toggled to not appear in the Slideshow
 * Set Oblivion's MO2 names to `Oblivion` not `oblivion`
 * Fix validation tests to run in CI
 * Add `check for broken archives` batch functionality


### PR DESCRIPTION
Moved property changes to the top because It's the most important and most noticeable thing for both modlist creators and modlist user