### PR TITLE
Removed UpdateLoop abort

### DIFF
--- a/Wabbajack/AppState.cs
+++ b/Wabbajack/AppState.cs
@@ -520,7 +520,6 @@ namespace Wabbajack
                         UIReady = true;
                         Running = false;
                         installing = false;
-                        slideshowThread.Abort();
                     }
                 })
                 {


### PR DESCRIPTION
Quick fix I noticed while developing other stuff.  Thought I'd push it real quick since you guys are discussing pushing another release.

The UpdateLoop abort that gets called after an Begin() run I don't think is desirable.  I had Lexy's guide fail on me when downloading Skyrim Realistic Overhaul, for example, and when trying to resume none of the CPU status or slideshow features worked because the thread was dead.

I think the work shortcircuiting it was trying to do is fine without it, as the slideshow code checks if it's installing and exits out if not.  So it's not a heavy thing to leave the thread running for a potential second install run