### PR TITLE
Fix duplicate requests to the NexusApi draining the rate limit

### DIFF
--- a/Wabbajack/NexusApi/NexusApi.cs
+++ b/Wabbajack/NexusApi/NexusApi.cs
@@ -182,7 +182,10 @@ namespace Wabbajack.NexusApi
             var response = responseTask.Result;
             UpdateRemaining(response);
 
-            using (var stream = _httpClient.GetStreamSync(url))
+            var contentTask = response.Content.ReadAsStreamAsync();
+            contentTask.Wait();
+
+            using (var stream = contentTask.Result)
             {
                 return stream.FromJSON<T>();
             }


### PR DESCRIPTION
In a previous PR, I mistakenly introduced a bug causing twice the amount of requests to the NexusApi than required.