### PR TITLE
Make it sync

### DIFF
--- a/Compression.BSA/BA2Reader.cs
+++ b/Compression.BSA/BA2Reader.cs
@@ -1,17 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Drawing;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-using Alphaleonis.Win32.Filesystem;
-using ICSharpCode.SharpZipLib.Zip;
 using ICSharpCode.SharpZipLib.Zip.Compression;
-using Microsoft.SqlServer.Server;
 using File = Alphaleonis.Win32.Filesystem.File;
 
 namespace Compression.BSA
@@ -188,7 +180,7 @@ namespace Compression.BSA
 
         public uint HeaderSize => DDS.HeaderSizeForFormat((DXGI_FORMAT)_format);
 
-        public async Task CopyDataToAsync(Stream output)
+        public void CopyDataTo(Stream output)
         {
             var bw = new BinaryWriter(output);
 
@@ -206,18 +198,18 @@ namespace Compression.BSA
 
                     if (!isCompressed)
                     {
-                        await br.BaseStream.ReadAsync(full, 0, full.Length);
+                        br.BaseStream.Read(full, 0, full.Length);
                     }
                     else
                     {
                         byte[] compressed = new byte[chunk._packSz];
-                        await br.BaseStream.ReadAsync(compressed, 0, compressed.Length);
+                        br.BaseStream.Read(compressed, 0, compressed.Length);
                         var inflater = new Inflater();
                         inflater.SetInput(compressed);
                         inflater.Inflate(full);
                     }
 
-                    await bw.BaseStream.WriteAsync(full, 0, full.Length);
+                    bw.BaseStream.Write(full, 0, full.Length);
                 }
             }
 
@@ -450,7 +442,7 @@ namespace Compression.BSA
         public uint Size => _realSize;
         public FileStateObject State => new BA2FileEntryState(this);
 
-        public async Task CopyDataToAsync(Stream output)
+        public void CopyDataTo(Stream output)
         {
             using (var fs = File.OpenRead(_bsa._filename))
             {
@@ -458,11 +450,11 @@ namespace Compression.BSA
                 uint len = Compressed ? _size : _realSize;
 
                 var bytes = new byte[len];
-                await fs.ReadAsync(bytes, 0, (int) len);
+                fs.Read(bytes, 0, (int) len);
 
                 if (!Compressed)
                 {
-                    await output.WriteAsync(bytes, 0, bytes.Length);
+                    output.Write(bytes, 0, bytes.Length);
                 }
                 else
                 {
@@ -470,7 +462,7 @@ namespace Compression.BSA
                     var inflater = new Inflater();
                     inflater.SetInput(bytes);
                     inflater.Inflate(uncompressed);
-                    await output.WriteAsync(uncompressed, 0, uncompressed.Length);
+                    output.Write(uncompressed, 0, uncompressed.Length);
                 }
             }
         }

--- a/Compression.BSA/BSABuilder.cs
+++ b/Compression.BSA/BSABuilder.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using ICSharpCode.SharpZipLib.Zip.Compression.Streams;
 using K4os.Compression.LZ4;
 using K4os.Compression.LZ4.Streams;
@@ -77,11 +76,11 @@ namespace Compression.BSA
         public void Dispose()
         {
         }
-        public async Task AddFile(FileStateObject state, Stream src)
+        public void AddFile(FileStateObject state, Stream src)
         {
             var ostate = (BSAFileStateObject) state;
 
-            var r = await FileEntry.Create(this, ostate.Path, src, ostate.FlipCompression);
+            var r = FileEntry.Create(this, ostate.Path, src, ostate.FlipCompression);
 
             lock (this)
             {
@@ -89,7 +88,7 @@ namespace Compression.BSA
             }
         }
 
-        public async Task Build(string outputName)
+        public void Build(string outputName)
         {
             RegenFolderRecords();
             if (File.Exists(outputName)) File.Delete(outputName);
@@ -122,7 +121,7 @@ namespace Compression.BSA
                 foreach (var file in _files) wtr.Write(file._nameBytes);
 
                 foreach (var file in _files) 
-                    await file.WriteData(wtr);
+                    file.WriteData(wtr);
             }
         }
 
@@ -237,7 +236,7 @@ namespace Compression.BSA
         internal byte[] _pathBytes;
         internal byte[] _rawData;
 
-        public static async Task<FileEntry> Create(BSABuilder bsa, string path, Stream src, bool flipCompression)
+        public static FileEntry Create(BSABuilder bsa, string path, Stream src, bool flipCompression)
         {
             var entry = new FileEntry();
             entry._bsa = bsa;
@@ -250,7 +249,7 @@ namespace Compression.BSA
             entry._flipCompression = flipCompression;
 
             var ms = new MemoryStream();
-            await src.CopyToAsync(ms);
+            src.CopyTo(ms);
             entry._rawData = ms.ToArray();
             entry._originalSize = entry._rawData.Length;
 
@@ -321,7 +320,7 @@ namespace Compression.BSA
             wtr.Write(0xDEADBEEF);
         }
 
-        internal async Task WriteData(BinaryWriter wtr)
+        internal void WriteData(BinaryWriter wtr)
         {
             var offset = (uint) wtr.BaseStream.Position;
             wtr.BaseStream.Position = _offsetOffset;
@@ -333,11 +332,11 @@ namespace Compression.BSA
             if (Compressed)
             {
                 wtr.Write((uint) _originalSize);
-                await wtr.BaseStream.WriteAsync(_rawData, 0, _rawData.Length);
+                wtr.BaseStream.Write(_rawData, 0, _rawData.Length);
             }
             else
             {
-                await wtr.BaseStream.WriteAsync(_rawData, 0, _rawData.Length);
+                wtr.BaseStream.Write(_rawData, 0, _rawData.Length);
             }
         }
     }

--- a/Compression.BSA/BSADispatch.cs
+++ b/Compression.BSA/BSADispatch.cs
@@ -1,32 +1,23 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
+﻿using System.IO;
 using System.Text;
-using System.Threading.Tasks;
-using Wabbajack.Common.CSP;
 
 namespace Compression.BSA
 {
     public static class BSADispatch
     {
-        public static Task<IBSAReader> OpenRead(string filename)
+        public static IBSAReader OpenRead(string filename)
         {
-            return CSPExtensions.ThreadedTask<IBSAReader>(() =>
+            var fourcc = "";
+            using (var file = File.OpenRead(filename))
             {
-                string fourcc = "";
-                using (var file = File.OpenRead(filename))
-                {
-                    fourcc = Encoding.ASCII.GetString(new BinaryReader(file).ReadBytes(4));
-                }
+                fourcc = Encoding.ASCII.GetString(new BinaryReader(file).ReadBytes(4));
+            }
 
-                if (fourcc == "BSA\0")
-                    return new BSAReader(filename);
-                if (fourcc == "BTDX")
-                    return new BA2Reader(filename);
-                throw new InvalidDataException("Filename is not a .bsa or .ba2, magic " + fourcc);
-
-            });
+            if (fourcc == "BSA\0")
+                return new BSAReader(filename);
+            if (fourcc == "BTDX")
+                return new BA2Reader(filename);
+            throw new InvalidDataException("Filename is not a .bsa or .ba2, magic " + fourcc);
         }
     }
 }

--- a/Compression.BSA/BSAReader.cs
+++ b/Compression.BSA/BSAReader.cs
@@ -2,8 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using ICSharpCode.SharpZipLib.Zip.Compression.Streams;
 using K4os.Compression.LZ4.Streams;
 using File = Alphaleonis.Win32.Filesystem.File;
@@ -303,7 +301,7 @@ namespace Compression.BSA
             _name = rdr.ReadStringTerm(_bsa.HeaderType);
         }
 
-        public async Task CopyDataToAsync(Stream output)
+        public void CopyDataTo(Stream output)
         {
             using (var in_file = File.OpenRead(_bsa._fileName))
             using (var rdr = new BinaryReader(in_file))
@@ -315,11 +313,11 @@ namespace Compression.BSA
                     if (Compressed)
                     {
                         var r = LZ4Stream.Decode(rdr.BaseStream);
-                        await r.CopyToLimitAsync(output, (int) _originalSize);
+                        r.CopyToLimit(output, (int) _originalSize);
                     }
                     else
                     {
-                        await rdr.BaseStream.CopyToLimitAsync(output, (int) _onDiskSize);
+                        rdr.BaseStream.CopyToLimit(output, (int) _onDiskSize);
                     }
                 }
                 else
@@ -327,18 +325,18 @@ namespace Compression.BSA
                     if (Compressed)
                         using (var z = new InflaterInputStream(rdr.BaseStream))
                         {
-                            await z.CopyToLimitAsync(output, (int) _originalSize);
+                            z.CopyToLimit(output, (int) _originalSize);
                         }
                     else
-                        await rdr.BaseStream.CopyToLimitAsync(output, (int) _onDiskSize);
+                        rdr.BaseStream.CopyToLimit(output, (int) _onDiskSize);
                 }
             }
         }
 
-        public async Task<byte[]> GetData()
+        public byte[] GetData()
         {
             var ms = new MemoryStream();
-            await CopyDataToAsync(ms);
+            CopyDataTo(ms);
             return ms.ToArray();
         }
     }

--- a/Compression.BSA/Compression.BSA.csproj
+++ b/Compression.BSA/Compression.BSA.csproj
@@ -110,11 +110,5 @@
       <Version>1.2.0</Version>
     </PackageReference>
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Wabbajack.Common.CSP\Wabbajack.Common.CSP.csproj">
-      <Project>{9e69bc98-1512-4977-b683-6e7e5292c0b8}</Project>
-      <Name>Wabbajack.Common.CSP</Name>
-    </ProjectReference>
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Compression.BSA/DDS.cs
+++ b/Compression.BSA/DDS.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Runtime.InteropServices;
 
 namespace Compression.BSA
 {

--- a/Compression.BSA/IBSAReader.cs
+++ b/Compression.BSA/IBSAReader.cs
@@ -1,9 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Compression.BSA
 {
@@ -19,8 +16,8 @@ namespace Compression.BSA
 
     public interface IBSABuilder : IDisposable
     {
-        Task AddFile(FileStateObject state, Stream src);
-        Task Build(string filename);
+        void AddFile(FileStateObject state, Stream src);
+        void Build(string filename);
     }
 
     public class ArchiveStateObject
@@ -59,6 +56,6 @@ namespace Compression.BSA
         /// in order to maintain thread-safe access. 
         /// </summary>
         /// <param name="output"></param>
-        Task CopyDataToAsync(Stream output);
+        void CopyDataTo(Stream output);
     }
 }

--- a/Compression.BSA/Utils.cs
+++ b/Compression.BSA/Utils.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
-using System.Threading.Tasks;
 using Path = Alphaleonis.Win32.Filesystem.Path;
 
 namespace Compression.BSA
@@ -140,20 +139,6 @@ namespace Compression.BSA
             for (var i = 0; i < ext.Length; i++) hash3 = hash3 * 0x1003f + (byte) ext[i];
 
             return ((ulong) (hash2 + hash3) << 32) + hash1;
-        }
-
-        public static async Task CopyToLimitAsync(this Stream frm, Stream tw, int limit)
-        {
-            var buff = new byte[1024 * 16];
-            while (limit > 0)
-            {
-                var to_read = Math.Min(buff.Length, limit);
-                var read = await frm.ReadAsync(buff, 0, to_read);
-                await tw.WriteAsync(buff, 0, read);
-                limit -= read;
-            }
-
-            await tw.FlushAsync();
         }
 
         public static void CopyToLimit(this Stream frm, Stream tw, int limit)

--- a/Compression.BSA/Utils.cs
+++ b/Compression.BSA/Utils.cs
@@ -144,7 +144,7 @@ namespace Compression.BSA
 
         public static async Task CopyToLimitAsync(this Stream frm, Stream tw, int limit)
         {
-            var buff = new byte[1024];
+            var buff = new byte[1024 * 16];
             while (limit > 0)
             {
                 var to_read = Math.Min(buff.Length, limit);
@@ -153,7 +153,7 @@ namespace Compression.BSA
                 limit -= read;
             }
 
-            tw.Flush();
+            await tw.FlushAsync();
         }
 
         public static void CopyToLimit(this Stream frm, Stream tw, int limit)

--- a/Wabbajack.Lib/CompilationSteps/DeconstructBSAs.cs
+++ b/Wabbajack.Lib/CompilationSteps/DeconstructBSAs.cs
@@ -77,7 +77,7 @@ namespace Wabbajack.Lib.CompilationSteps
             }
 
             CreateBSA directive;
-            using (var bsa = BSADispatch.OpenRead(source.AbsolutePath).Result)
+            using (var bsa = BSADispatch.OpenRead(source.AbsolutePath))
             {
                 directive = new CreateBSA
                 {

--- a/Wabbajack.Lib/Compiler.cs
+++ b/Wabbajack.Lib/Compiler.cs
@@ -28,6 +28,7 @@ namespace Wabbajack.Lib
 {
     public class Compiler : ACompiler
     {
+
         private string _mo2DownloadsFolder;
 
         public Dictionary<string, IEnumerable<IndexedFileMatch>> DirectMatchIndex;
@@ -49,6 +50,8 @@ namespace Wabbajack.Lib
 
             ModListOutputFolder = "output_folder";
             ModListOutputFile = MO2Profile + ExtensionManager.Extension;
+            VFS.ProgressUpdates.Debounce(new TimeSpan(0, 0, 0, 0, 100))
+                .Subscribe(itm => _progressUpdates.OnNext(itm));
         }
 
         public dynamic MO2Ini { get; }
@@ -119,13 +122,24 @@ namespace Wabbajack.Lib
 
             Info("Using Profiles: " + string.Join(", ", SelectedProfiles.OrderBy(p => p)));
 
+            VFS.IntegrateFromFile(_vfsCacheName).Wait();
+
             Info($"Indexing {MO2Folder}");
             VFS.AddRoot(MO2Folder).Wait();
+
+            VFS.WriteToFile(_vfsCacheName).Wait();
+
             Info($"Indexing {GamePath}");
             VFS.AddRoot(GamePath).Wait();
 
+            VFS.WriteToFile(_vfsCacheName).Wait();
+
+
             Info($"Indexing {MO2DownloadsFolder}");
             VFS.AddRoot(MO2DownloadsFolder).Wait();
+
+            VFS.WriteToFile(_vfsCacheName).Wait();
+
 
             Info("Cleaning output folder");
             if (Directory.Exists(ModListOutputFolder))
@@ -151,6 +165,8 @@ namespace Wabbajack.Lib
             {
                 Info($"Indexing {loot_path}");
                 VFS.AddRoot(loot_path).Wait();
+                VFS.WriteToFile(_vfsCacheName).Wait();
+
 
                 loot_files = Directory.EnumerateFiles(loot_path, "userlist.yaml", SearchOption.AllDirectories)
                     .Where(p => p.FileExists())

--- a/Wabbajack.Lib/Compiler.cs
+++ b/Wabbajack.Lib/Compiler.cs
@@ -122,23 +122,23 @@ namespace Wabbajack.Lib
 
             Info("Using Profiles: " + string.Join(", ", SelectedProfiles.OrderBy(p => p)));
 
-            VFS.IntegrateFromFile(_vfsCacheName).Wait();
+            VFS.IntegrateFromFile(_vfsCacheName);
 
             Info($"Indexing {MO2Folder}");
-            VFS.AddRoot(MO2Folder).Wait();
+            VFS.AddRoot(MO2Folder);
 
-            VFS.WriteToFile(_vfsCacheName).Wait();
+            VFS.WriteToFile(_vfsCacheName);
 
             Info($"Indexing {GamePath}");
-            VFS.AddRoot(GamePath).Wait();
+            VFS.AddRoot(GamePath);
 
-            VFS.WriteToFile(_vfsCacheName).Wait();
+            VFS.WriteToFile(_vfsCacheName);
 
 
             Info($"Indexing {MO2DownloadsFolder}");
-            VFS.AddRoot(MO2DownloadsFolder).Wait();
+            VFS.AddRoot(MO2DownloadsFolder);
 
-            VFS.WriteToFile(_vfsCacheName).Wait();
+            VFS.WriteToFile(_vfsCacheName);
 
 
             Info("Cleaning output folder");
@@ -164,8 +164,8 @@ namespace Wabbajack.Lib
             if (Directory.Exists(loot_path))
             {
                 Info($"Indexing {loot_path}");
-                VFS.AddRoot(loot_path).Wait();
-                VFS.WriteToFile(_vfsCacheName).Wait();
+                VFS.AddRoot(loot_path);
+                VFS.WriteToFile(_vfsCacheName);
 
 
                 loot_files = Directory.EnumerateFiles(loot_path, "userlist.yaml", SearchOption.AllDirectories)
@@ -468,13 +468,13 @@ namespace Wabbajack.Lib
                 var bsa_id = to.Split('\\')[1];
                 var bsa = InstallDirectives.OfType<CreateBSA>().First(b => b.TempID == bsa_id);
 
-                using (var a = await BSADispatch.OpenRead(Path.Combine(MO2Folder, bsa.To)))
+                using (var a = BSADispatch.OpenRead(Path.Combine(MO2Folder, bsa.To)))
                 {
                     var find = Path.Combine(to.Split('\\').Skip(2).ToArray());
                     var file = a.Files.First(e => e.Path.Replace('/', '\\') == find);
                     using (var ms = new MemoryStream())
                     {
-                        await file.CopyDataToAsync(ms);
+                        file.CopyDataTo(ms);
                         return ms.ToArray();
                     }
                 }

--- a/Wabbajack.Lib/Installer.cs
+++ b/Wabbajack.Lib/Installer.cs
@@ -150,7 +150,7 @@ namespace Wabbajack.Lib
                     Error("Cannot continue, was unable to download one or more archives");
             }
 
-            PrimeVFS().Wait();
+            PrimeVFS();
 
             BuildFolderStructure();
             InstallArchives();
@@ -233,7 +233,7 @@ namespace Wabbajack.Lib
         ///     We don't want to make the installer index all the archives, that's just a waste of time, so instead
         ///     we'll pass just enough information to VFS to let it know about the files we have.
         /// </summary>
-        private async Task PrimeVFS()
+        private void PrimeVFS()
         {
             VFS.AddKnown(HashedArchives.Select(a => new KnownFile
             {
@@ -247,7 +247,7 @@ namespace Wabbajack.Lib
                 .OfType<FromArchive>()
                 .Select(f => new KnownFile { Paths = f.ArchiveHashPath}));
 
-            await VFS.BackfillMissing();
+            VFS.BackfillMissing();
         }
 
         private void BuildBSAs()
@@ -386,7 +386,7 @@ namespace Wabbajack.Lib
                 return g;
             }).ToList();
 
-            var on_finish = VFS.Stage(vfiles.Select(f => f.FromFile).Distinct()).Result;
+            var on_finish = VFS.Stage(vfiles.Select(f => f.FromFile).Distinct());
 
 
             Status($"Copying files for {archive.Name}");

--- a/Wabbajack.Lib/VortexCompiler.cs
+++ b/Wabbajack.Lib/VortexCompiler.cs
@@ -95,13 +95,13 @@ namespace Wabbajack.Lib
             CreateMetaFiles();
 
             Info($"Indexing {StagingFolder}");
-            VFS.AddRoot(StagingFolder).Wait();
+            VFS.AddRoot(StagingFolder);
 
             Info($"Indexing {GamePath}");
-            VFS.AddRoot(GamePath).Wait();
+            VFS.AddRoot(GamePath);
 
             Info($"Indexing {DownloadsFolder}");
-            VFS.AddRoot(DownloadsFolder).Wait();
+            VFS.AddRoot(DownloadsFolder);
 
             AddExternalFolder();
 

--- a/Wabbajack.Lib/VortexInstaller.cs
+++ b/Wabbajack.Lib/VortexInstaller.cs
@@ -156,7 +156,7 @@ namespace Wabbajack.Lib
                 return g;
             }).ToList();
 
-            var onFinish = VFS.Stage(vFiles.Select(f => f.FromFile).Distinct()).Result;
+            var onFinish = VFS.Stage(vFiles.Select(f => f.FromFile).Distinct());
 
             Status($"Copying files for {archive.Name}");
 

--- a/Wabbajack.Test/EndToEndTests.cs
+++ b/Wabbajack.Test/EndToEndTests.cs
@@ -90,9 +90,9 @@ namespace Wabbajack.Test
             File.Copy(src, Path.Combine(utils.DownloadsFolder, filename));
 
             if (mod_name == null)
-                FileExtractor.ExtractAll(src, utils.MO2Folder).Wait();
+                FileExtractor.ExtractAll(src, utils.MO2Folder);
             else
-                FileExtractor.ExtractAll(src, Path.Combine(utils.ModsFolder, mod_name)).Wait();
+                FileExtractor.ExtractAll(src, Path.Combine(utils.ModsFolder, mod_name));
 
         }
 
@@ -127,7 +127,7 @@ namespace Wabbajack.Test
             var dest = Path.Combine(utils.DownloadsFolder, file.file_name);
             File.Copy(src, dest);
 
-            FileExtractor.ExtractAll(src, Path.Combine(utils.ModsFolder, mod_name)).Wait();
+            FileExtractor.ExtractAll(src, Path.Combine(utils.ModsFolder, mod_name));
 
             File.WriteAllText(dest + ".meta", ini);
         }

--- a/Wabbajack.VirtualFileSystem.Test/VirtualFileSystemTests.cs
+++ b/Wabbajack.VirtualFileSystem.Test/VirtualFileSystemTests.cs
@@ -29,10 +29,10 @@ namespace Wabbajack.VirtualFileSystem.Test
         }
 
         [TestMethod]
-        public async Task FilesAreIndexed()
+        public void FilesAreIndexed()
         {
             AddFile("test.txt", "This is a test");
-            await AddTestRoot();
+            AddTestRoot();
 
             var file = context.Index.ByFullPath[Path.Combine(VFS_TEST_DIR_FULL, "test.txt")];
             Assert.IsNotNull(file);
@@ -41,11 +41,11 @@ namespace Wabbajack.VirtualFileSystem.Test
             Assert.AreEqual(file.Hash, "qX0GZvIaTKM=");
         }
 
-        private async Task AddTestRoot()
+        private void AddTestRoot()
         {
-            await context.AddRoot(VFS_TEST_DIR_FULL);
-            await context.WriteToFile(Path.Combine(VFS_TEST_DIR_FULL, "vfs_cache.bin"));
-            await context.IntegrateFromFile(Path.Combine(VFS_TEST_DIR_FULL, "vfs_cache.bin"));
+            context.AddRoot(VFS_TEST_DIR_FULL);
+            context.WriteToFile(Path.Combine(VFS_TEST_DIR_FULL, "vfs_cache.bin"));
+            context.IntegrateFromFile(Path.Combine(VFS_TEST_DIR_FULL, "vfs_cache.bin"));
         }
 
 
@@ -54,7 +54,7 @@ namespace Wabbajack.VirtualFileSystem.Test
         {
             AddFile("archive/test.txt", "This is a test");
             ZipUpFolder("archive", "test.zip");
-            await AddTestRoot();
+            AddTestRoot();
 
             var abs_path = Path.Combine(VFS_TEST_DIR_FULL, "test.zip");
             var file = context.Index.ByFullPath[abs_path];
@@ -77,7 +77,7 @@ namespace Wabbajack.VirtualFileSystem.Test
             ZipUpFolder("archive", "test.zip");
 
             AddFile("test.txt", "This is a test");
-            await AddTestRoot();
+            AddTestRoot();
 
 
             var files = context.Index.ByHash["qX0GZvIaTKM="];
@@ -88,7 +88,7 @@ namespace Wabbajack.VirtualFileSystem.Test
         public async Task DeletedFilesAreRemoved()
         {
             AddFile("test.txt", "This is a test");
-            await AddTestRoot();
+            AddTestRoot();
 
             var file = context.Index.ByFullPath[Path.Combine(VFS_TEST_DIR_FULL, "test.txt")];
             Assert.IsNotNull(file);
@@ -98,21 +98,21 @@ namespace Wabbajack.VirtualFileSystem.Test
 
             File.Delete(Path.Combine(VFS_TEST_DIR_FULL, "test.txt"));
 
-            await AddTestRoot();
+            AddTestRoot();
 
             CollectionAssert.DoesNotContain(context.Index.ByFullPath, Path.Combine(VFS_TEST_DIR_FULL, "test.txt"));
         }
 
         [TestMethod]
-        public async Task UnmodifiedFilesAreNotReIndexed()
+        public void UnmodifiedFilesAreNotReIndexed()
         {
             AddFile("test.txt", "This is a test");
-            await AddTestRoot();
+            AddTestRoot();
 
             var old_file = context.Index.ByFullPath[Path.Combine(VFS_TEST_DIR_FULL, "test.txt")];
             var old_time = old_file.LastAnalyzed;
 
-            await AddTestRoot();
+            AddTestRoot();
 
             var new_file = context.Index.ByFullPath[Path.Combine(VFS_TEST_DIR_FULL, "test.txt")];
 
@@ -120,23 +120,23 @@ namespace Wabbajack.VirtualFileSystem.Test
         }
 
         [TestMethod]
-        public async Task CanStageSimpleArchives()
+        public void CanStageSimpleArchives()
         {
             AddFile("archive/test.txt", "This is a test");
             ZipUpFolder("archive", "test.zip");
-            await AddTestRoot();
+            AddTestRoot();
 
             var abs_path = Path.Combine(VFS_TEST_DIR_FULL, "test.zip");
             var file = context.Index.ByFullPath[abs_path + "|test.txt"];
 
-            var cleanup = await context.Stage(new List<VirtualFile> {file});
+            var cleanup = context.Stage(new List<VirtualFile> {file});
             Assert.AreEqual("This is a test", File.ReadAllText(file.StagedPath));
 
             cleanup();
         }
 
         [TestMethod]
-        public async Task CanStageNestedArchives()
+        public void CanStageNestedArchives()
         {
             AddFile("archive/test.txt", "This is a test");
             ZipUpFolder("archive", "test.zip");
@@ -146,11 +146,11 @@ namespace Wabbajack.VirtualFileSystem.Test
                 Path.Combine(VFS_TEST_DIR_FULL, @"archive\other\dir\nested.zip"));
             ZipUpFolder("archive", "test.zip");
 
-            await AddTestRoot();
+            AddTestRoot();
 
             var files = context.Index.ByHash["qX0GZvIaTKM="];
 
-            var cleanup = await context.Stage(files);
+            var cleanup = context.Stage(files);
 
             foreach (var file in files)
                 Assert.AreEqual("This is a test", File.ReadAllText(file.StagedPath));
@@ -159,7 +159,7 @@ namespace Wabbajack.VirtualFileSystem.Test
         }
 
         [TestMethod]
-        public async Task CanRequestPortableFileTrees()
+        public void CanRequestPortableFileTrees()
         {
             AddFile("archive/test.txt", "This is a test");
             ZipUpFolder("archive", "test.zip");
@@ -169,7 +169,7 @@ namespace Wabbajack.VirtualFileSystem.Test
                 Path.Combine(VFS_TEST_DIR_FULL, @"archive\other\dir\nested.zip"));
             ZipUpFolder("archive", "test.zip");
 
-            await AddTestRoot();
+            AddTestRoot();
 
             var files = context.Index.ByHash["qX0GZvIaTKM="];
             var archive = context.Index.ByRootPath[Path.Combine(VFS_TEST_DIR_FULL, "test.zip")];
@@ -178,12 +178,12 @@ namespace Wabbajack.VirtualFileSystem.Test
 
             var new_context = new Context();
 
-            await new_context.IntegrateFromPortable(state,
+            new_context.IntegrateFromPortable(state,
                 new Dictionary<string, string> {{archive.Hash, archive.FullPath}});
 
             var new_files = new_context.Index.ByHash["qX0GZvIaTKM="];
 
-            var close = await new_context.Stage(new_files);
+            var close = new_context.Stage(new_files);
 
             foreach (var file in new_files)
                 Assert.AreEqual("This is a test", File.ReadAllText(file.StagedPath));

--- a/Wabbajack.VirtualFileSystem/Context.cs
+++ b/Wabbajack.VirtualFileSystem/Context.cs
@@ -46,15 +46,12 @@ namespace Wabbajack.VirtualFileSystem
             return new TemporaryDirectory(Path.Combine(_stagingFolder, Guid.NewGuid().ToString()));
         }
 
-        public async Task<IndexRoot> AddRoot(string root)
+        public IndexRoot AddRoot(string root)
         {
             if (!Path.IsPathRooted(root))
                 throw new InvalidDataException($"Path is not absolute: {root}");
 
-            var filtered = await Index.AllFiles
-                .ToChannel()
-                .UnorderedPipelineRx(o => o.Where(file => File.Exists(file.Name)))
-                .TakeAll();
+            var filtered = Index.AllFiles.Where(file => File.Exists(file.Name)).ToList();
 
             var byPath = filtered.ToImmutableDictionary(f => f.Name);
 
@@ -62,26 +59,20 @@ namespace Wabbajack.VirtualFileSystem
             
             var results = Channel.Create(1024, ProgressUpdater<VirtualFile>($"Indexing {root}", filesToIndex.Count));
 
-            var pipeline = filesToIndex
-                .ToChannel()
-                .UnorderedPipeline(results, async f =>
-                {
-                    if (byPath.TryGetValue(f, out var found))
-                    {
-                        var fi = new FileInfo(f);
-                        if (found.LastModified == fi.LastWriteTimeUtc.Ticks && found.Size == fi.Length)
-                            return found;
-                    }
+            var allFiles= filesToIndex
+                            .PMap(f =>
+                            {
+                                if (byPath.TryGetValue(f, out var found))
+                                {
+                                    var fi = new FileInfo(f);
+                                    if (found.LastModified == fi.LastWriteTimeUtc.Ticks && found.Size == fi.Length)
+                                        return found;
+                                }
 
-                    return await VirtualFile.Analyze(this, null, f, f);
-                });
+                                return VirtualFile.Analyze(this, null, f, f);
+                            });
 
-            var allFiles = await results.TakeAll();
-
-            // Should already be done but let's make the async tracker happy
-            await pipeline;
-
-            var newIndex = await IndexRoot.Empty.Integrate(filtered.Concat(allFiles).ToList());
+            var newIndex = IndexRoot.Empty.Integrate(filtered.Concat(allFiles).ToList());
 
             lock (this)
             {
@@ -110,7 +101,7 @@ namespace Wabbajack.VirtualFileSystem
             });
         }
 
-        public async Task WriteToFile(string filename)
+        public void WriteToFile(string filename)
         {
             using (var fs = File.OpenWrite(filename))
             using (var bw = new BinaryWriter(fs, Encoding.UTF8, true))
@@ -121,28 +112,26 @@ namespace Wabbajack.VirtualFileSystem
                 bw.Write(FileVersion);
                 bw.Write((ulong) Index.AllFiles.Count);
 
-                var sizes = await Index.AllFiles
-                    .ToChannel()
-                    .UnorderedPipelineSync(f =>
+                var sizes = Index.AllFiles
+                    .PMap(f =>
                     {
                         var ms = new MemoryStream();
                         f.Write(ms);
                         return ms;
                     })
-                    .Select(async ms =>
+                    .Select(ms =>
                     {
                         var size = ms.Position;
                         ms.Position = 0;
                         bw.Write((ulong) size);
-                        await ms.CopyToAsync(fs);
+                        ms.CopyTo(fs);
                         return ms.Position;
-                    })
-                    .TakeAll();
+                    });
                 Utils.Log($"Wrote {fs.Position.ToFileSizeString()} file as vfs cache file {filename}");
             }
         }
 
-        public async Task IntegrateFromFile(string filename)
+        public void IntegrateFromFile(string filename)
         {
             try
             {
@@ -156,23 +145,15 @@ namespace Wabbajack.VirtualFileSystem
 
                     var numFiles = br.ReadUInt64();
 
-                    var input = Channel.Create(1024, ProgressUpdater<byte[]>("Loading VFS", numFiles));
-                    var pipeline = input.UnorderedPipelineSync(
-                            data => VirtualFile.Read(this, data))
-                        .TakeAll();
-
-                    for (ulong idx = 0; idx < numFiles; idx++)
-                    {
-                        var size = br.ReadUInt64();
-                        var bytes = new byte[size];
-                        await br.BaseStream.ReadAsync(bytes, 0, (int) size);
-                        await input.Put(bytes);
-                    }
-
-                    input.Close();
-
-                    var files = await pipeline;
-                    var newIndex = await Index.Integrate(files);
+                    var files = Enumerable.Range(0, (int) numFiles)
+                        .Select(idx =>
+                        {
+                            var size = br.ReadUInt64();
+                            var bytes = new byte[size];
+                            br.BaseStream.Read(bytes, 0, (int) size);
+                            return VirtualFile.Read(this, bytes);
+                        }).ToList();
+                    var newIndex = Index.Integrate(files);
                     lock (this)
                     {
                         Index = newIndex;
@@ -186,7 +167,7 @@ namespace Wabbajack.VirtualFileSystem
             }
         }
 
-        public async Task<Action> Stage(IEnumerable<VirtualFile> files)
+        public Action Stage(IEnumerable<VirtualFile> files)
         {
             var grouped = files.SelectMany(f => f.FilesInFullPath)
                 .Distinct()
@@ -200,7 +181,7 @@ namespace Wabbajack.VirtualFileSystem
             foreach (var group in grouped)
             {
                 var tmpPath = Path.Combine(_stagingFolder, Guid.NewGuid().ToString());
-                await FileExtractor.ExtractAll(group.Key.StagedPath, tmpPath);
+                FileExtractor.ExtractAll(group.Key.StagedPath, tmpPath);
                 paths.Add(tmpPath);
                 foreach (var file in group)
                     file.StagedPath = Path.Combine(tmpPath, file.Name);
@@ -229,16 +210,14 @@ namespace Wabbajack.VirtualFileSystem
                 }).ToList();
         }
 
-        public async Task IntegrateFromPortable(List<PortableFile> state, Dictionary<string, string> links)
+        public void IntegrateFromPortable(List<PortableFile> state, Dictionary<string, string> links)
         {
             var indexedState = state.GroupBy(f => f.ParentHash)
                 .ToDictionary(f => f.Key ?? "", f => (IEnumerable<PortableFile>) f);
-            var parents = await indexedState[""]
-                .ToChannel()
-                .UnorderedPipelineSync(f => VirtualFile.CreateFromPortable(this, indexedState, links, f))
-                .TakeAll();
+            var parents = indexedState[""]
+                .PMap(f => VirtualFile.CreateFromPortable(this, indexedState, links, f));
 
-            var newIndex = await Index.Integrate(parents);
+            var newIndex = Index.Integrate(parents);
             lock (this)
             {
                 Index = newIndex;
@@ -247,7 +226,7 @@ namespace Wabbajack.VirtualFileSystem
 
         public async Task<DisposableList<VirtualFile>> StageWith(IEnumerable<VirtualFile> files)
         {
-            return new DisposableList<VirtualFile>(await Stage(files), files);
+            return new DisposableList<VirtualFile>(Stage(files), files);
         }
 
 
@@ -259,7 +238,7 @@ namespace Wabbajack.VirtualFileSystem
             _knownFiles.AddRange(known);
         }
 
-        public async Task BackfillMissing()
+        public void BackfillMissing()
         {
             var newFiles = _knownFiles.Where(f => f.Paths.Length == 1)
                                        .GroupBy(f => f.Hash)
@@ -293,7 +272,7 @@ namespace Wabbajack.VirtualFileSystem
             }
             _knownFiles.Where(f => f.Paths.Length > 1).Do(BackFillOne);
 
-            var newIndex = await Index.Integrate(newFiles.Values.ToList());
+            var newIndex = Index.Integrate(newFiles.Values.ToList());
 
             lock (this)
                 Index = newIndex;
@@ -359,31 +338,28 @@ namespace Wabbajack.VirtualFileSystem
         public ImmutableDictionary<string, ImmutableStack<VirtualFile>> ByName { get; set; }
         public ImmutableDictionary<string, VirtualFile> ByRootPath { get; }
 
-        public async Task<IndexRoot> Integrate(List<VirtualFile> files)
+        public IndexRoot Integrate(List<VirtualFile> files)
         {
             Utils.Log($"Integrating");
             var allFiles = AllFiles.Concat(files).GroupBy(f => f.Name).Select(g => g.Last()).ToImmutableList();
 
-            var byFullPath = Task.Run(() =>
-                allFiles.SelectMany(f => f.ThisAndAllChildren)
-                    .ToImmutableDictionary(f => f.FullPath));
+            var byFullPath = allFiles.SelectMany(f => f.ThisAndAllChildren)
+                                     .ToImmutableDictionary(f => f.FullPath);
 
-            var byHash = Task.Run(() =>
-                allFiles.SelectMany(f => f.ThisAndAllChildren)
-                    .Where(f => f.Hash != null)
-                    .ToGroupedImmutableDictionary(f => f.Hash));
+            var byHash = allFiles.SelectMany(f => f.ThisAndAllChildren)
+                                 .Where(f => f.Hash != null)
+                                 .ToGroupedImmutableDictionary(f => f.Hash);
 
-            var byName = Task.Run(() =>
-                allFiles.SelectMany(f => f.ThisAndAllChildren)
-                    .ToGroupedImmutableDictionary(f => f.Name));
+            var byName = allFiles.SelectMany(f => f.ThisAndAllChildren)
+                                 .ToGroupedImmutableDictionary(f => f.Name);
 
-            var byRootPath = Task.Run(() => allFiles.ToImmutableDictionary(f => f.Name));
+            var byRootPath = allFiles.ToImmutableDictionary(f => f.Name);
 
             var result = new IndexRoot(allFiles,
-                await byFullPath.ConfigureAwait(false),
-                await byHash.ConfigureAwait(false),
-                await byRootPath.ConfigureAwait(false),
-                await byName.ConfigureAwait(false));
+                byFullPath,
+                byHash,
+                byRootPath,
+                byName);
             Utils.Log($"Done integrating");
             return result;
         }


### PR DESCRIPTION
I hate doing this, but I'm about to rip out all the async work I've been doing the past few days. And so I should probably document why:

Old approach: 
* Small number of dedicated threads (one per HW thread/core)
* These threads can steal work from each other, so they load balance much like async code. 
* We can track the status of these threads at any time by looking at the thread-local state of the worker. 
* It's quite fast since the only point of synchronization is on the work queue.

New approach (what I'm removing)
* Everything is async and uses tasks
* A task per small job (hashing a file, finding a match for a file, etc)
* Ends up spamming the scheduler with thousands of tasks that it has to try and schedule
* We could try to track async state, to give us a view of what's happening in the system but that's hard since we don't ever really know what CPU core is running what task. So we can get task-level info, but not CPU level info. 
* This ends up being slow because each async method gets transformed into a state machine that is often heap-allocated. So something as simple as hashing a file can end up going through hundreds of state machine transformations. 
* It's such a massive change that it breaks a lot of the current GUI interactions. 

What this PR does: 
* Keeps the shiny new VFS system since that did turn out to be rather clean
* Gets rid of all non gui async code

In future updates:
* We can create Rx streams off of the compiler for better reporting about what's going on in the system 
* Look at making parts of the system async
* We can make the WorkerQueue instance specific. So we can configure the size of the queue *after* we analyze the state of the system (disk speed, CPU cores, amount of ram, etc.)

Let's get philosophical: 

Going async with code has never been about performance. Instead it's about reducing thread count and responsiveness for IO heavy applications. Threads clock in at about 2MB of heap space per thread. So in our app we probably use around 60MB of heap space for our worker threads. So memory pressure is not an issue in Wabbajack. As far as responsiveness goes, our app doesn't need to respond to rapid user input, nor respond to requests in a few milliseconds. Instead our primary limitations are IO throughput, we're extracting tens of gigabytes of files, and the biggest limit there will be how fast we can shove data through the disk. So going async doesn't help us at all. We called `.WriteAsync`, now what do we do? Do we go and get another buffer and write that? We can't really since we already have 10+ threads pounding on the disk. 

If we could sustain 1GB/sec on a disk (unlikely considering most people don't have super-fast NVME drives), and if we consider we're extracting textures from a `.7z`, then we're going to be doing a max of about 500MB/sec of transfer (read data, extract, write). In that case, if we have 8 threads, each thread has 62MB/sec of bandwidth to work with, there's just no way we're going to be CPU bound and need more than 8 threads at that rate. If nothing else, we probably want to back down the rate a bit so we don't slam the IO on the system so hard. 