### PR TITLE
Exit if user doesn't have Nexus premium during pack creation

### DIFF
--- a/Wabbajack/Compiler.cs
+++ b/Wabbajack/Compiler.cs
@@ -264,7 +264,7 @@ namespace Wabbajack
             if (IndexedArchives.Any(a => a.IniData?.General?.gameName != null))
             {
                 var nexusClient = new NexusApiClient();
-                if (!nexusClient.IsPremium) Info($"User {nexusClient.Username} is not a premium Nexus user, cannot continue");
+                if (!nexusClient.IsPremium) Error($"User {nexusClient.Username} is not a premium Nexus user, so we cannot access the necessary API calls, cannot continue");
 
             }
 


### PR DESCRIPTION
This is consistent with the other spot where premium is checked. I also added detail to the error message.

Since this was just marked info before, it would continue and fail on each file with "Error Getting Nexus Download URL - One or more errors occured." Nexus sends an error message in the returned JSON under the key `message`, but it wasn't immediately obvious to me how to extract that and return it as I don't use C#. Around https://github.com/wabbajack-tools/wabbajack/blob/master/Wabbajack/NexusApi/NexusApi.cs#L188 it's coerced into a `List<DownloadLink>`, I presume the "one or more errors" comes from that failing.