### PR TITLE
Slide show timing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ### Changelog
 
+#### Unreleased changes
+* Nothing yet...
+* Slideshow more responsive on pressing next
+
 #### Version 1.0 alpha 2 - 10/15/2019
 * Fix installer running in wrong mode
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Unreleased changes
 * Nothing yet...
 * Slideshow more responsive on pressing next
+* Slideshow timer resets when next is pressed
 
 #### Version 1.0 alpha 2 - 10/15/2019
 * Fix installer running in wrong mode

--- a/Wabbajack/UI/SlideShow.cs
+++ b/Wabbajack/UI/SlideShow.cs
@@ -151,8 +151,8 @@ namespace Wabbajack
                         this.WhenAny(x => x.Enable),
                         this.WhenAny(x => x.AppState.Installing),
                         resultSelector: (enabled, installing) => enabled && installing))
-                // Don't ever update more than once every half second.  ToDo: Update to debounce
-                .Throttle(TimeSpan.FromMilliseconds(500), RxApp.MainThreadScheduler)
+                // Don't ever update more than once every half second.
+                .Debounce(TimeSpan.FromMilliseconds(500), RxApp.MainThreadScheduler)
                 .ObserveOn(RxApp.MainThreadScheduler)
                 .Subscribe(_ => this.UpdateSlideShowItem())
                 .DisposeWith(this.CompositeDisposable);

--- a/Wabbajack/UI/SlideShow.cs
+++ b/Wabbajack/UI/SlideShow.cs
@@ -270,7 +270,7 @@ namespace Wabbajack
             var idx = _random.Next(0, SlideShowElements.Count);
             var element = SlideShowElements[idx];
 
-            if (checkLast)
+            if (checkLast && SlideShowElements.Count > 1)
             {
                 while (element == _lastSlide && (!element.IsNSFW || (element.IsNSFW && ShowNSFW)))
                 {


### PR DESCRIPTION
- Added Debounce logic to slideshow next button. Immediate response on clicking /w throttling on any following spam
- Natural slideshow rollover timer resets when user manually hits next
- Bugfix for infinite loop when only one slide available

The old throttle logic was bad because it waited its entire timespan before activating, and if any more clicks arrive in between, the timer would reset.  So if the user clicked constantly, it potentially would never actually go next.  In normal usage, this just meant it was delayed sluggish activation