### PR TITLE
Some Styling

### DIFF
--- a/Wabbajack.Common/Extensions/RxExt.cs
+++ b/Wabbajack.Common/Extensions/RxExt.cs
@@ -60,6 +60,32 @@ namespace Wabbajack
                 .Switch();
         }
 
+        /// <summary>
+        /// Convenience operator to subscribe to the source observable, only when a second "switch" observable is on.
+        /// When the switch is on, the source will be subscribed to, and its updates passed through.
+        /// When the switch is off, the subscription to the source observable will be stopped, and no signal will be published.
+        /// </summary>
+        /// <param name="source">Source observable to subscribe to if on</param>
+        /// <param name="filterSwitch">On/Off signal of whether to subscribe to source observable</param>
+        /// <param name="valueOnOff">Value to fire when switching off</param>
+        /// <returns>Observable that publishes data from source, if the switch is on.</returns>
+        public static IObservable<T> FilterSwitch<T>(this IObservable<T> source, IObservable<bool> filterSwitch, T valueWhenOff)
+        {
+            return filterSwitch
+                .DistinctUntilChanged()
+                .Select(on =>
+                {
+                    if (on)
+                    {
+                        return source;
+                    }
+                    else
+                    {
+                        return Observable.Return<T>(valueWhenOff);
+                    }
+                })
+                .Switch();
+        }
 
         /// Inspiration:
         /// http://reactivex.io/documentation/operators/debounce.html

--- a/Wabbajack/Themes/Styles.xaml
+++ b/Wabbajack/Themes/Styles.xaml
@@ -955,7 +955,7 @@
         <Setter Property="Background" Value="{StaticResource TextBoxBackground}" />
         <Setter Property="BorderBrush" Value="{StaticResource TextBoxBorder}" />
         <Setter Property="BorderThickness" Value="1" />
-        <Setter Property="Padding" Value="2,2,2,1" />
+        <Setter Property="Padding" Value="3" />
         <Setter Property="AllowDrop" Value="true" />
         <Setter Property="FocusVisualStyle" Value="{x:Null}" />
         <Setter Property="ScrollViewer.PanningMode" Value="VerticalFirst" />
@@ -3616,4 +3616,11 @@
             </Setter.Value>
         </Setter>
     </Style>
+
+    <!--  FilePicker  -->
+    <Style x:Key="MainFilePickerStyle" TargetType="{x:Type local:FilePicker}">
+        <Setter Property="FontSize" Value="14" />
+    </Style>
+    <Style BasedOn="{StaticResource MainFilePickerStyle}" TargetType="{x:Type local:FilePicker}" />
+
 </ResourceDictionary>

--- a/Wabbajack/Themes/Styles.xaml
+++ b/Wabbajack/Themes/Styles.xaml
@@ -12,8 +12,8 @@
     <local:BoolToVisibilityConverter x:Key="bool2VisibilityConverter" />
     <local:BoolToVisibilityHiddenConverter x:Key="bool2VisibilityHiddenConverter" />
     <local:InverseBooleanConverter x:Key="InverseBooleanConverter" />
-    <local:IsNotNullVisibilityConverter x:Key="IsNotNullVisibilityConverter"/>
-    <local:EqualsToBoolConverter x:Key="EqualsToBoolConverter"/>
+    <local:IsNotNullVisibilityConverter x:Key="IsNotNullVisibilityConverter" />
+    <local:EqualsToBoolConverter x:Key="EqualsToBoolConverter" />
 
     <!--  Colors  -->
     <Color x:Key="WindowBackgroundColor">#121212</Color>
@@ -21,6 +21,7 @@
     <Color x:Key="LightBackgroundColor">#414141</Color>
     <Color x:Key="BackgroundColor">#3D3D3D</Color>
     <Color x:Key="DisabledBackgroundColor">#424242</Color>
+    <Color x:Key="PressedBackgroundColor">#394140</Color>
     <Color x:Key="LightDisabledBackgroundColor">#666666</Color>
 
     <Color x:Key="ForegroundColor">#EFEFEF</Color>
@@ -35,6 +36,7 @@
     <Color x:Key="Primary">#BB86FC</Color>
     <Color x:Key="PrimaryVariant">#3700B3</Color>
     <Color x:Key="Secondary">#03DAC6</Color>
+    <Color x:Key="DarkSecondary">#0e8f83</Color>
     <Color x:Key="Complementary">#C7FC86</Color>
     <Color x:Key="Analogous1">#868CFC</Color>
     <Color x:Key="Analogous2">#F686FC</Color>
@@ -58,6 +60,7 @@
     <SolidColorBrush x:Key="PrimaryBrush" Color="{StaticResource Primary}" />
     <SolidColorBrush x:Key="PrimaryVariantBrush" Color="{StaticResource PrimaryVariant}" />
     <SolidColorBrush x:Key="SecondaryBrush" Color="{StaticResource Secondary}" />
+    <SolidColorBrush x:Key="DarkSecondaryBrush" Color="{StaticResource DarkSecondary}" />
     <SolidColorBrush x:Key="ComplementaryBrush" Color="{StaticResource Complementary}" />
     <SolidColorBrush x:Key="Analogous1Brush" Color="{StaticResource Analogous1}" />
     <SolidColorBrush x:Key="Analogous2Brush" Color="{StaticResource Analogous2}" />
@@ -93,11 +96,11 @@
     <SolidColorBrush x:Key="ButtonNormalBorder" Color="#4C4C4C" />
 
     <SolidColorBrush x:Key="ButtonForeground" Color="{StaticResource ForegroundColor}" />
-    <SolidColorBrush x:Key="MouseOverButtonForeground" Color="#1B1B1B" />
+    <SolidColorBrush x:Key="MouseOverButtonForeground" Color="White" />
     <SolidColorBrush x:Key="ButtonBackground" Color="{StaticResource LightBackgroundColor}" />
     <SolidColorBrush x:Key="ButtonBorder" Color="{StaticResource DarkBackgroundColor}" />
-    <SolidColorBrush x:Key="PressedButtonBackground" Color="{StaticResource DisabledBackgroundColor}" />
-    <SolidColorBrush x:Key="MouseOverButtonBackground" Color="#AAAAAA" />
+    <SolidColorBrush x:Key="PressedButtonBackground" Color="{StaticResource PressedBackgroundColor}" />
+    <SolidColorBrush x:Key="MouseOverButtonBackground" Color="{StaticResource LightBackgroundColor}" />
     <SolidColorBrush x:Key="DisabledButtonBackground" Color="{StaticResource LightDisabledBackgroundColor}" />
     <SolidColorBrush x:Key="DisabledButtonForeground" Color="{StaticResource DisabledBackgroundColor}" />
 
@@ -1400,25 +1403,47 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Button}">
-                    <Border
-                        Background="{TemplateBinding Background}"
-                        BorderBrush="{TemplateBinding BorderBrush}"
-                        BorderThickness="{TemplateBinding BorderThickness}"
-                        CornerRadius="3">
-                        <ContentPresenter
-                            Margin="{TemplateBinding Padding}"
-                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                            RecognizesAccessKey="True"
-                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                    </Border>
+                    <Grid>
+                        <Border
+                            Background="{StaticResource SecondaryBrush}"
+                            CornerRadius="3"
+                            Opacity="0.7">
+                            <Border.Effect>
+                                <BlurEffect Radius="5" />
+                            </Border.Effect>
+                            <Border.Style>
+                                <Style TargetType="Border">
+                                    <Setter Property="Visibility" Value="Hidden" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding IsMouseOver, RelativeSource={RelativeSource AncestorType={x:Type Button}}}" Value="True">
+                                            <Setter Property="Visibility" Value="Visible" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Border.Style>
+                        </Border>
+                        <Border
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="3">
+                            <ContentPresenter
+                                Margin="{TemplateBinding Padding}"
+                                HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                RecognizesAccessKey="True"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                        </Border>
+                    </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="true">
                             <Setter Property="Background" Value="{StaticResource MouseOverButtonBackground}" />
+                            <Setter Property="BorderBrush" Value="{StaticResource DarkSecondaryBrush}" />
                             <Setter Property="Foreground" Value="{StaticResource MouseOverButtonForeground}" />
                         </Trigger>
                         <Trigger Property="IsPressed" Value="true">
                             <Setter Property="Background" Value="{StaticResource PressedButtonBackground}" />
+                            <Setter Property="BorderBrush" Value="{StaticResource SecondaryBrush}" />
                             <Setter Property="Foreground" Value="{StaticResource ButtonForeground}" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="false">

--- a/Wabbajack/Themes/Styles.xaml
+++ b/Wabbajack/Themes/Styles.xaml
@@ -1,27 +1,28 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-                    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                    xmlns:local="clr-namespace:Wabbajack"
-                    xmlns:mahapps="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
-                    xmlns:darkBlendTheme="clr-namespace:DarkBlendTheme"
-                    mc:Ignorable="d">
+﻿<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:darkBlendTheme="clr-namespace:DarkBlendTheme"
+    xmlns:local="clr-namespace:Wabbajack"
+    xmlns:mahapps="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
 
-    <!--Converters-->
+    <!--  Converters  -->
     <local:BoolToVisibilityConverter x:Key="bool2VisibilityConverter" />
     <local:BoolToVisibilityHiddenConverter x:Key="bool2VisibilityHiddenConverter" />
     <local:InverseBooleanConverter x:Key="InverseBooleanConverter" />
     <local:IsNotNullVisibilityConverter x:Key="IsNotNullVisibilityConverter"/>
     <local:EqualsToBoolConverter x:Key="EqualsToBoolConverter"/>
 
-    <!--Colors-->
+    <!--  Colors  -->
     <Color x:Key="WindowBackgroundColor">#121212</Color>
     <Color x:Key="DarkBackgroundColor">#292929</Color>
     <Color x:Key="LightBackgroundColor">#414141</Color>
     <Color x:Key="BackgroundColor">#3D3D3D</Color>
     <Color x:Key="DisabledBackgroundColor">#424242</Color>
     <Color x:Key="LightDisabledBackgroundColor">#666666</Color>
-    
+
     <Color x:Key="ForegroundColor">#EFEFEF</Color>
 
     <Color x:Key="HighlightColor">#BDBDBD</Color>
@@ -50,9 +51,9 @@
     <SolidColorBrush x:Key="DarkBackgroundBrush" Color="{StaticResource DarkBackgroundColor}" />
     <SolidColorBrush x:Key="LightBackgroundBrush" Color="{StaticResource LightBackgroundColor}" />
     <SolidColorBrush x:Key="BackgroundBrush" Color="{StaticResource BackgroundColor}" />
-    <SolidColorBrush x:Key="ForegroundBrush" Color="{StaticResource ForegroundColor}"/>
-    <SolidColorBrush x:Key="MouseOverForegroundBrush" Color="{StaticResource DarkBackgroundColor}"/>
-    <SolidColorBrush x:Key="WindowBackgroundBrush" Color="{StaticResource WindowBackgroundColor}"/>
+    <SolidColorBrush x:Key="ForegroundBrush" Color="{StaticResource ForegroundColor}" />
+    <SolidColorBrush x:Key="MouseOverForegroundBrush" Color="{StaticResource DarkBackgroundColor}" />
+    <SolidColorBrush x:Key="WindowBackgroundBrush" Color="{StaticResource WindowBackgroundColor}" />
 
     <SolidColorBrush x:Key="PrimaryBrush" Color="{StaticResource Primary}" />
     <SolidColorBrush x:Key="PrimaryVariantBrush" Color="{StaticResource PrimaryVariant}" />
@@ -63,89 +64,89 @@
     <SolidColorBrush x:Key="Triadic1Brush" Color="{StaticResource Triadic1}" />
     <SolidColorBrush x:Key="Triadic2Brush" Color="{StaticResource Triadic2}" />
 
-    <SolidColorBrush x:Key="TabControlNormalBorderBrush" Color="{StaticResource WindowBackgroundColor}"/>
+    <SolidColorBrush x:Key="TabControlNormalBorderBrush" Color="{StaticResource WindowBackgroundColor}" />
 
-    <SolidColorBrush x:Key="TabItemHotBackground" Color="{StaticResource HotColor}"/>
-    <SolidColorBrush x:Key="TabItemSelectedBackground" Color="{StaticResource LightBackgroundColor}"/>
-    <SolidColorBrush x:Key="TabItemHotBorderBrush" Color="{StaticResource HotColor}"/>
-    <SolidColorBrush x:Key="TabItemDisabledBackground" Color="{StaticResource DarkBackgroundColor}"/>
-    <SolidColorBrush x:Key="TabItemDisabledBorderBrush" Color="{StaticResource DarkBackgroundColor}"/>
+    <SolidColorBrush x:Key="TabItemHotBackground" Color="{StaticResource HotColor}" />
+    <SolidColorBrush x:Key="TabItemSelectedBackground" Color="{StaticResource LightBackgroundColor}" />
+    <SolidColorBrush x:Key="TabItemHotBorderBrush" Color="{StaticResource HotColor}" />
+    <SolidColorBrush x:Key="TabItemDisabledBackground" Color="{StaticResource DarkBackgroundColor}" />
+    <SolidColorBrush x:Key="TabItemDisabledBorderBrush" Color="{StaticResource DarkBackgroundColor}" />
 
     <SolidColorBrush x:Key="ScrollViewerBackground" Color="{StaticResource DarkBackgroundColor}" />
-    <SolidColorBrush x:Key="VerticalScrollBarBackground" Color="{StaticResource BackgroundColor}"/>
+    <SolidColorBrush x:Key="VerticalScrollBarBackground" Color="{StaticResource BackgroundColor}" />
     <SolidColorBrush x:Key="HorizontalScrollBarBackground" Color="{StaticResource BackgroundColor}" />
-    <SolidColorBrush x:Key="VerticalScrollBarThumb" Color="#808080"/>
-    <SolidColorBrush x:Key="ScrollBarDisabledBackground" Color="{StaticResource BackgroundColor}"/>
-    <SolidColorBrush x:Key="ScrollBarHotThumb" Color="#CCCCCC"/>
-    <SolidColorBrush x:Key="ScrollBarSelectedThumb" Color="#E5E5E5"/>
-    <SolidColorBrush x:Key="CornerBorder" Color="{StaticResource DarkBackgroundColor}"/>
+    <SolidColorBrush x:Key="VerticalScrollBarThumb" Color="#808080" />
+    <SolidColorBrush x:Key="ScrollBarDisabledBackground" Color="{StaticResource BackgroundColor}" />
+    <SolidColorBrush x:Key="ScrollBarHotThumb" Color="#CCCCCC" />
+    <SolidColorBrush x:Key="ScrollBarSelectedThumb" Color="#E5E5E5" />
+    <SolidColorBrush x:Key="CornerBorder" Color="{StaticResource DarkBackgroundColor}" />
 
     <SolidColorBrush x:Key="TextBoxBorder" Color="{StaticResource DarkBackgroundColor}" />
     <SolidColorBrush x:Key="TextBoxBackground" Color="{StaticResource DarkBackgroundColor}" />
     <SolidColorBrush x:Key="TextBoxDisabledForeground" Color="#8C8C8C" />
     <SolidColorBrush x:Key="TextBoxDisabledBackground" Color="{StaticResource DisabledBackgroundColor}" />
-    <SolidColorBrush x:Key="InactiveSelectionHighlightBrush" Color="#335C85"/>
+    <SolidColorBrush x:Key="InactiveSelectionHighlightBrush" Color="#335C85" />
 
-    <SolidColorBrush x:Key="ComboBoxButtonNormalBackground" Color="#808080"/>
+    <SolidColorBrush x:Key="ComboBoxButtonNormalBackground" Color="#808080" />
 
-    <SolidColorBrush x:Key="ButtonNormalBackground" Color="{StaticResource DarkBackgroundColor}"/>
-    <SolidColorBrush x:Key="ButtonNormalBorder" Color="#4C4C4C"/>
+    <SolidColorBrush x:Key="ButtonNormalBackground" Color="{StaticResource DarkBackgroundColor}" />
+    <SolidColorBrush x:Key="ButtonNormalBorder" Color="#4C4C4C" />
 
-    <SolidColorBrush x:Key="ButtonForeground" Color="{StaticResource ForegroundColor}"/>
-    <SolidColorBrush x:Key="MouseOverButtonForeground" Color="#1B1B1B"/>
-    <SolidColorBrush x:Key="ButtonBackground" Color="{StaticResource LightBackgroundColor}"/>
-    <SolidColorBrush x:Key="ButtonBorder" Color="{StaticResource DarkBackgroundColor}"/>
-    <SolidColorBrush x:Key="PressedButtonBackground" Color="{StaticResource DisabledBackgroundColor}"/>
-    <SolidColorBrush x:Key="MouseOverButtonBackground" Color="#AAAAAA"/>
-    <SolidColorBrush x:Key="DisabledButtonBackground" Color="{StaticResource LightDisabledBackgroundColor}"/>
-    <SolidColorBrush x:Key="DisabledButtonForeground" Color="{StaticResource DisabledBackgroundColor}"/>
+    <SolidColorBrush x:Key="ButtonForeground" Color="{StaticResource ForegroundColor}" />
+    <SolidColorBrush x:Key="MouseOverButtonForeground" Color="#1B1B1B" />
+    <SolidColorBrush x:Key="ButtonBackground" Color="{StaticResource LightBackgroundColor}" />
+    <SolidColorBrush x:Key="ButtonBorder" Color="{StaticResource DarkBackgroundColor}" />
+    <SolidColorBrush x:Key="PressedButtonBackground" Color="{StaticResource DisabledBackgroundColor}" />
+    <SolidColorBrush x:Key="MouseOverButtonBackground" Color="#AAAAAA" />
+    <SolidColorBrush x:Key="DisabledButtonBackground" Color="{StaticResource LightDisabledBackgroundColor}" />
+    <SolidColorBrush x:Key="DisabledButtonForeground" Color="{StaticResource DisabledBackgroundColor}" />
 
-    <SolidColorBrush x:Key="Expander.Background" Color="{StaticResource LightBackgroundColor}"/>
-    <SolidColorBrush x:Key="Expander.MouseOver.Arrow.Stroke" Color="{StaticResource ForegroundColor}"/>
-    <SolidColorBrush x:Key="Expander.Disabled.Arrow.Stroke" Color="{StaticResource LightDisabledBackgroundColor}"/>
-    <SolidColorBrush x:Key="Expander.Static.Arrow.Stroke" Color="#AAAAAA"/>
+    <SolidColorBrush x:Key="Expander.Background" Color="{StaticResource LightBackgroundColor}" />
+    <SolidColorBrush x:Key="Expander.MouseOver.Arrow.Stroke" Color="{StaticResource ForegroundColor}" />
+    <SolidColorBrush x:Key="Expander.Disabled.Arrow.Stroke" Color="{StaticResource LightDisabledBackgroundColor}" />
+    <SolidColorBrush x:Key="Expander.Static.Arrow.Stroke" Color="#AAAAAA" />
 
-    <SolidColorBrush x:Key="CheckBoxFillNormal" Color="{StaticResource LightDisabledBackgroundColor}"/>
-    <SolidColorBrush x:Key="CheckBoxMouseOverStroke" Color="{StaticResource ForegroundColor}"/>
-    <SolidColorBrush x:Key="CheckBoxDisabledStroke" Color="{StaticResource DisabledBackgroundColor}"/>
-    <SolidColorBrush x:Key="CheckBoxDisabledForeground" Color="#939393"/>
-    <SolidColorBrush x:Key="CheckBoxStroke" Color="{StaticResource DarkBackgroundColor}"/>
+    <SolidColorBrush x:Key="CheckBoxFillNormal" Color="{StaticResource LightDisabledBackgroundColor}" />
+    <SolidColorBrush x:Key="CheckBoxMouseOverStroke" Color="{StaticResource ForegroundColor}" />
+    <SolidColorBrush x:Key="CheckBoxDisabledStroke" Color="{StaticResource DisabledBackgroundColor}" />
+    <SolidColorBrush x:Key="CheckBoxDisabledForeground" Color="#939393" />
+    <SolidColorBrush x:Key="CheckBoxStroke" Color="{StaticResource DarkBackgroundColor}" />
 
-    <SolidColorBrush x:Key="RadioButtonMouseOverStroke" Color="{StaticResource ForegroundColor}"/>
-    <SolidColorBrush x:Key="RadioButtonDisabledStroke" Color="{StaticResource DisabledBackgroundColor}"/>
-    <SolidColorBrush x:Key="RadioButtonDisabledForeground" Color="#939393"/>
-    <SolidColorBrush x:Key="RadioButtonStroke" Color="{StaticResource DarkBackgroundColor}"/>
-    <SolidColorBrush x:Key="RadioButtonForeground" Color="{StaticResource ForegroundColor}"/>
-    <SolidColorBrush x:Key="RadioButtonBackground" Color="{StaticResource LightDisabledBackgroundColor}"/>
+    <SolidColorBrush x:Key="RadioButtonMouseOverStroke" Color="{StaticResource ForegroundColor}" />
+    <SolidColorBrush x:Key="RadioButtonDisabledStroke" Color="{StaticResource DisabledBackgroundColor}" />
+    <SolidColorBrush x:Key="RadioButtonDisabledForeground" Color="#939393" />
+    <SolidColorBrush x:Key="RadioButtonStroke" Color="{StaticResource DarkBackgroundColor}" />
+    <SolidColorBrush x:Key="RadioButtonForeground" Color="{StaticResource ForegroundColor}" />
+    <SolidColorBrush x:Key="RadioButtonBackground" Color="{StaticResource LightDisabledBackgroundColor}" />
 
-    <SolidColorBrush x:Key="ListBorder" Color="{StaticResource DarkBackgroundColor}"/>
-    <SolidColorBrush x:Key="ListBackground" Color="{StaticResource DarkBackgroundColor}"/>
-    <SolidColorBrush x:Key="SelectedListItem" Color="{StaticResource HighlightColor}"/>
-    <SolidColorBrush x:Key="SelectedListItemForeground" Color="{StaticResource DarkBackgroundColor}"/>
-    <SolidColorBrush x:Key="MouseOverListItem" Color="#4A4A4A"/>
+    <SolidColorBrush x:Key="ListBorder" Color="{StaticResource DarkBackgroundColor}" />
+    <SolidColorBrush x:Key="ListBackground" Color="{StaticResource DarkBackgroundColor}" />
+    <SolidColorBrush x:Key="SelectedListItem" Color="{StaticResource HighlightColor}" />
+    <SolidColorBrush x:Key="SelectedListItemForeground" Color="{StaticResource DarkBackgroundColor}" />
+    <SolidColorBrush x:Key="MouseOverListItem" Color="#4A4A4A" />
 
-    <SolidColorBrush x:Key="TreeViewBackground" Color="{StaticResource DarkBackgroundColor}"/>
-    <SolidColorBrush x:Key="TreeViewDisabledForeground" Color="{StaticResource LightDisabledBackgroundColor}"/>
+    <SolidColorBrush x:Key="TreeViewBackground" Color="{StaticResource DarkBackgroundColor}" />
+    <SolidColorBrush x:Key="TreeViewDisabledForeground" Color="{StaticResource LightDisabledBackgroundColor}" />
 
-    <SolidColorBrush x:Key="DisabledMenuForeground" Color="#656565"/>
-    <SolidColorBrush x:Key="MenuBackground" Color="#3A3A3A"/>
-    <SolidColorBrush x:Key="MenuItemSelectionFill" Color="{StaticResource HighlightColor}"/>
-    <SolidColorBrush x:Key="SubMenuBackgroundBrush" Color="#3A3A3A"/>
-    <SolidColorBrush x:Key="MenuItemPressedFill" Color="{StaticResource HighlightColor}"/>
-    <SolidColorBrush x:Key="SubMenuBorderBrush" Color="{StaticResource LightBackgroundColor}"/>
-    <SolidColorBrush x:Key="SubMenuRepeatButtonBrush" Color="{StaticResource HotColor}"/>
-    <SolidColorBrush x:Key="SubMenuHoverRepeatButtonBrush" Color="#7F7F7F"/>
-    <SolidColorBrush x:Key="MenuSeparatorBrush" Color="#4C4C4C"/>
+    <SolidColorBrush x:Key="DisabledMenuForeground" Color="#656565" />
+    <SolidColorBrush x:Key="MenuBackground" Color="#3A3A3A" />
+    <SolidColorBrush x:Key="MenuItemSelectionFill" Color="{StaticResource HighlightColor}" />
+    <SolidColorBrush x:Key="SubMenuBackgroundBrush" Color="#3A3A3A" />
+    <SolidColorBrush x:Key="MenuItemPressedFill" Color="{StaticResource HighlightColor}" />
+    <SolidColorBrush x:Key="SubMenuBorderBrush" Color="{StaticResource LightBackgroundColor}" />
+    <SolidColorBrush x:Key="SubMenuRepeatButtonBrush" Color="{StaticResource HotColor}" />
+    <SolidColorBrush x:Key="SubMenuHoverRepeatButtonBrush" Color="#7F7F7F" />
+    <SolidColorBrush x:Key="MenuSeparatorBrush" Color="#4C4C4C" />
 
-    <SolidColorBrush x:Key="DataGridBackgroundBrush" Color="{StaticResource DarkBackgroundColor}"/>
-    <SolidColorBrush x:Key="DataGridHeaderBackgroundBrush" Color="{StaticResource DarkBackgroundColor}"/>
-    <SolidColorBrush x:Key="DataGridHeaderMouseOverBrush" Color="#AAAAAA"/>
-    <SolidColorBrush x:Key="DataGridHeaderBorderBrush" Color="{StaticResource DisabledBackgroundColor}"/>
-	<SolidColorBrush x:Key="DataGridRowBorderBrush" Color="{StaticResource DisabledBackgroundColor}"/>
-    <SolidColorBrush x:Key="DataGridRowBackgroundBrush" Color="{StaticResource DarkBackgroundColor}"/>
-	<SolidColorBrush x:Key="DataGridRowSelectedBrush" Color="{StaticResource HighlightColor}"/>
-    <SolidColorBrush x:Key="GridLinesBrush" Color="Transparent"/>
-    <SolidColorBrush x:Key="{x:Static DataGrid.FocusBorderBrushKey}" Color="Red"/>
+    <SolidColorBrush x:Key="DataGridBackgroundBrush" Color="{StaticResource DarkBackgroundColor}" />
+    <SolidColorBrush x:Key="DataGridHeaderBackgroundBrush" Color="{StaticResource DarkBackgroundColor}" />
+    <SolidColorBrush x:Key="DataGridHeaderMouseOverBrush" Color="#AAAAAA" />
+    <SolidColorBrush x:Key="DataGridHeaderBorderBrush" Color="{StaticResource DisabledBackgroundColor}" />
+    <SolidColorBrush x:Key="DataGridRowBorderBrush" Color="{StaticResource DisabledBackgroundColor}" />
+    <SolidColorBrush x:Key="DataGridRowBackgroundBrush" Color="{StaticResource DarkBackgroundColor}" />
+    <SolidColorBrush x:Key="DataGridRowSelectedBrush" Color="{StaticResource HighlightColor}" />
+    <SolidColorBrush x:Key="GridLinesBrush" Color="Transparent" />
+    <SolidColorBrush x:Key="{x:Static DataGrid.FocusBorderBrushKey}" Color="Red" />
 
     <Geometry x:Key="MenuScrollDownArrowGeometry">M-0.7,5.2 L-2.2,6.7 3.6,12.6 9.5,6.7 8,5.2 3.6,9.6 z</Geometry>
     <Geometry x:Key="MenuScrollUpArrowGeometry">M-2.2,10.9 L-0.7,12.4 3.7,8 8,12.4 9.5,10.9 3.7,5 z</Geometry>
@@ -158,40 +159,40 @@
     <Geometry x:Key="RepeatButton">M3.5445026,0 L7.0890052,7.0890053 L3.0459049E-09,7.0890053 z</Geometry>
     <Geometry x:Key="ComboBoxArrow">M-0,6 L-0,8 8,8 8,-0 6,-0 6,6 z</Geometry>
     <Geometry x:Key="ExpanderToggleButtonArrow">M5,-0 L9,5 1,5 z</Geometry>
-    
 
-    <!--FontStyle-->
+
+    <!--  FontStyle  -->
     <Style TargetType="{x:Type TextBlock}">
-        <Setter Property="FontFamily" Value="Calibri light"/>
+        <Setter Property="FontFamily" Value="Calibri light" />
         <!--<Setter Property="Foreground" Value="{StaticResource ForegroundBrush}"/>-->
     </Style>
     <Style TargetType="{x:Type Control}">
-        <Setter Property="FontFamily" Value="Calibri light"/>
-        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="Calibri light" />
+        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}" />
     </Style>
     <Style TargetType="{x:Type Window}">
-        <Setter Property="FontFamily" Value="Calibri light"/>
-        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}"/>
-        <Setter Property="Background" Value="{StaticResource WindowBackgroundBrush}"/>
+        <Setter Property="FontFamily" Value="Calibri light" />
+        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}" />
+        <Setter Property="Background" Value="{StaticResource WindowBackgroundBrush}" />
     </Style>
-    <!-- Necessary for Blend designer for UserControls -->
+    <!--  Necessary for Blend designer for UserControls  -->
     <Style TargetType="{x:Type UserControl}">
-        <Setter Property="FontFamily" Value="Calibri light"/>
-        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="Calibri light" />
+        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}" />
     </Style>
 
 
-    <!--TabControl-->
+    <!--  TabControl  -->
     <Style TargetType="{x:Type TabControl}">
         <Style.Resources>
             <Style x:Key="BottomStyle" TargetType="{x:Type FrameworkElement}">
-                <Setter Property="RenderTransformOrigin" Value="0.5,0.5"/>
+                <Setter Property="RenderTransformOrigin" Value="0.5,0.5" />
                 <Setter Property="RenderTransform">
                     <Setter.Value>
                         <TransformGroup>
-                            <ScaleTransform ScaleY="-1" ScaleX="1"/>
-                            <SkewTransform AngleY="0" AngleX="0"/>
-                            <RotateTransform Angle="0"/>
+                            <ScaleTransform ScaleX="1" ScaleY="-1" />
+                            <SkewTransform AngleX="0" AngleY="0" />
+                            <RotateTransform Angle="0" />
                             <TranslateTransform />
                         </TransformGroup>
                     </Setter.Value>
@@ -212,10 +213,10 @@
                         <RotateTransform Angle="-90" />
                     </Setter.Value>
                 </Setter>
-                <Setter Property="RenderTransformOrigin" Value="0.5,0.5"/>
+                <Setter Property="RenderTransformOrigin" Value="0.5,0.5" />
                 <Setter Property="RenderTransform">
                     <Setter.Value>
-                        <ScaleTransform ScaleY="-1"/>
+                        <ScaleTransform ScaleY="-1" />
                     </Setter.Value>
                 </Setter>
             </Style>
@@ -240,138 +241,149 @@
                 <Setter Property="Control.Template">
                     <Setter.Value>
                         <ControlTemplate>
-                            <Rectangle Margin="3,3,3,1" SnapsToDevicePixels="true"
-                                       Stroke="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
-                                       StrokeThickness="1" StrokeDashArray="1 2"/>
+                            <Rectangle
+                                Margin="3,3,3,1"
+                                SnapsToDevicePixels="true"
+                                Stroke="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
+                                StrokeDashArray="1 2"
+                                StrokeThickness="1" />
                         </ControlTemplate>
                     </Setter.Value>
                 </Setter>
             </Style>
 
             <Style TargetType="{x:Type TabItem}">
-                <Setter Property="FocusVisualStyle" Value="{StaticResource TabItemFocusVisual}"/>
-                <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}"/>
-                <Setter Property="Padding" Value="6,1,6,1"/>
-                <Setter Property="BorderBrush" Value="{StaticResource TabControlNormalBorderBrush}"/>
-                <Setter Property="Background" Value="{StaticResource ButtonNormalBackground}"/>
-                <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
-                <Setter Property="VerticalContentAlignment" Value="Stretch"/>
+                <Setter Property="FocusVisualStyle" Value="{StaticResource TabItemFocusVisual}" />
+                <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}" />
+                <Setter Property="Padding" Value="6,1,6,1" />
+                <Setter Property="BorderBrush" Value="{StaticResource TabControlNormalBorderBrush}" />
+                <Setter Property="Background" Value="{StaticResource ButtonNormalBackground}" />
+                <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                <Setter Property="VerticalContentAlignment" Value="Stretch" />
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="{x:Type TabItem}">
                             <Grid x:Name="Container">
-                                <Grid x:Name="Grid" SnapsToDevicePixels="true" Margin="1,0,-12,0">
+                                <Grid
+                                    x:Name="Grid"
+                                    Margin="1,0,-12,0"
+                                    SnapsToDevicePixels="true">
                                     <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="Auto"/>
-                                        <ColumnDefinition Width="Auto"/>
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="Auto" />
                                     </Grid.ColumnDefinitions>
                                     <Grid.RowDefinitions>
-                                        <RowDefinition Height="Auto"/>
-                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
                                     </Grid.RowDefinitions>
-                                    <Border x:Name="Bd"
-									    Grid.Column="0"
-									    CornerRadius="3,0,0,0"
-									    BorderBrush="{TemplateBinding BorderBrush}"
-									    BorderThickness="0"
-									    Background="{TemplateBinding Background}"
-									    Padding="{TemplateBinding Padding}">
-                                        <ContentPresenter x:Name="Content" Margin="6,1,6,1" ContentSource="Header"
-										    HorizontalAlignment="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"
-										    RecognizesAccessKey="True"
-										    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-										    VerticalAlignment="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"/>
+                                    <Border
+                                        x:Name="Bd"
+                                        Grid.Column="0"
+                                        Padding="{TemplateBinding Padding}"
+                                        Background="{TemplateBinding Background}"
+                                        BorderBrush="{TemplateBinding BorderBrush}"
+                                        BorderThickness="0"
+                                        CornerRadius="3,0,0,0">
+                                        <ContentPresenter
+                                            x:Name="Content"
+                                            Margin="6,1,6,1"
+                                            HorizontalAlignment="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"
+                                            VerticalAlignment="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"
+                                            ContentSource="Header"
+                                            RecognizesAccessKey="True"
+                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                                     </Border>
-                                    <Path x:Name="RoundedCorner"
-                                          Grid.Column="1"
-                                          Grid.Row="0"
-                                          Width="24"
-                                          Stretch="Fill"
-                                          Data="{StaticResource TabItemRoundedCorner}"
-                                          Fill="{TemplateBinding Background}" />
+                                    <Path
+                                        x:Name="RoundedCorner"
+                                        Grid.Row="0"
+                                        Grid.Column="1"
+                                        Width="24"
+                                        Data="{StaticResource TabItemRoundedCorner}"
+                                        Fill="{TemplateBinding Background}"
+                                        Stretch="Fill" />
                                 </Grid>
                             </Grid>
                             <ControlTemplate.Triggers>
                                 <Trigger Property="IsMouseOver" Value="true">
-                                    <Setter Property="Background" TargetName="Bd" Value="{StaticResource TabItemHotBackground}"/>
-                                    <Setter Property="Fill"  TargetName="RoundedCorner" Value="{StaticResource TabItemHotBackground}"/>
+                                    <Setter TargetName="Bd" Property="Background" Value="{StaticResource TabItemHotBackground}" />
+                                    <Setter TargetName="RoundedCorner" Property="Fill" Value="{StaticResource TabItemHotBackground}" />
                                 </Trigger>
                                 <Trigger Property="IsSelected" Value="true">
-                                    <Setter Property="Panel.ZIndex" Value="1"/>
-                                    <Setter Property="Background" TargetName="Bd" Value="{StaticResource TabItemSelectedBackground}"/>
-                                    <Setter Property="Fill"  TargetName="RoundedCorner" Value="{StaticResource TabItemSelectedBackground}"/>
+                                    <Setter Property="Panel.ZIndex" Value="1" />
+                                    <Setter TargetName="Bd" Property="Background" Value="{StaticResource TabItemSelectedBackground}" />
+                                    <Setter TargetName="RoundedCorner" Property="Fill" Value="{StaticResource TabItemSelectedBackground}" />
                                 </Trigger>
                                 <MultiTrigger>
                                     <MultiTrigger.Conditions>
-                                        <Condition Property="IsSelected" Value="false"/>
-                                        <Condition Property="IsMouseOver" Value="true"/>
+                                        <Condition Property="IsSelected" Value="false" />
+                                        <Condition Property="IsMouseOver" Value="true" />
                                     </MultiTrigger.Conditions>
-                                    <Setter Property="BorderBrush" TargetName="Bd" Value="{StaticResource TabItemHotBorderBrush}"/>
-                                    <Setter Property="Fill"  TargetName="RoundedCorner" Value="{StaticResource TabItemHotBorderBrush}"/>
+                                    <Setter TargetName="Bd" Property="BorderBrush" Value="{StaticResource TabItemHotBorderBrush}" />
+                                    <Setter TargetName="RoundedCorner" Property="Fill" Value="{StaticResource TabItemHotBorderBrush}" />
                                 </MultiTrigger>
                                 <Trigger Property="TabStripPlacement" Value="Bottom">
                                     <!--<Setter Property="BorderThickness" TargetName="Bd" Value="1,0,1,1"/>-->
-                                    <Setter Property="Style" TargetName="RoundedCorner" Value="{StaticResource BottomStyle}"/>
-                                    <Setter Property="Style" TargetName="Bd" Value="{StaticResource BottomStyle}"/>
-                                    <Setter Property="Style" TargetName="Content" Value="{StaticResource BottomStyle}"/>
+                                    <Setter TargetName="RoundedCorner" Property="Style" Value="{StaticResource BottomStyle}" />
+                                    <Setter TargetName="Bd" Property="Style" Value="{StaticResource BottomStyle}" />
+                                    <Setter TargetName="Content" Property="Style" Value="{StaticResource BottomStyle}" />
                                 </Trigger>
                                 <Trigger Property="TabStripPlacement" Value="Left">
                                     <!--<Setter Property="BorderThickness" TargetName="Bd" Value="1,1,0,1"/>-->
-                                    <Setter Property="Grid.Row" TargetName="Bd" Value="0"/>
-                                    <Setter Property="Grid.Column" TargetName="Bd" Value="0"/>
-                                    <Setter Property="Grid.Row" TargetName="RoundedCorner" Value="1"/>
-                                    <Setter Property="Grid.Column" TargetName="RoundedCorner" Value="0"/>
-                                    <Setter Property="Style" TargetName="RoundedCorner" Value="{StaticResource RoundedCornerLeftStyle}"/>
-                                    <Setter Property="Style" TargetName="Bd" Value="{StaticResource LeftStyle}"/>
-                                    <Setter Property="Style" TargetName="Content" Value="{StaticResource DefaultStyle}"/>
-                                    <Setter Property="Margin" TargetName="Grid" Value="0,1,0,-16"/>
-                                    <Setter Property="CornerRadius" TargetName="Bd" Value="0 3 0 0"/>
-                                    <Setter Property="Margin" TargetName="RoundedCorner" Value="0 4 0 0"/>
+                                    <Setter TargetName="Bd" Property="Grid.Row" Value="0" />
+                                    <Setter TargetName="Bd" Property="Grid.Column" Value="0" />
+                                    <Setter TargetName="RoundedCorner" Property="Grid.Row" Value="1" />
+                                    <Setter TargetName="RoundedCorner" Property="Grid.Column" Value="0" />
+                                    <Setter TargetName="RoundedCorner" Property="Style" Value="{StaticResource RoundedCornerLeftStyle}" />
+                                    <Setter TargetName="Bd" Property="Style" Value="{StaticResource LeftStyle}" />
+                                    <Setter TargetName="Content" Property="Style" Value="{StaticResource DefaultStyle}" />
+                                    <Setter TargetName="Grid" Property="Margin" Value="0,1,0,-16" />
+                                    <Setter TargetName="Bd" Property="CornerRadius" Value="0 3 0 0" />
+                                    <Setter TargetName="RoundedCorner" Property="Margin" Value="0,4,0,0" />
                                 </Trigger>
                                 <Trigger Property="TabStripPlacement" Value="Right">
                                     <!--<Setter Property="BorderThickness" TargetName="Bd" Value="0,1,1,1"/>-->
-                                    <Setter Property="Grid.Row" TargetName="Bd" Value="0"/>
-                                    <Setter Property="Grid.Column" TargetName="Bd" Value="1"/>
-                                    <Setter Property="Grid.Row" TargetName="RoundedCorner" Value="1"/>
-                                    <Setter Property="Grid.Column" TargetName="RoundedCorner" Value="1"/>
-                                    <Setter Property="Style" TargetName="RoundedCorner" Value="{StaticResource RightStyle}"/>
-                                    <Setter Property="Style" TargetName="Bd" Value="{StaticResource RightStyle}"/>
-                                    <Setter Property="Style" TargetName="Content" Value="{StaticResource DefaultStyle}"/>
-                                    <Setter Property="Margin" TargetName="Grid" Value="0,1,0,-12"/>
+                                    <Setter TargetName="Bd" Property="Grid.Row" Value="0" />
+                                    <Setter TargetName="Bd" Property="Grid.Column" Value="1" />
+                                    <Setter TargetName="RoundedCorner" Property="Grid.Row" Value="1" />
+                                    <Setter TargetName="RoundedCorner" Property="Grid.Column" Value="1" />
+                                    <Setter TargetName="RoundedCorner" Property="Style" Value="{StaticResource RightStyle}" />
+                                    <Setter TargetName="Bd" Property="Style" Value="{StaticResource RightStyle}" />
+                                    <Setter TargetName="Content" Property="Style" Value="{StaticResource DefaultStyle}" />
+                                    <Setter TargetName="Grid" Property="Margin" Value="0,1,0,-12" />
                                 </Trigger>
                                 <MultiTrigger>
                                     <MultiTrigger.Conditions>
-                                        <Condition Property="IsSelected" Value="true"/>
-                                        <Condition Property="TabStripPlacement" Value="Top"/>
+                                        <Condition Property="IsSelected" Value="true" />
+                                        <Condition Property="TabStripPlacement" Value="Top" />
                                     </MultiTrigger.Conditions>
-                                    <Setter Property="Margin"  Value="0,0,0,-1"/>
+                                    <Setter Property="Margin" Value="0,0,0,-1" />
                                 </MultiTrigger>
                                 <MultiTrigger>
                                     <MultiTrigger.Conditions>
-                                        <Condition Property="IsSelected" Value="true"/>
-                                        <Condition Property="TabStripPlacement" Value="Bottom"/>
+                                        <Condition Property="IsSelected" Value="true" />
+                                        <Condition Property="TabStripPlacement" Value="Bottom" />
                                     </MultiTrigger.Conditions>
-                                    <Setter Property="Margin" Value="0,-1,0,0"/>
+                                    <Setter Property="Margin" Value="0,-1,0,0" />
                                 </MultiTrigger>
                                 <MultiTrigger>
                                     <MultiTrigger.Conditions>
-                                        <Condition Property="IsSelected" Value="true"/>
-                                        <Condition Property="TabStripPlacement" Value="Left"/>
+                                        <Condition Property="IsSelected" Value="true" />
+                                        <Condition Property="TabStripPlacement" Value="Left" />
                                     </MultiTrigger.Conditions>
-                                    <Setter Property="Margin" Value="0,0,-1,0"/>
+                                    <Setter Property="Margin" Value="0,0,-1,0" />
                                 </MultiTrigger>
                                 <MultiTrigger>
                                     <MultiTrigger.Conditions>
-                                        <Condition Property="IsSelected" Value="true"/>
-                                        <Condition Property="TabStripPlacement" Value="Right"/>
+                                        <Condition Property="IsSelected" Value="true" />
+                                        <Condition Property="TabStripPlacement" Value="Right" />
                                     </MultiTrigger.Conditions>
-                                    <Setter Property="Margin" Value="-1,0,0,0"/>
+                                    <Setter Property="Margin" Value="-1,0,0,0" />
                                 </MultiTrigger>
                                 <Trigger Property="IsEnabled" Value="false">
-                                    <Setter Property="Background" TargetName="Bd" Value="{StaticResource TabItemDisabledBackground}"/>
-                                    <Setter Property="BorderBrush" TargetName="Bd" Value="{StaticResource TabItemDisabledBorderBrush}"/>
-                                    <Setter Property="Fill" TargetName="RoundedCorner" Value="{StaticResource TabItemDisabledBackground}"></Setter>
-                                    <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+                                    <Setter TargetName="Bd" Property="Background" Value="{StaticResource TabItemDisabledBackground}" />
+                                    <Setter TargetName="Bd" Property="BorderBrush" Value="{StaticResource TabItemDisabledBorderBrush}" />
+                                    <Setter TargetName="RoundedCorner" Property="Fill" Value="{StaticResource TabItemDisabledBackground}" />
+                                    <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" />
                                 </Trigger>
                             </ControlTemplate.Triggers>
                         </ControlTemplate>
@@ -381,154 +393,175 @@
         </Style.Resources>
         <Setter Property="OverridesDefaultStyle" Value="True" />
         <!--<Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>-->
-        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}"/>
-        <Setter Property="Padding" Value="4"/>
-        <Setter Property="BorderThickness" Value="1"/>
-        <Setter Property="BorderBrush" Value="{StaticResource TabControlNormalBorderBrush}"/>
-        <Setter Property="Background" Value="{DynamicResource TabItemSelectedBackground}"/>
-        <Setter Property="HorizontalContentAlignment" Value="Center"/>
-        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}" />
+        <Setter Property="Padding" Value="4" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="BorderBrush" Value="{StaticResource TabControlNormalBorderBrush}" />
+        <Setter Property="Background" Value="{DynamicResource TabItemSelectedBackground}" />
+        <Setter Property="HorizontalContentAlignment" Value="Center" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type TabControl}">
-                    <Grid ClipToBounds="true" SnapsToDevicePixels="true" KeyboardNavigation.TabNavigation="Local">
+                    <Grid
+                        ClipToBounds="true"
+                        KeyboardNavigation.TabNavigation="Local"
+                        SnapsToDevicePixels="true">
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition x:Name="ColumnDefinition0"/>
-                            <ColumnDefinition x:Name="ColumnDefinition1" Width="0"/>
+                            <ColumnDefinition x:Name="ColumnDefinition0" />
+                            <ColumnDefinition x:Name="ColumnDefinition1" Width="0" />
                         </Grid.ColumnDefinitions>
                         <Grid.RowDefinitions>
-                            <RowDefinition x:Name="RowDefinition0" Height="Auto"/>
-                            <RowDefinition x:Name="RowDefinition1" Height="*"/>
+                            <RowDefinition x:Name="RowDefinition0" Height="Auto" />
+                            <RowDefinition x:Name="RowDefinition1" Height="*" />
                         </Grid.RowDefinitions>
-                        <TabPanel x:Name="HeaderPanel" Grid.Column="0" IsItemsHost="true"
-							Grid.Row="0" KeyboardNavigation.TabIndex="1" Panel.ZIndex="1"/>
-                        <Border x:Name="ContentPanel"
-							BorderBrush="{TemplateBinding BorderBrush}"
-							BorderThickness="{TemplateBinding BorderThickness}"
-							Background="{TemplateBinding Background}"
-							Grid.Column="0"
-							Grid.Row="1"
-							KeyboardNavigation.DirectionalNavigation="Contained"
-							KeyboardNavigation.TabIndex="2" KeyboardNavigation.TabNavigation="Local">
-                            <ContentPresenter x:Name="PART_SelectedContentHost"
-								ContentSource="SelectedContent"
-								Margin="{TemplateBinding Padding}"
-								SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                        <TabPanel
+                            x:Name="HeaderPanel"
+                            Grid.Row="0"
+                            Grid.Column="0"
+                            Panel.ZIndex="1"
+                            IsItemsHost="true"
+                            KeyboardNavigation.TabIndex="1" />
+                        <Border
+                            x:Name="ContentPanel"
+                            Grid.Row="1"
+                            Grid.Column="0"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            KeyboardNavigation.DirectionalNavigation="Contained"
+                            KeyboardNavigation.TabIndex="2"
+                            KeyboardNavigation.TabNavigation="Local">
+                            <ContentPresenter
+                                x:Name="PART_SelectedContentHost"
+                                Margin="{TemplateBinding Padding}"
+                                ContentSource="SelectedContent"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         </Border>
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="TabStripPlacement" Value="Bottom">
-                            <Setter Property="Grid.Row" TargetName="HeaderPanel" Value="1"/>
-                            <Setter Property="Grid.Row" TargetName="ContentPanel" Value="0"/>
-                            <Setter Property="Height" TargetName="RowDefinition0" Value="*"/>
-                            <Setter Property="Height" TargetName="RowDefinition1" Value="Auto"/>
+                            <Setter TargetName="HeaderPanel" Property="Grid.Row" Value="1" />
+                            <Setter TargetName="ContentPanel" Property="Grid.Row" Value="0" />
+                            <Setter TargetName="RowDefinition0" Property="Height" Value="*" />
+                            <Setter TargetName="RowDefinition1" Property="Height" Value="Auto" />
                             <!--<Setter Property="Margin" TargetName="HeaderPanel" Value="2,0,2,2"/>-->
                         </Trigger>
                         <Trigger Property="TabStripPlacement" Value="Left">
-                            <Setter Property="Grid.Row" TargetName="HeaderPanel" Value="0"/>
-                            <Setter Property="Grid.Row" TargetName="ContentPanel" Value="0"/>
-                            <Setter Property="Grid.Column" TargetName="HeaderPanel" Value="0"/>
-                            <Setter Property="Grid.Column" TargetName="ContentPanel" Value="1"/>
-                            <Setter Property="Width" TargetName="ColumnDefinition0" Value="Auto"/>
-                            <Setter Property="Width" TargetName="ColumnDefinition1" Value="*"/>
-                            <Setter Property="Height" TargetName="RowDefinition0" Value="*"/>
-                            <Setter Property="Height" TargetName="RowDefinition1" Value="0"/>
+                            <Setter TargetName="HeaderPanel" Property="Grid.Row" Value="0" />
+                            <Setter TargetName="ContentPanel" Property="Grid.Row" Value="0" />
+                            <Setter TargetName="HeaderPanel" Property="Grid.Column" Value="0" />
+                            <Setter TargetName="ContentPanel" Property="Grid.Column" Value="1" />
+                            <Setter TargetName="ColumnDefinition0" Property="Width" Value="Auto" />
+                            <Setter TargetName="ColumnDefinition1" Property="Width" Value="*" />
+                            <Setter TargetName="RowDefinition0" Property="Height" Value="*" />
+                            <Setter TargetName="RowDefinition1" Property="Height" Value="0" />
                             <!--<Setter Property="Margin" TargetName="HeaderPanel" Value="2,2,0,2"/>-->
                         </Trigger>
                         <Trigger Property="TabStripPlacement" Value="Right">
-                            <Setter Property="Grid.Row" TargetName="HeaderPanel" Value="0"/>
-                            <Setter Property="Grid.Row" TargetName="ContentPanel" Value="0"/>
-                            <Setter Property="Grid.Column" TargetName="HeaderPanel" Value="1"/>
-                            <Setter Property="Grid.Column" TargetName="ContentPanel" Value="0"/>
-                            <Setter Property="Width" TargetName="ColumnDefinition0" Value="*"/>
-                            <Setter Property="Width" TargetName="ColumnDefinition1" Value="Auto"/>
-                            <Setter Property="Height" TargetName="RowDefinition0" Value="*"/>
-                            <Setter Property="Height" TargetName="RowDefinition1" Value="0"/>
+                            <Setter TargetName="HeaderPanel" Property="Grid.Row" Value="0" />
+                            <Setter TargetName="ContentPanel" Property="Grid.Row" Value="0" />
+                            <Setter TargetName="HeaderPanel" Property="Grid.Column" Value="1" />
+                            <Setter TargetName="ContentPanel" Property="Grid.Column" Value="0" />
+                            <Setter TargetName="ColumnDefinition0" Property="Width" Value="*" />
+                            <Setter TargetName="ColumnDefinition1" Property="Width" Value="Auto" />
+                            <Setter TargetName="RowDefinition0" Property="Height" Value="*" />
+                            <Setter TargetName="RowDefinition1" Property="Height" Value="0" />
                             <!--<Setter Property="Margin" TargetName="HeaderPanel" Value="0,2,2,2"/>-->
-                            <Setter Property="Grid.Column" TargetName="HeaderPanel" Value="1"/>
+                            <Setter TargetName="HeaderPanel" Property="Grid.Column" Value="1" />
 
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="false">
-                            <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+                            <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
-    <!-- ScrollBar -->
+    <!--  ScrollBar  -->
     <Style TargetType="{x:Type ScrollViewer}">
-        <Setter Property="Background" Value="{DynamicResource ScrollViewerBackground}"/>
+        <Setter Property="Background" Value="{DynamicResource ScrollViewerBackground}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ScrollViewer}">
                     <Grid x:Name="Grid" Background="{TemplateBinding Background}">
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
                         <Grid.RowDefinitions>
-                            <RowDefinition Height="*"/>
-                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="Auto" />
                         </Grid.RowDefinitions>
-                        <Rectangle x:Name="Corner"
-							Grid.Column="1"
-							Grid.Row="1"
-							Fill="{TemplateBinding Background}"/>
-                        <ScrollContentPresenter x:Name="PART_ScrollContentPresenter"
-							CanContentScroll="{TemplateBinding CanContentScroll}"
-							CanHorizontallyScroll="False"
-							CanVerticallyScroll="False"
-							ContentTemplate="{TemplateBinding ContentTemplate}"
-							Content="{TemplateBinding Content}"
-							Grid.Column="0"
-							Grid.Row="0"
-							Margin="{TemplateBinding Padding}"/>
-                        <ScrollBar x:Name="PART_VerticalScrollBar"
-							AutomationProperties.AutomationId="VerticalScrollBar"
-							Cursor="Arrow"
-							Grid.Column="1"
-							Grid.Row="0"
-							Maximum="{TemplateBinding ScrollableHeight}"
-							Minimum="0" 
-							Visibility="{TemplateBinding ComputedVerticalScrollBarVisibility}"
-							Value="{Binding VerticalOffset, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}"
-							ViewportSize="{TemplateBinding ViewportHeight}"
-							Style="{DynamicResource VerticalScrollBarStyle}"/>
-                        <ScrollBar x:Name="PART_HorizontalScrollBar"
-							AutomationProperties.AutomationId="HorizontalScrollBar"
-							Cursor="Arrow"
-							Grid.Column="0" 
-							Grid.Row="1"
-							Maximum="{TemplateBinding ScrollableWidth}"
-							Minimum="0"
-							Orientation="Horizontal"
-							Visibility="{TemplateBinding ComputedHorizontalScrollBarVisibility}"
-							Value="{Binding HorizontalOffset, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}"
-							ViewportSize="{TemplateBinding ViewportWidth}"
-							Style="{DynamicResource HorisontalScrollBarStyle}"/>
+                        <Rectangle
+                            x:Name="Corner"
+                            Grid.Row="1"
+                            Grid.Column="1"
+                            Fill="{TemplateBinding Background}" />
+                        <ScrollContentPresenter
+                            x:Name="PART_ScrollContentPresenter"
+                            Grid.Row="0"
+                            Grid.Column="0"
+                            Margin="{TemplateBinding Padding}"
+                            CanContentScroll="{TemplateBinding CanContentScroll}"
+                            CanHorizontallyScroll="False"
+                            CanVerticallyScroll="False"
+                            Content="{TemplateBinding Content}"
+                            ContentTemplate="{TemplateBinding ContentTemplate}" />
+                        <ScrollBar
+                            x:Name="PART_VerticalScrollBar"
+                            Grid.Row="0"
+                            Grid.Column="1"
+                            AutomationProperties.AutomationId="VerticalScrollBar"
+                            Cursor="Arrow"
+                            Maximum="{TemplateBinding ScrollableHeight}"
+                            Minimum="0"
+                            Style="{DynamicResource VerticalScrollBarStyle}"
+                            ViewportSize="{TemplateBinding ViewportHeight}"
+                            Visibility="{TemplateBinding ComputedVerticalScrollBarVisibility}"
+                            Value="{Binding VerticalOffset, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}" />
+                        <ScrollBar
+                            x:Name="PART_HorizontalScrollBar"
+                            Grid.Row="1"
+                            Grid.Column="0"
+                            AutomationProperties.AutomationId="HorizontalScrollBar"
+                            Cursor="Arrow"
+                            Maximum="{TemplateBinding ScrollableWidth}"
+                            Minimum="0"
+                            Orientation="Horizontal"
+                            Style="{DynamicResource HorisontalScrollBarStyle}"
+                            ViewportSize="{TemplateBinding ViewportWidth}"
+                            Visibility="{TemplateBinding ComputedHorizontalScrollBarVisibility}"
+                            Value="{Binding HorizontalOffset, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}" />
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
     <Style x:Key="RepeatButtonUpStyle" TargetType="{x:Type RepeatButton}">
-        <Setter Property="OverridesDefaultStyle" Value="true"/>
-        <Setter Property="Focusable" Value="false"/>
-        <Setter Property="IsTabStop" Value="false"/>
+        <Setter Property="OverridesDefaultStyle" Value="true" />
+        <Setter Property="Focusable" Value="false" />
+        <Setter Property="IsTabStop" Value="false" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type RepeatButton}">
                     <Grid Background="Transparent">
-                        <Path x:Name="TrianglePath" Data="{StaticResource RepeatButton}" 
-									Fill="{StaticResource VerticalScrollBarThumb}" Height="Auto" Margin="5" Stretch="Fill" Width="Auto"/>
+                        <Path
+                            x:Name="TrianglePath"
+                            Width="Auto"
+                            Height="Auto"
+                            Margin="5"
+                            Data="{StaticResource RepeatButton}"
+                            Fill="{StaticResource VerticalScrollBarThumb}"
+                            Stretch="Fill" />
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter Property="Fill" TargetName="TrianglePath" Value="{StaticResource ScrollBarHotThumb}"/>
+                            <Setter TargetName="TrianglePath" Property="Fill" Value="{StaticResource ScrollBarHotThumb}" />
                         </Trigger>
-                        <Trigger Property="IsPressed"  Value="True">
-                            <Setter Property="Fill" TargetName="TrianglePath" Value="{StaticResource ScrollBarSelectedThumb}"/>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter TargetName="TrianglePath" Property="Fill" Value="{StaticResource ScrollBarSelectedThumb}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -536,51 +569,64 @@
         </Setter>
     </Style>
     <Style x:Key="ScrollBarThumb" TargetType="{x:Type Thumb}">
-        <Setter Property="OverridesDefaultStyle" Value="true"/>
-        <Setter Property="IsTabStop" Value="false"/>
+        <Setter Property="OverridesDefaultStyle" Value="true" />
+        <Setter Property="IsTabStop" Value="false" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Thumb}">
                     <Grid>
-                        <Rectangle x:Name="VerticalThumb" Fill="{StaticResource VerticalScrollBarThumb}"
-									Width="7.4" RadiusX="4" RadiusY="4"/>
+                        <Rectangle
+                            x:Name="VerticalThumb"
+                            Width="7.4"
+                            Fill="{StaticResource VerticalScrollBarThumb}"
+                            RadiusX="4"
+                            RadiusY="4" />
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter Property="Fill" TargetName="VerticalThumb" Value="{StaticResource ScrollBarHotThumb}"/>
+                            <Setter TargetName="VerticalThumb" Property="Fill" Value="{StaticResource ScrollBarHotThumb}" />
                         </Trigger>
-                        <Trigger Property="IsDragging"  Value="True">
-                            <Setter Property="Fill" TargetName="VerticalThumb" Value="{StaticResource ScrollBarSelectedThumb}"/>
+                        <Trigger Property="IsDragging" Value="True">
+                            <Setter TargetName="VerticalThumb" Property="Fill" Value="{StaticResource ScrollBarSelectedThumb}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
-    <Style x:Key="RepeatButtonDownStyle" TargetType="{x:Type RepeatButton}" BasedOn="{StaticResource RepeatButtonUpStyle}">
+    <Style
+        x:Key="RepeatButtonDownStyle"
+        BasedOn="{StaticResource RepeatButtonUpStyle}"
+        TargetType="{x:Type RepeatButton}">
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type RepeatButton}">
                     <Grid Background="Transparent">
-                        <Path x:Name="BottomTrianglePath" Data="{StaticResource RepeatButton}" 
-									Fill="{StaticResource VerticalScrollBarThumb}" Height="Auto" Margin="5" Stretch="Fill" Width="Auto"
-									RenderTransformOrigin="0.5,0.5">
+                        <Path
+                            x:Name="BottomTrianglePath"
+                            Width="Auto"
+                            Height="Auto"
+                            Margin="5"
+                            Data="{StaticResource RepeatButton}"
+                            Fill="{StaticResource VerticalScrollBarThumb}"
+                            RenderTransformOrigin="0.5,0.5"
+                            Stretch="Fill">
                             <Path.RenderTransform>
                                 <TransformGroup>
-                                    <ScaleTransform ScaleY="-1" ScaleX="1"/>
-                                    <SkewTransform AngleY="0" AngleX="0"/>
-                                    <RotateTransform Angle="0"/>
-                                    <TranslateTransform/>
+                                    <ScaleTransform ScaleX="1" ScaleY="-1" />
+                                    <SkewTransform AngleX="0" AngleY="0" />
+                                    <RotateTransform Angle="0" />
+                                    <TranslateTransform />
                                 </TransformGroup>
                             </Path.RenderTransform>
                         </Path>
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter Property="Fill" TargetName="BottomTrianglePath" Value="{StaticResource ScrollBarHotThumb}"/>
+                            <Setter TargetName="BottomTrianglePath" Property="Fill" Value="{StaticResource ScrollBarHotThumb}" />
                         </Trigger>
-                        <Trigger Property="IsPressed"  Value="True">
-                            <Setter Property="Fill" TargetName="BottomTrianglePath" Value="{StaticResource ScrollBarSelectedThumb}"/>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter TargetName="BottomTrianglePath" Property="Fill" Value="{StaticResource ScrollBarSelectedThumb}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -588,71 +634,85 @@
         </Setter>
     </Style>
     <Style x:Key="VerticalScrollBarPageButton" TargetType="{x:Type RepeatButton}">
-        <Setter Property="OverridesDefaultStyle" Value="true"/>
-        <Setter Property="Background" Value="Transparent"/>
-        <Setter Property="Focusable" Value="false"/>
-        <Setter Property="IsTabStop" Value="false"/>
+        <Setter Property="OverridesDefaultStyle" Value="true" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="Focusable" Value="false" />
+        <Setter Property="IsTabStop" Value="false" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type RepeatButton}">
-                    <Rectangle Fill="{TemplateBinding Background}"
-								Height="{TemplateBinding Height}"
-								Width="{TemplateBinding Width}"/>
+                    <Rectangle
+                        Width="{TemplateBinding Width}"
+                        Height="{TemplateBinding Height}"
+                        Fill="{TemplateBinding Background}" />
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
 
     <Style x:Key="HorizontalScrollBarPageButton" TargetType="{x:Type RepeatButton}">
-        <Setter Property="OverridesDefaultStyle" Value="true"/>
-        <Setter Property="Background" Value="Transparent"/>
-        <Setter Property="Focusable" Value="false"/>
-        <Setter Property="IsTabStop" Value="false"/>
+        <Setter Property="OverridesDefaultStyle" Value="true" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="Focusable" Value="false" />
+        <Setter Property="IsTabStop" Value="false" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type RepeatButton}">
-                    <Rectangle Fill="{TemplateBinding Background}" Height="{TemplateBinding Height}" Width="{TemplateBinding Width}"/>
+                    <Rectangle
+                        Width="{TemplateBinding Width}"
+                        Height="{TemplateBinding Height}"
+                        Fill="{TemplateBinding Background}" />
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
     <Style x:Key="VerticalScrollBarStyle" TargetType="{x:Type ScrollBar}">
-        <Setter Property="Background" Value="{StaticResource VerticalScrollBarBackground}"/>
-        <Setter Property="Stylus.IsPressAndHoldEnabled" Value="false"/>
-        <Setter Property="Stylus.IsFlicksEnabled" Value="false"/>
-        <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
-        <Setter Property="Width" Value="{DynamicResource {x:Static SystemParameters.VerticalScrollBarWidthKey}}"/>
-        <Setter Property="MinWidth" Value="{DynamicResource {x:Static SystemParameters.VerticalScrollBarWidthKey}}"/>
+        <Setter Property="Background" Value="{StaticResource VerticalScrollBarBackground}" />
+        <Setter Property="Stylus.IsPressAndHoldEnabled" Value="false" />
+        <Setter Property="Stylus.IsFlicksEnabled" Value="false" />
+        <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
+        <Setter Property="Width" Value="{DynamicResource {x:Static SystemParameters.VerticalScrollBarWidthKey}}" />
+        <Setter Property="MinWidth" Value="{DynamicResource {x:Static SystemParameters.VerticalScrollBarWidthKey}}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ScrollBar}">
-                    <Grid x:Name="Bg" Background="{TemplateBinding Background}" SnapsToDevicePixels="true">
+                    <Grid
+                        x:Name="Bg"
+                        Background="{TemplateBinding Background}"
+                        SnapsToDevicePixels="true">
                         <Grid.RowDefinitions>
-                            <RowDefinition MaxHeight="{DynamicResource {x:Static SystemParameters.VerticalScrollBarButtonHeightKey}}"/>
-                            <RowDefinition Height="0.00001*"/>
-                            <RowDefinition MaxHeight="{DynamicResource {x:Static SystemParameters.VerticalScrollBarButtonHeightKey}}"/>
+                            <RowDefinition MaxHeight="{DynamicResource {x:Static SystemParameters.VerticalScrollBarButtonHeightKey}}" />
+                            <RowDefinition Height="0.00001*" />
+                            <RowDefinition MaxHeight="{DynamicResource {x:Static SystemParameters.VerticalScrollBarButtonHeightKey}}" />
                         </Grid.RowDefinitions>
-                        <RepeatButton Command="{x:Static ScrollBar.LineUpCommand}"
-									IsEnabled="{TemplateBinding IsMouseOver}"
-									Style="{StaticResource RepeatButtonUpStyle}"/>
-                        <Track x:Name="PART_Track" IsDirectionReversed="true" IsEnabled="{TemplateBinding IsMouseOver}" Grid.Row="1">
+                        <RepeatButton
+                            Command="{x:Static ScrollBar.LineUpCommand}"
+                            IsEnabled="{TemplateBinding IsMouseOver}"
+                            Style="{StaticResource RepeatButtonUpStyle}" />
+                        <Track
+                            x:Name="PART_Track"
+                            Grid.Row="1"
+                            IsDirectionReversed="true"
+                            IsEnabled="{TemplateBinding IsMouseOver}">
                             <Track.DecreaseRepeatButton>
-                                <RepeatButton Command="{x:Static ScrollBar.PageUpCommand}" Style="{StaticResource VerticalScrollBarPageButton}"/>
+                                <RepeatButton Command="{x:Static ScrollBar.PageUpCommand}" Style="{StaticResource VerticalScrollBarPageButton}" />
                             </Track.DecreaseRepeatButton>
                             <Track.IncreaseRepeatButton>
-                                <RepeatButton Command="{x:Static ScrollBar.PageDownCommand}" Style="{StaticResource VerticalScrollBarPageButton}"/>
+                                <RepeatButton Command="{x:Static ScrollBar.PageDownCommand}" Style="{StaticResource VerticalScrollBarPageButton}" />
                             </Track.IncreaseRepeatButton>
                             <Track.Thumb>
-                                <Thumb Style="{StaticResource ScrollBarThumb}"/>
+                                <Thumb Style="{StaticResource ScrollBarThumb}" />
                             </Track.Thumb>
                         </Track>
-                        <RepeatButton Command="{x:Static ScrollBar.LineDownCommand}"
-									IsEnabled="{TemplateBinding IsMouseOver}" Grid.Row="2" 
-									Style="{DynamicResource RepeatButtonDownStyle}"/>
+                        <RepeatButton
+                            Grid.Row="2"
+                            Command="{x:Static ScrollBar.LineDownCommand}"
+                            IsEnabled="{TemplateBinding IsMouseOver}"
+                            Style="{DynamicResource RepeatButtonDownStyle}" />
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsEnabled" Value="false">
-                            <Setter Property="Background" TargetName="Bg" Value="{StaticResource ScrollBarDisabledBackground}"/>
+                            <Setter TargetName="Bg" Property="Background" Value="{StaticResource ScrollBarDisabledBackground}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -660,37 +720,50 @@
         </Setter>
         <Style.Triggers>
             <Trigger Property="Orientation" Value="Horizontal">
-                <Setter Property="Width" Value="Auto"/>
-                <Setter Property="MinWidth" Value="0"/>
-                <Setter Property="Height" Value="{DynamicResource {x:Static SystemParameters.HorizontalScrollBarHeightKey}}"/>
-                <Setter Property="MinHeight" Value="{DynamicResource {x:Static SystemParameters.HorizontalScrollBarHeightKey}}"/>
-                <Setter Property="Background" Value="{StaticResource HorizontalScrollBarBackground}"/>
+                <Setter Property="Width" Value="Auto" />
+                <Setter Property="MinWidth" Value="0" />
+                <Setter Property="Height" Value="{DynamicResource {x:Static SystemParameters.HorizontalScrollBarHeightKey}}" />
+                <Setter Property="MinHeight" Value="{DynamicResource {x:Static SystemParameters.HorizontalScrollBarHeightKey}}" />
+                <Setter Property="Background" Value="{StaticResource HorizontalScrollBarBackground}" />
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="{x:Type ScrollBar}">
-                            <Grid x:Name="Bg" Background="{TemplateBinding Background}" SnapsToDevicePixels="true">
+                            <Grid
+                                x:Name="Bg"
+                                Background="{TemplateBinding Background}"
+                                SnapsToDevicePixels="true">
                                 <Grid.ColumnDefinitions>
-                                    <ColumnDefinition MaxWidth="{DynamicResource {x:Static SystemParameters.HorizontalScrollBarButtonWidthKey}}"/>
-                                    <ColumnDefinition Width="0.00001*"/>
-                                    <ColumnDefinition MaxWidth="{DynamicResource {x:Static SystemParameters.HorizontalScrollBarButtonWidthKey}}"/>
+                                    <ColumnDefinition MaxWidth="{DynamicResource {x:Static SystemParameters.HorizontalScrollBarButtonWidthKey}}" />
+                                    <ColumnDefinition Width="0.00001*" />
+                                    <ColumnDefinition MaxWidth="{DynamicResource {x:Static SystemParameters.HorizontalScrollBarButtonWidthKey}}" />
                                 </Grid.ColumnDefinitions>
-                                <RepeatButton Command="{x:Static ScrollBar.LineLeftCommand}" IsEnabled="{TemplateBinding IsMouseOver}" Style="{StaticResource RepeatButtonUpStyle}"/>
-                                <Track x:Name="PART_Track" Grid.Column="1" IsEnabled="{TemplateBinding IsMouseOver}">
+                                <RepeatButton
+                                    Command="{x:Static ScrollBar.LineLeftCommand}"
+                                    IsEnabled="{TemplateBinding IsMouseOver}"
+                                    Style="{StaticResource RepeatButtonUpStyle}" />
+                                <Track
+                                    x:Name="PART_Track"
+                                    Grid.Column="1"
+                                    IsEnabled="{TemplateBinding IsMouseOver}">
                                     <Track.DecreaseRepeatButton>
-                                        <RepeatButton Command="{x:Static ScrollBar.PageLeftCommand}" Style="{StaticResource HorizontalScrollBarPageButton}"/>
+                                        <RepeatButton Command="{x:Static ScrollBar.PageLeftCommand}" Style="{StaticResource HorizontalScrollBarPageButton}" />
                                     </Track.DecreaseRepeatButton>
                                     <Track.IncreaseRepeatButton>
-                                        <RepeatButton Command="{x:Static ScrollBar.PageRightCommand}" Style="{StaticResource HorizontalScrollBarPageButton}"/>
+                                        <RepeatButton Command="{x:Static ScrollBar.PageRightCommand}" Style="{StaticResource HorizontalScrollBarPageButton}" />
                                     </Track.IncreaseRepeatButton>
                                     <Track.Thumb>
-                                        <Thumb Style="{StaticResource ScrollBarThumb}"/>
+                                        <Thumb Style="{StaticResource ScrollBarThumb}" />
                                     </Track.Thumb>
                                 </Track>
-                                <RepeatButton Grid.Column="2" Command="{x:Static ScrollBar.LineRightCommand}" IsEnabled="{TemplateBinding IsMouseOver}" Style="{StaticResource RepeatButtonUpStyle}"/>
+                                <RepeatButton
+                                    Grid.Column="2"
+                                    Command="{x:Static ScrollBar.LineRightCommand}"
+                                    IsEnabled="{TemplateBinding IsMouseOver}"
+                                    Style="{StaticResource RepeatButtonUpStyle}" />
                             </Grid>
                             <ControlTemplate.Triggers>
                                 <Trigger Property="IsEnabled" Value="false">
-                                    <Setter Property="Background" TargetName="Bg" Value="{StaticResource ScrollBarDisabledBackground}"/>
+                                    <Setter TargetName="Bg" Property="Background" Value="{StaticResource ScrollBarDisabledBackground}" />
                                 </Trigger>
                             </ControlTemplate.Triggers>
                         </ControlTemplate>
@@ -700,45 +773,58 @@
         </Style.Triggers>
     </Style>
     <Style x:Key="HorisontalScrollBarStyle" TargetType="{x:Type ScrollBar}">
-        <Setter Property="Background" Value="{StaticResource VerticalScrollBarBackground}"/>
-        <Setter Property="Stylus.IsPressAndHoldEnabled" Value="false"/>
-        <Setter Property="Stylus.IsFlicksEnabled" Value="false"/>
-        <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
-        <Setter Property="Width" Value="{DynamicResource {x:Static SystemParameters.VerticalScrollBarWidthKey}}"/>
-        <Setter Property="MinWidth" Value="{DynamicResource {x:Static SystemParameters.VerticalScrollBarWidthKey}}"/>
+        <Setter Property="Background" Value="{StaticResource VerticalScrollBarBackground}" />
+        <Setter Property="Stylus.IsPressAndHoldEnabled" Value="false" />
+        <Setter Property="Stylus.IsFlicksEnabled" Value="false" />
+        <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
+        <Setter Property="Width" Value="{DynamicResource {x:Static SystemParameters.VerticalScrollBarWidthKey}}" />
+        <Setter Property="MinWidth" Value="{DynamicResource {x:Static SystemParameters.VerticalScrollBarWidthKey}}" />
         <Style.Triggers>
             <Trigger Property="Orientation" Value="Horizontal">
-                <Setter Property="Width" Value="Auto"/>
-                <Setter Property="MinWidth" Value="0"/>
-                <Setter Property="Height" Value="{DynamicResource {x:Static SystemParameters.HorizontalScrollBarHeightKey}}"/>
-                <Setter Property="MinHeight" Value="{DynamicResource {x:Static SystemParameters.HorizontalScrollBarHeightKey}}"/>
-                <Setter Property="Background" Value="{StaticResource HorizontalScrollBarBackground}"/>
+                <Setter Property="Width" Value="Auto" />
+                <Setter Property="MinWidth" Value="0" />
+                <Setter Property="Height" Value="{DynamicResource {x:Static SystemParameters.HorizontalScrollBarHeightKey}}" />
+                <Setter Property="MinHeight" Value="{DynamicResource {x:Static SystemParameters.HorizontalScrollBarHeightKey}}" />
+                <Setter Property="Background" Value="{StaticResource HorizontalScrollBarBackground}" />
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="{x:Type ScrollBar}">
-                            <Grid x:Name="Bg" Background="{TemplateBinding Background}" SnapsToDevicePixels="true">
+                            <Grid
+                                x:Name="Bg"
+                                Background="{TemplateBinding Background}"
+                                SnapsToDevicePixels="true">
                                 <Grid.ColumnDefinitions>
-                                    <ColumnDefinition MaxWidth="{DynamicResource {x:Static SystemParameters.HorizontalScrollBarButtonWidthKey}}"/>
-                                    <ColumnDefinition Width="0.00001*"/>
-                                    <ColumnDefinition MaxWidth="{DynamicResource {x:Static SystemParameters.HorizontalScrollBarButtonWidthKey}}"/>
+                                    <ColumnDefinition MaxWidth="{DynamicResource {x:Static SystemParameters.HorizontalScrollBarButtonWidthKey}}" />
+                                    <ColumnDefinition Width="0.00001*" />
+                                    <ColumnDefinition MaxWidth="{DynamicResource {x:Static SystemParameters.HorizontalScrollBarButtonWidthKey}}" />
                                 </Grid.ColumnDefinitions>
-                                <RepeatButton Command="{x:Static ScrollBar.LineLeftCommand}" IsEnabled="{TemplateBinding IsMouseOver}" Style="{DynamicResource RepeatLeftButtonStyle}"/>
-                                <Track x:Name="PART_Track" Grid.Column="1" IsEnabled="{TemplateBinding IsMouseOver}">
+                                <RepeatButton
+                                    Command="{x:Static ScrollBar.LineLeftCommand}"
+                                    IsEnabled="{TemplateBinding IsMouseOver}"
+                                    Style="{DynamicResource RepeatLeftButtonStyle}" />
+                                <Track
+                                    x:Name="PART_Track"
+                                    Grid.Column="1"
+                                    IsEnabled="{TemplateBinding IsMouseOver}">
                                     <Track.DecreaseRepeatButton>
-                                        <RepeatButton Command="{x:Static ScrollBar.PageLeftCommand}" Style="{StaticResource HorizontalScrollBarPageButton}"/>
+                                        <RepeatButton Command="{x:Static ScrollBar.PageLeftCommand}" Style="{StaticResource HorizontalScrollBarPageButton}" />
                                     </Track.DecreaseRepeatButton>
                                     <Track.IncreaseRepeatButton>
-                                        <RepeatButton Command="{x:Static ScrollBar.PageRightCommand}" Style="{StaticResource HorizontalScrollBarPageButton}"/>
+                                        <RepeatButton Command="{x:Static ScrollBar.PageRightCommand}" Style="{StaticResource HorizontalScrollBarPageButton}" />
                                     </Track.IncreaseRepeatButton>
                                     <Track.Thumb>
-                                        <Thumb Style="{DynamicResource HorisontalThumbStyle}"/>
+                                        <Thumb Style="{DynamicResource HorisontalThumbStyle}" />
                                     </Track.Thumb>
                                 </Track>
-                                <RepeatButton Grid.Column="2" Command="{x:Static ScrollBar.LineRightCommand}" IsEnabled="{TemplateBinding IsMouseOver}" Style="{DynamicResource RepeatRightButtonStyle}"/>
+                                <RepeatButton
+                                    Grid.Column="2"
+                                    Command="{x:Static ScrollBar.LineRightCommand}"
+                                    IsEnabled="{TemplateBinding IsMouseOver}"
+                                    Style="{DynamicResource RepeatRightButtonStyle}" />
                             </Grid>
                             <ControlTemplate.Triggers>
                                 <Trigger Property="IsEnabled" Value="false">
-                                    <Setter Property="Background" TargetName="Bg" Value="{StaticResource ScrollBarDisabledBackground}"/>
+                                    <Setter TargetName="Bg" Property="Background" Value="{StaticResource ScrollBarDisabledBackground}" />
                                 </Trigger>
                             </ControlTemplate.Triggers>
                         </ControlTemplate>
@@ -748,21 +834,25 @@
         </Style.Triggers>
     </Style>
     <Style x:Key="HorisontalThumbStyle" TargetType="{x:Type Thumb}">
-        <Setter Property="OverridesDefaultStyle" Value="true"/>
-        <Setter Property="IsTabStop" Value="false"/>
+        <Setter Property="OverridesDefaultStyle" Value="true" />
+        <Setter Property="IsTabStop" Value="false" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Thumb}">
                     <Grid>
-                        <Rectangle x:Name="VerticalThumb" Fill="{StaticResource VerticalScrollBarThumb}"
-									Height="7.4" RadiusX="4" RadiusY="4"/>
+                        <Rectangle
+                            x:Name="VerticalThumb"
+                            Height="7.4"
+                            Fill="{StaticResource VerticalScrollBarThumb}"
+                            RadiusX="4"
+                            RadiusY="4" />
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter Property="Fill" TargetName="VerticalThumb" Value="{StaticResource ScrollBarHotThumb}"/>
+                            <Setter TargetName="VerticalThumb" Property="Fill" Value="{StaticResource ScrollBarHotThumb}" />
                         </Trigger>
-                        <Trigger Property="IsDragging"  Value="True">
-                            <Setter Property="Fill" TargetName="VerticalThumb" Value="{StaticResource ScrollBarSelectedThumb}"/>
+                        <Trigger Property="IsDragging" Value="True">
+                            <Setter TargetName="VerticalThumb" Property="Fill" Value="{StaticResource ScrollBarSelectedThumb}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -770,30 +860,36 @@
         </Setter>
     </Style>
     <Style x:Key="RepeatLeftButtonStyle" TargetType="{x:Type RepeatButton}">
-        <Setter Property="OverridesDefaultStyle" Value="true"/>
-        <Setter Property="Focusable" Value="false"/>
-        <Setter Property="IsTabStop" Value="false"/>
+        <Setter Property="OverridesDefaultStyle" Value="true" />
+        <Setter Property="Focusable" Value="false" />
+        <Setter Property="IsTabStop" Value="false" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type RepeatButton}">
                     <Grid Background="Transparent" RenderTransformOrigin="0.5,0.5">
                         <Grid.RenderTransform>
                             <TransformGroup>
-                                <ScaleTransform/>
-                                <SkewTransform/>
-                                <RotateTransform Angle="270"/>
-                                <TranslateTransform/>
+                                <ScaleTransform />
+                                <SkewTransform />
+                                <RotateTransform Angle="270" />
+                                <TranslateTransform />
                             </TransformGroup>
                         </Grid.RenderTransform>
-                        <Path x:Name="TrianglePath" Data="{StaticResource RepeatButton}" 
-									Fill="{StaticResource VerticalScrollBarThumb}" Height="Auto" Margin="5" Stretch="Fill" Width="Auto"/>
+                        <Path
+                            x:Name="TrianglePath"
+                            Width="Auto"
+                            Height="Auto"
+                            Margin="5"
+                            Data="{StaticResource RepeatButton}"
+                            Fill="{StaticResource VerticalScrollBarThumb}"
+                            Stretch="Fill" />
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter Property="Fill" TargetName="TrianglePath" Value="{StaticResource ScrollBarHotThumb}"/>
+                            <Setter TargetName="TrianglePath" Property="Fill" Value="{StaticResource ScrollBarHotThumb}" />
                         </Trigger>
-                        <Trigger Property="IsPressed"  Value="True">
-                            <Setter Property="Fill" TargetName="TrianglePath" Value="{StaticResource ScrollBarSelectedThumb}"/>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter TargetName="TrianglePath" Property="Fill" Value="{StaticResource ScrollBarSelectedThumb}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -801,39 +897,46 @@
         </Setter>
     </Style>
     <Style x:Key="RepeatRightButtonStyle" TargetType="{x:Type RepeatButton}">
-        <Setter Property="OverridesDefaultStyle" Value="true"/>
-        <Setter Property="Focusable" Value="false"/>
-        <Setter Property="IsTabStop" Value="false"/>
+        <Setter Property="OverridesDefaultStyle" Value="true" />
+        <Setter Property="Focusable" Value="false" />
+        <Setter Property="IsTabStop" Value="false" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type RepeatButton}">
                     <Grid Background="Transparent" RenderTransformOrigin="0.5,0.5">
                         <Grid.RenderTransform>
                             <TransformGroup>
-                                <ScaleTransform/>
-                                <SkewTransform/>
-                                <RotateTransform Angle="270"/>
-                                <TranslateTransform/>
+                                <ScaleTransform />
+                                <SkewTransform />
+                                <RotateTransform Angle="270" />
+                                <TranslateTransform />
                             </TransformGroup>
                         </Grid.RenderTransform>
-                        <Path x:Name="TrianglePath" Data="{StaticResource RepeatButton}" 
-									Fill="{StaticResource VerticalScrollBarThumb}" Height="Auto" Margin="5" Stretch="Fill" Width="Auto" RenderTransformOrigin="0.5,0.5">
+                        <Path
+                            x:Name="TrianglePath"
+                            Width="Auto"
+                            Height="Auto"
+                            Margin="5"
+                            Data="{StaticResource RepeatButton}"
+                            Fill="{StaticResource VerticalScrollBarThumb}"
+                            RenderTransformOrigin="0.5,0.5"
+                            Stretch="Fill">
                             <Path.RenderTransform>
                                 <TransformGroup>
-                                    <ScaleTransform/>
-                                    <SkewTransform/>
-                                    <RotateTransform Angle="180"/>
-                                    <TranslateTransform/>
+                                    <ScaleTransform />
+                                    <SkewTransform />
+                                    <RotateTransform Angle="180" />
+                                    <TranslateTransform />
                                 </TransformGroup>
                             </Path.RenderTransform>
                         </Path>
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter Property="Fill" TargetName="TrianglePath" Value="{StaticResource ScrollBarHotThumb}"/>
+                            <Setter TargetName="TrianglePath" Property="Fill" Value="{StaticResource ScrollBarHotThumb}" />
                         </Trigger>
-                        <Trigger Property="IsPressed"  Value="True">
-                            <Setter Property="Fill" TargetName="TrianglePath" Value="{StaticResource ScrollBarSelectedThumb}"/>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter TargetName="TrianglePath" Property="Fill" Value="{StaticResource ScrollBarSelectedThumb}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -841,7 +944,7 @@
         </Setter>
     </Style>
 
-    <!-- TextBox -->
+    <!--  TextBox  -->
     <Style
         x:Key="MainTextBoxStyle"
         BasedOn="{StaticResource {x:Type Control}}"
@@ -960,57 +1063,62 @@
     </Style>
     <Style BasedOn="{StaticResource MainTextBoxStyle}" TargetType="TextBox" />
 
-    <!-- ComboBox -->
+    <!--  ComboBox  -->
     <Style x:Key="ComboBoxFocusVisual">
         <Setter Property="Control.Template">
             <Setter.Value>
                 <ControlTemplate>
-                    <Rectangle Margin="2,2,21,2" SnapsToDevicePixels="true"
-						Stroke="{StaticResource ForegroundBrush}"
-						StrokeThickness="1"
-						StrokeDashArray="1 2"/>
+                    <Rectangle
+                        Margin="2,2,21,2"
+                        SnapsToDevicePixels="true"
+                        Stroke="{StaticResource ForegroundBrush}"
+                        StrokeDashArray="1 2"
+                        StrokeThickness="1" />
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
 
-    
+
 
     <Style x:Key="ComboBoxReadonlyToggleButton" TargetType="{x:Type ToggleButton}">
-        <Setter Property="OverridesDefaultStyle" Value="true"/>
-        <Setter Property="IsTabStop" Value="false"/>
-        <Setter Property="Focusable" Value="false"/>
-        <Setter Property="ClickMode" Value="Press"/>
-        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="OverridesDefaultStyle" Value="true" />
+        <Setter Property="IsTabStop" Value="false" />
+        <Setter Property="Focusable" Value="false" />
+        <Setter Property="ClickMode" Value="Press" />
+        <Setter Property="Background" Value="Transparent" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ToggleButton}">
-                    <Border  
-						CornerRadius="3"             
-						BorderBrush="{TemplateBinding BorderBrush}" 
-						Background="{TemplateBinding Background}" 
-						SnapsToDevicePixels="true">
-                        <Border x:Name="PopUpButton"
-							HorizontalAlignment="Right"
-							Background="{DynamicResource ComboBoxButtonNormalBackground}"
-							CornerRadius="3"
-							Margin="1"
-							Width="15">
-                            <Path x:Name="Arrow" Data="{StaticResource ComboBoxArrow}" 
-								HorizontalAlignment="Center" 
-								VerticalAlignment="Center"
-								Width="5.5"
-								Height="5.5" 
-								Stretch="Fill" 
-								Fill="{DynamicResource ButtonForeground}"
-                                RenderTransformOrigin="0.5,0.5" 
-                                Margin="0,4,0,7">
+                    <Border
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        CornerRadius="3"
+                        SnapsToDevicePixels="true">
+                        <Border
+                            x:Name="PopUpButton"
+                            Width="15"
+                            Margin="1"
+                            HorizontalAlignment="Right"
+                            Background="{DynamicResource ComboBoxButtonNormalBackground}"
+                            CornerRadius="3">
+                            <Path
+                                x:Name="Arrow"
+                                Width="5.5"
+                                Height="5.5"
+                                Margin="0,4,0,7"
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Center"
+                                Data="{StaticResource ComboBoxArrow}"
+                                Fill="{DynamicResource ButtonForeground}"
+                                RenderTransformOrigin="0.5,0.5"
+                                Stretch="Fill">
                                 <Path.RenderTransform>
                                     <TransformGroup>
-                                        <ScaleTransform/>
-                                        <SkewTransform/>
-                                        <RotateTransform Angle="45"/>
-                                        <TranslateTransform/>
+                                        <ScaleTransform />
+                                        <SkewTransform />
+                                        <RotateTransform Angle="45" />
+                                        <TranslateTransform />
                                     </TransformGroup>
                                 </Path.RenderTransform>
                             </Path>
@@ -1018,10 +1126,10 @@
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="true">
-                            <Setter Property="Background" TargetName="PopUpButton" Value="{DynamicResource MouseOverButtonBackground}"/>
+                            <Setter TargetName="PopUpButton" Property="Background" Value="{DynamicResource MouseOverButtonBackground}" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="false">
-                            <Setter Property="Fill" TargetName="Arrow" Value="{DynamicResource DisabledButtonForeground}"/>
+                            <Setter TargetName="Arrow" Property="Fill" Value="{DynamicResource DisabledButtonForeground}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -1031,172 +1139,187 @@
     <ControlTemplate x:Key="ComboBoxEditableTemplate" TargetType="{x:Type ComboBox}">
         <Grid x:Name="Placement" SnapsToDevicePixels="true">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
-            <Popup x:Name="PART_Popup"
-				AllowsTransparency="true" 
-				Grid.ColumnSpan="2"
-				IsOpen="{Binding IsDropDownOpen, RelativeSource={RelativeSource TemplatedParent}}" 
-				Margin="1" 
-				PopupAnimation="{DynamicResource {x:Static SystemParameters.ComboBoxPopupAnimationKey}}" 
-				Placement="Bottom">
-                <Border x:Name="Shdw"
-					Background="Transparent" 
-					MaxHeight="{TemplateBinding MaxDropDownHeight}" 
-					MinWidth="{Binding ActualWidth, ElementName=Placement}">
-                    <Border x:Name="DropDownBorder" 
-						BorderBrush="{TemplateBinding BorderBrush}" 
-						BorderThickness="1" 
-						Background="{TemplateBinding Background}">
+            <Popup
+                x:Name="PART_Popup"
+                Grid.ColumnSpan="2"
+                Margin="1"
+                AllowsTransparency="true"
+                IsOpen="{Binding IsDropDownOpen, RelativeSource={RelativeSource TemplatedParent}}"
+                Placement="Bottom"
+                PopupAnimation="{DynamicResource {x:Static SystemParameters.ComboBoxPopupAnimationKey}}">
+                <Border
+                    x:Name="Shdw"
+                    MinWidth="{Binding ActualWidth, ElementName=Placement}"
+                    MaxHeight="{TemplateBinding MaxDropDownHeight}"
+                    Background="Transparent">
+                    <Border
+                        x:Name="DropDownBorder"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="1">
                         <ScrollViewer x:Name="DropDownScrollViewer">
                             <Grid RenderOptions.ClearTypeHint="Enabled">
-                                <Canvas HorizontalAlignment="Left" 
-									Height="0" 
-									VerticalAlignment="Top" 
-									Width="0">
-                                    <Rectangle x:Name="OpaqueRect" 
-										Fill="{Binding Background, ElementName=DropDownBorder}" 
-										Height="{Binding ActualHeight, ElementName=DropDownBorder}" 
-										Width="{Binding ActualWidth, ElementName=DropDownBorder}"/>
+                                <Canvas
+                                    Width="0"
+                                    Height="0"
+                                    HorizontalAlignment="Left"
+                                    VerticalAlignment="Top">
+                                    <Rectangle
+                                        x:Name="OpaqueRect"
+                                        Width="{Binding ActualWidth, ElementName=DropDownBorder}"
+                                        Height="{Binding ActualHeight, ElementName=DropDownBorder}"
+                                        Fill="{Binding Background, ElementName=DropDownBorder}" />
                                 </Canvas>
-                                <ItemsPresenter x:Name="ItemsPresenter"
-									KeyboardNavigation.DirectionalNavigation="Contained" 
-									SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                <ItemsPresenter
+                                    x:Name="ItemsPresenter"
+                                    KeyboardNavigation.DirectionalNavigation="Contained"
+                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                             </Grid>
                         </ScrollViewer>
                     </Border>
                 </Border>
             </Popup>
-            <Border x:Name="Border" 
-				BorderBrush="{TemplateBinding Background}" 
-				BorderThickness="{TemplateBinding BorderThickness}" 
-				Background="{TemplateBinding Background}" 
-				CornerRadius="3"
-				Grid.ColumnSpan="2"/>
+            <Border
+                x:Name="Border"
+                Grid.ColumnSpan="2"
+                Background="{TemplateBinding Background}"
+                BorderBrush="{TemplateBinding Background}"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                CornerRadius="3" />
             <TextBox x:Name="PART_EditableTextBox" />
-            <ToggleButton Grid.Column="1" 
-				IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" 
-				Style="{StaticResource ComboBoxReadonlyToggleButton}"/>
+            <ToggleButton
+                Grid.Column="1"
+                IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
+                Style="{StaticResource ComboBoxReadonlyToggleButton}" />
         </Grid>
         <ControlTemplate.Triggers>
             <Trigger Property="HasItems" Value="false">
-                <Setter Property="Height" TargetName="DropDownBorder" Value="95"/>
+                <Setter TargetName="DropDownBorder" Property="Height" Value="95" />
             </Trigger>
             <Trigger Property="IsEnabled" Value="false">
-                <Setter Property="Foreground" Value="{DynamicResource TextBoxDisabledForeground}"/>
-                <Setter Property="Background" Value="{DynamicResource TextBoxDisabledBackground}"/>
+                <Setter Property="Foreground" Value="{DynamicResource TextBoxDisabledForeground}" />
+                <Setter Property="Background" Value="{DynamicResource TextBoxDisabledBackground}" />
             </Trigger>
             <MultiTrigger>
                 <MultiTrigger.Conditions>
-                    <Condition Property="IsGrouping" Value="true"/>
+                    <Condition Property="IsGrouping" Value="true" />
                     <!--<Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false"/>-->
                 </MultiTrigger.Conditions>
-                <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
+                <Setter Property="ScrollViewer.CanContentScroll" Value="false" />
             </MultiTrigger>
-            <Trigger Property="HasDropShadow" SourceName="PART_Popup" Value="true">
-                <Setter Property="Margin" TargetName="Shdw" Value="0,0,5,5"/>
-                <Setter Property="Background" TargetName="Shdw" Value="#71000000"/>
+            <Trigger SourceName="PART_Popup" Property="HasDropShadow" Value="true">
+                <Setter TargetName="Shdw" Property="Margin" Value="0,0,5,5" />
+                <Setter TargetName="Shdw" Property="Background" Value="#71000000" />
             </Trigger>
-            <Trigger Property="ScrollViewer.CanContentScroll" SourceName="DropDownScrollViewer" Value="false">
-                <Setter Property="Canvas.Top" TargetName="OpaqueRect" Value="{Binding VerticalOffset, ElementName=DropDownScrollViewer}"/>
-                <Setter Property="Canvas.Left" TargetName="OpaqueRect" Value="{Binding HorizontalOffset, ElementName=DropDownScrollViewer}"/>
+            <Trigger SourceName="DropDownScrollViewer" Property="ScrollViewer.CanContentScroll" Value="false">
+                <Setter TargetName="OpaqueRect" Property="Canvas.Top" Value="{Binding VerticalOffset, ElementName=DropDownScrollViewer}" />
+                <Setter TargetName="OpaqueRect" Property="Canvas.Left" Value="{Binding HorizontalOffset, ElementName=DropDownScrollViewer}" />
             </Trigger>
         </ControlTemplate.Triggers>
     </ControlTemplate>
     <Style TargetType="{x:Type ComboBox}">
-        <Setter Property="FocusVisualStyle" Value="{StaticResource ComboBoxFocusVisual}"/>
-        <Setter Property="Foreground" Value="{DynamicResource ButtonForeground}"/>
-        <Setter Property="Background" Value="{StaticResource ButtonNormalBackground}"/>
-        <Setter Property="BorderBrush" Value="{StaticResource ButtonNormalBorder}"/>
-        <Setter Property="Padding" Value="5,3,5,1"/>
-        <Setter Property="BorderThickness" Value="1"/>
-        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto"/>
-        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto"/>
-        <Setter Property="ScrollViewer.CanContentScroll" Value="true"/>
-        <Setter Property="ScrollViewer.PanningMode" Value="Both"/>
-        <Setter Property="Stylus.IsFlicksEnabled" Value="False"/>
-        <Setter Property="ItemContainerStyle" Value="{DynamicResource ComboBoxItemStyle}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource ComboBoxFocusVisual}" />
+        <Setter Property="Foreground" Value="{DynamicResource ButtonForeground}" />
+        <Setter Property="Background" Value="{StaticResource ButtonNormalBackground}" />
+        <Setter Property="BorderBrush" Value="{StaticResource ButtonNormalBorder}" />
+        <Setter Property="Padding" Value="5,3,5,1" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />
+        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
+        <Setter Property="ScrollViewer.CanContentScroll" Value="true" />
+        <Setter Property="ScrollViewer.PanningMode" Value="Both" />
+        <Setter Property="Stylus.IsFlicksEnabled" Value="False" />
+        <Setter Property="ItemContainerStyle" Value="{DynamicResource ComboBoxItemStyle}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ComboBox}">
                     <Grid x:Name="MainGrid" SnapsToDevicePixels="true">
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition MinWidth="18" Width="Auto"/>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" MinWidth="18" />
                         </Grid.ColumnDefinitions>
-                        <Popup x:Name="PART_Popup" 
-							AllowsTransparency="true" 
-							Grid.ColumnSpan="2"
-							IsOpen="{Binding IsDropDownOpen, RelativeSource={RelativeSource TemplatedParent}}" 
-							Margin="1" 
-							PopupAnimation="{DynamicResource {x:Static SystemParameters.ComboBoxPopupAnimationKey}}" 
-							Placement="Bottom">
-                            <Border x:Name="Shdw" 
-								Background="Transparent" 
-								MaxHeight="{TemplateBinding MaxDropDownHeight}" 
-								MinWidth="{Binding ActualWidth, ElementName=MainGrid}">
-                                <Border x:Name="DropDownBorder" 
-									BorderBrush="{TemplateBinding BorderBrush}" 
-									BorderThickness="1" 
-									Background="{TemplateBinding Background}">
-                                    <ScrollViewer x:Name="DropDownScrollViewer" 
-										>
+                        <Popup
+                            x:Name="PART_Popup"
+                            Grid.ColumnSpan="2"
+                            Margin="1"
+                            AllowsTransparency="true"
+                            IsOpen="{Binding IsDropDownOpen, RelativeSource={RelativeSource TemplatedParent}}"
+                            Placement="Bottom"
+                            PopupAnimation="{DynamicResource {x:Static SystemParameters.ComboBoxPopupAnimationKey}}">
+                            <Border
+                                x:Name="Shdw"
+                                MinWidth="{Binding ActualWidth, ElementName=MainGrid}"
+                                MaxHeight="{TemplateBinding MaxDropDownHeight}"
+                                Background="Transparent">
+                                <Border
+                                    x:Name="DropDownBorder"
+                                    Background="{TemplateBinding Background}"
+                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                    BorderThickness="1">
+                                    <ScrollViewer x:Name="DropDownScrollViewer">
                                         <Grid RenderOptions.ClearTypeHint="Enabled">
-                                            <Canvas HorizontalAlignment="Left" 
-												Height="0" 
-												VerticalAlignment="Top" 
-												Width="0">
-                                                <Rectangle x:Name="OpaqueRect" 
-													Fill="{Binding Background, ElementName=DropDownBorder}" 
-													Height="{Binding ActualHeight, ElementName=DropDownBorder}" 
-													Width="{Binding ActualWidth, ElementName=DropDownBorder}"/>
+                                            <Canvas
+                                                Width="0"
+                                                Height="0"
+                                                HorizontalAlignment="Left"
+                                                VerticalAlignment="Top">
+                                                <Rectangle
+                                                    x:Name="OpaqueRect"
+                                                    Width="{Binding ActualWidth, ElementName=DropDownBorder}"
+                                                    Height="{Binding ActualHeight, ElementName=DropDownBorder}"
+                                                    Fill="{Binding Background, ElementName=DropDownBorder}" />
                                             </Canvas>
-                                            <ItemsPresenter x:Name="ItemsPresenter" 
-												KeyboardNavigation.DirectionalNavigation="Contained" 
-												SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                            <ItemsPresenter
+                                                x:Name="ItemsPresenter"
+                                                KeyboardNavigation.DirectionalNavigation="Contained"
+                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                                         </Grid>
                                     </ScrollViewer>
                                 </Border>
                             </Border>
                         </Popup>
-                        <ToggleButton BorderBrush="{TemplateBinding BorderBrush}" 
-							Background="{TemplateBinding Background}" 
-							Grid.ColumnSpan="2" 
-							IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
-							Style="{StaticResource ComboBoxReadonlyToggleButton}"/>
-                        <ContentPresenter ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}" 
-							ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}"
-							Content="{TemplateBinding SelectionBoxItem}" 
-							ContentStringFormat="{TemplateBinding SelectionBoxItemStringFormat}" 
-							HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" 
-							IsHitTestVisible="false" 
-							Margin="{TemplateBinding Padding}" 
-							SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" 
-							VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                        <ToggleButton
+                            Grid.ColumnSpan="2"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
+                            Style="{StaticResource ComboBoxReadonlyToggleButton}" />
+                        <ContentPresenter
+                            Margin="{TemplateBinding Padding}"
+                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                            Content="{TemplateBinding SelectionBoxItem}"
+                            ContentStringFormat="{TemplateBinding SelectionBoxItemStringFormat}"
+                            ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
+                            ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}"
+                            IsHitTestVisible="false"
+                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                     </Grid>
                     <ControlTemplate.Triggers>
-                        <Trigger Property="HasDropShadow" SourceName="PART_Popup" Value="true">
-                            <Setter Property="Margin" TargetName="Shdw" Value="0,0,5,5"/>
-                            <Setter Property="Background" TargetName="Shdw" Value="#71000000"/>
+                        <Trigger SourceName="PART_Popup" Property="HasDropShadow" Value="true">
+                            <Setter TargetName="Shdw" Property="Margin" Value="0,0,5,5" />
+                            <Setter TargetName="Shdw" Property="Background" Value="#71000000" />
                         </Trigger>
                         <Trigger Property="HasItems" Value="false">
-                            <Setter Property="Height" TargetName="DropDownBorder" Value="95"/>
+                            <Setter TargetName="DropDownBorder" Property="Height" Value="95" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="false">
-                            <Setter Property="Foreground" Value="{DynamicResource TextBoxDisabledForeground}"/>
-                            <Setter Property="Background" Value="{DynamicResource TextBoxDisabledBackground}"/>
+                            <Setter Property="Foreground" Value="{DynamicResource TextBoxDisabledForeground}" />
+                            <Setter Property="Background" Value="{DynamicResource TextBoxDisabledBackground}" />
                         </Trigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
-                                <Condition Property="IsGrouping" Value="true"/>
+                                <Condition Property="IsGrouping" Value="true" />
                                 <!--<Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false"/>-->
                             </MultiTrigger.Conditions>
-                            <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
+                            <Setter Property="ScrollViewer.CanContentScroll" Value="false" />
                         </MultiTrigger>
-                        <Trigger Property="ScrollViewer.CanContentScroll" SourceName="DropDownScrollViewer" Value="false">
-                            <Setter Property="Canvas.Top" TargetName="OpaqueRect" Value="{Binding VerticalOffset, ElementName=DropDownScrollViewer}"/>
-                            <Setter Property="Canvas.Left" TargetName="OpaqueRect" Value="{Binding HorizontalOffset, ElementName=DropDownScrollViewer}"/>
+                        <Trigger SourceName="DropDownScrollViewer" Property="ScrollViewer.CanContentScroll" Value="false">
+                            <Setter TargetName="OpaqueRect" Property="Canvas.Top" Value="{Binding VerticalOffset, ElementName=DropDownScrollViewer}" />
+                            <Setter TargetName="OpaqueRect" Property="Canvas.Left" Value="{Binding HorizontalOffset, ElementName=DropDownScrollViewer}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -1206,31 +1329,40 @@
             <Trigger Property="IsEditable" Value="true">
                 <!--<Setter Property="BorderBrush" Value="{StaticResource TextBoxBorder2}"/>
                 <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.WindowBrushKey}}"/>-->
-                <Setter Property="IsTabStop" Value="false"/>
-                <Setter Property="Padding" Value="3"/>
-                <Setter Property="Template" Value="{StaticResource ComboBoxEditableTemplate}"/>
+                <Setter Property="IsTabStop" Value="false" />
+                <Setter Property="Padding" Value="3" />
+                <Setter Property="Template" Value="{StaticResource ComboBoxEditableTemplate}" />
             </Trigger>
         </Style.Triggers>
     </Style>
 
     <Style x:Key="ComboBoxItemStyle" TargetType="{x:Type ComboBoxItem}">
-        <Setter Property="HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"/>
-        <Setter Property="VerticalContentAlignment" Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"/>
-        <Setter Property="Padding" Value="3,0,3,0"/>
-        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
+        <Setter Property="VerticalContentAlignment" Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
+        <Setter Property="Padding" Value="3,0,3,0" />
+        <Setter Property="Background" Value="Transparent" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ComboBoxItem}">
-                    <Border x:Name="Bd" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" Padding="{TemplateBinding Padding}" SnapsToDevicePixels="true">
-                        <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                    <Border
+                        x:Name="Bd"
+                        Padding="{TemplateBinding Padding}"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        SnapsToDevicePixels="true">
+                        <ContentPresenter
+                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsHighlighted" Value="true">
-                            <Setter Property="Background" TargetName="Bd" Value="{StaticResource SelectedListItem}"/>
-                            <Setter Property="Foreground" Value="Black"/>
+                            <Setter TargetName="Bd" Property="Background" Value="{StaticResource SelectedListItem}" />
+                            <Setter Property="Foreground" Value="Black" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="false">
-                            <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+                            <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -1238,57 +1370,60 @@
         </Setter>
     </Style>
 
-    <!-- Button-->
+    <!--  Button  -->
     <Style x:Key="ButtonFocusVisual">
         <Setter Property="Control.Template">
             <Setter.Value>
                 <ControlTemplate>
-                    <Rectangle Margin="2" SnapsToDevicePixels="true"
-						Stroke="{StaticResource ForegroundBrush}"
-						StrokeThickness="1"
-						StrokeDashArray="1 2"/>
+                    <Rectangle
+                        Margin="2"
+                        SnapsToDevicePixels="true"
+                        Stroke="{StaticResource ForegroundBrush}"
+                        StrokeDashArray="1 2"
+                        StrokeThickness="1" />
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
 
 
-    <Style TargetType="{x:Type Button}" x:Key="MainButtonStyle" >
-        <Setter Property="FocusVisualStyle" Value="{StaticResource ButtonFocusVisual}"/>
-        <Setter Property="Background" Value="{StaticResource ButtonBackground}"/>
-        <Setter Property="BorderBrush" Value="{StaticResource ButtonBorder}"/>
-        <Setter Property="BorderThickness" Value="1"/>
+    <Style x:Key="MainButtonStyle" TargetType="{x:Type Button}">
+        <Setter Property="FocusVisualStyle" Value="{StaticResource ButtonFocusVisual}" />
+        <Setter Property="Background" Value="{StaticResource ButtonBackground}" />
+        <Setter Property="BorderBrush" Value="{StaticResource ButtonBorder}" />
+        <Setter Property="BorderThickness" Value="1" />
         <Setter Property="Focusable" Value="False" />
-        <Setter Property="Foreground" Value="{StaticResource ButtonForeground}"/>
-        <Setter Property="HorizontalContentAlignment" Value="Center"/>
-        <Setter Property="VerticalContentAlignment" Value="Center"/>
-        <Setter Property="Padding" Value="1"/>
+        <Setter Property="Foreground" Value="{StaticResource ButtonForeground}" />
+        <Setter Property="HorizontalContentAlignment" Value="Center" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="Padding" Value="1" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Button}">
-                    <Border 
-						Background="{TemplateBinding Background}" 
-						BorderBrush="{TemplateBinding BorderBrush}"
-						BorderThickness="{TemplateBinding BorderThickness}"
-						CornerRadius="3">
-                        <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-							Margin="{TemplateBinding Padding}" 
-							RecognizesAccessKey="True" 
-							SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" 
-							VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                    <Border
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        CornerRadius="3">
+                        <ContentPresenter
+                            Margin="{TemplateBinding Padding}"
+                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                            RecognizesAccessKey="True"
+                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="true">
-                            <Setter Property="Background" Value="{StaticResource MouseOverButtonBackground}"/>
-                            <Setter Property="Foreground" Value="{StaticResource MouseOverButtonForeground}"/>
+                            <Setter Property="Background" Value="{StaticResource MouseOverButtonBackground}" />
+                            <Setter Property="Foreground" Value="{StaticResource MouseOverButtonForeground}" />
                         </Trigger>
                         <Trigger Property="IsPressed" Value="true">
-                            <Setter Property="Background" Value="{StaticResource PressedButtonBackground}"/>
-                            <Setter Property="Foreground" Value="{StaticResource ButtonForeground}"/>
+                            <Setter Property="Background" Value="{StaticResource PressedButtonBackground}" />
+                            <Setter Property="Foreground" Value="{StaticResource ButtonForeground}" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="false">
-                            <Setter Property="Foreground" Value="{StaticResource DisabledButtonForeground}"/>
-                            <Setter Property="Background" Value="{StaticResource DisabledButtonBackground}"/>
+                            <Setter Property="Foreground" Value="{StaticResource DisabledButtonForeground}" />
+                            <Setter Property="Background" Value="{StaticResource DisabledButtonBackground}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -1297,53 +1432,57 @@
     </Style>
     <Style BasedOn="{StaticResource MainButtonStyle}" TargetType="{x:Type Button}" />
 
-    <Style TargetType="ButtonBase" x:Key="CircleButtonStyle" BasedOn="{StaticResource MahApps.Metro.Styles.MetroCircleButtonStyle}" >
+    <Style
+        x:Key="CircleButtonStyle"
+        BasedOn="{StaticResource MahApps.Metro.Styles.MetroCircleButtonStyle}"
+        TargetType="ButtonBase">
         <Setter Property="Focusable" Value="False" />
     </Style>
 
-    <!-- ToggleButton-->
+    <!--  ToggleButton  -->
     <Style TargetType="{x:Type ToggleButton}">
-        <Setter Property="FocusVisualStyle" Value="{StaticResource ButtonFocusVisual}"/>
-        <Setter Property="Background" Value="{StaticResource ButtonBackground}"/>
-        <Setter Property="BorderBrush" Value="{StaticResource ButtonBorder}"/>
-        <Setter Property="BorderThickness" Value="1"></Setter>
-        <Setter Property="Foreground" Value="{StaticResource ButtonForeground}"/>
-        <Setter Property="HorizontalContentAlignment" Value="Center"/>
-        <Setter Property="VerticalContentAlignment" Value="Center"/>
-        <Setter Property="Padding" Value="1"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource ButtonFocusVisual}" />
+        <Setter Property="Background" Value="{StaticResource ButtonBackground}" />
+        <Setter Property="BorderBrush" Value="{StaticResource ButtonBorder}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="Foreground" Value="{StaticResource ButtonForeground}" />
+        <Setter Property="HorizontalContentAlignment" Value="Center" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="Padding" Value="1" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ToggleButton}">
-                    <Border  
-						BorderBrush="{TemplateBinding BorderBrush}" 
-						Background="{TemplateBinding Background}" 
+                    <Border
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}"
-						SnapsToDevicePixels="true"
-						CornerRadius="3">
-                        <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" 
-                                          Margin="{TemplateBinding Padding}" 
-                                          RecognizesAccessKey="True" 
-                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" 
-                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                        CornerRadius="3"
+                        SnapsToDevicePixels="true">
+                        <ContentPresenter
+                            Margin="{TemplateBinding Padding}"
+                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                            RecognizesAccessKey="True"
+                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                     </Border>
                     <ControlTemplate.Triggers>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
-                                <Condition Property="IsChecked" Value="false"/>
-                                <Condition Property="IsMouseOver" Value="true"/>
+                                <Condition Property="IsChecked" Value="false" />
+                                <Condition Property="IsMouseOver" Value="true" />
                             </MultiTrigger.Conditions>
                         </MultiTrigger>
                         <Trigger Property="IsMouseOver" Value="true">
-                            <Setter Property="Background" Value="{StaticResource MouseOverButtonBackground}"/>
-                            <Setter Property="Foreground" Value="{StaticResource MouseOverButtonForeground}"/>
+                            <Setter Property="Background" Value="{StaticResource MouseOverButtonBackground}" />
+                            <Setter Property="Foreground" Value="{StaticResource MouseOverButtonForeground}" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="false">
-                            <Setter Property="Foreground" Value="{StaticResource DisabledButtonForeground}"/>
-                            <Setter Property="Background" Value="{StaticResource DisabledButtonBackground}"/>
+                            <Setter Property="Foreground" Value="{StaticResource DisabledButtonForeground}" />
+                            <Setter Property="Background" Value="{StaticResource DisabledButtonBackground}" />
                         </Trigger>
                         <Trigger Property="IsChecked" Value="true">
-                            <Setter Property="Background" Value="{StaticResource PressedButtonBackground}"/>
-                            <Setter Property="Foreground" Value="{StaticResource ButtonForeground}"/>
+                            <Setter Property="Background" Value="{StaticResource PressedButtonBackground}" />
+                            <Setter Property="Foreground" Value="{StaticResource ButtonForeground}" />
                         </Trigger>
 
                     </ControlTemplate.Triggers>
@@ -1352,7 +1491,7 @@
         </Setter>
     </Style>
 
-    <!-- Expander -->
+    <!--  Expander  -->
 
 
     <Style x:Key="ExpanderRightHeaderStyle" TargetType="{x:Type ToggleButton}">
@@ -1362,33 +1501,46 @@
                     <Border Padding="{TemplateBinding Padding}">
                         <Grid Background="Transparent" SnapsToDevicePixels="False">
                             <Grid.RowDefinitions>
-                                <RowDefinition Height="19"/>
-                                <RowDefinition Height="*"/>
+                                <RowDefinition Height="19" />
+                                <RowDefinition Height="*" />
                             </Grid.RowDefinitions>
                             <Grid>
                                 <Grid.LayoutTransform>
                                     <TransformGroup>
                                         <TransformGroup.Children>
                                             <TransformCollection>
-                                                <RotateTransform Angle="-90"/>
+                                                <RotateTransform Angle="-90" />
                                             </TransformCollection>
                                         </TransformGroup.Children>
                                     </TransformGroup>
                                 </Grid.LayoutTransform>
-                                <Path x:Name="arrow" Data="{StaticResource ExpanderNormalArrow}" HorizontalAlignment="Center" SnapsToDevicePixels="false" Stroke="{StaticResource Expander.Static.Arrow.Stroke}" StrokeThickness="2" VerticalAlignment="Center"/>
+                                <Path
+                                    x:Name="arrow"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    Data="{StaticResource ExpanderNormalArrow}"
+                                    SnapsToDevicePixels="false"
+                                    Stroke="{StaticResource Expander.Static.Arrow.Stroke}"
+                                    StrokeThickness="2" />
                             </Grid>
-                            <ContentPresenter HorizontalAlignment="Center" Margin="0,4,0,0" Grid.Row="1" RecognizesAccessKey="True" SnapsToDevicePixels="True" VerticalAlignment="Top"/>
+                            <ContentPresenter
+                                Grid.Row="1"
+                                Margin="0,4,0,0"
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Top"
+                                RecognizesAccessKey="True"
+                                SnapsToDevicePixels="True" />
                         </Grid>
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsChecked" Value="true">
-                            <Setter Property="Data" TargetName="arrow" Value="{StaticResource ExpanderCheckedArrow}"/>
+                            <Setter TargetName="arrow" Property="Data" Value="{StaticResource ExpanderCheckedArrow}" />
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="true">
-                            <Setter Property="Stroke" TargetName="arrow" Value="{StaticResource Expander.MouseOver.Arrow.Stroke}"/>
+                            <Setter TargetName="arrow" Property="Stroke" Value="{StaticResource Expander.MouseOver.Arrow.Stroke}" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="false">
-                            <Setter Property="Stroke" TargetName="arrow" Value="{StaticResource Expander.Disabled.Arrow.Stroke}"/>
+                            <Setter TargetName="arrow" Property="Stroke" Value="{StaticResource Expander.Disabled.Arrow.Stroke}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -1402,33 +1554,46 @@
                     <Border Padding="{TemplateBinding Padding}">
                         <Grid Background="Transparent" SnapsToDevicePixels="False">
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="19"/>
-                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="19" />
+                                <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
                             <Grid>
                                 <Grid.LayoutTransform>
                                     <TransformGroup>
                                         <TransformGroup.Children>
                                             <TransformCollection>
-                                                <RotateTransform Angle="180"/>
+                                                <RotateTransform Angle="180" />
                                             </TransformCollection>
                                         </TransformGroup.Children>
                                     </TransformGroup>
                                 </Grid.LayoutTransform>
-                                <Path x:Name="arrow" Data="{StaticResource ExpanderNormalArrow}" HorizontalAlignment="Center" SnapsToDevicePixels="false" Stroke="{StaticResource Expander.Static.Arrow.Stroke}" StrokeThickness="2" VerticalAlignment="Center"/>
+                                <Path
+                                    x:Name="arrow"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    Data="{StaticResource ExpanderNormalArrow}"
+                                    SnapsToDevicePixels="false"
+                                    Stroke="{StaticResource Expander.Static.Arrow.Stroke}"
+                                    StrokeThickness="2" />
                             </Grid>
-                            <ContentPresenter Grid.Column="1" HorizontalAlignment="Left" Margin="4,0,0,0" RecognizesAccessKey="True" SnapsToDevicePixels="True" VerticalAlignment="Center"/>
+                            <ContentPresenter
+                                Grid.Column="1"
+                                Margin="4,0,0,0"
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Center"
+                                RecognizesAccessKey="True"
+                                SnapsToDevicePixels="True" />
                         </Grid>
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsChecked" Value="true">
-                            <Setter Property="Data" TargetName="arrow" Value="{StaticResource ExpanderCheckedArrow}"/>
+                            <Setter TargetName="arrow" Property="Data" Value="{StaticResource ExpanderCheckedArrow}" />
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="true">
-                            <Setter Property="Stroke" TargetName="arrow" Value="{StaticResource Expander.MouseOver.Arrow.Stroke}"/>
+                            <Setter TargetName="arrow" Property="Stroke" Value="{StaticResource Expander.MouseOver.Arrow.Stroke}" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="false">
-                            <Setter Property="Stroke" TargetName="arrow" Value="{StaticResource Expander.Disabled.Arrow.Stroke}"/>
+                            <Setter TargetName="arrow" Property="Stroke" Value="{StaticResource Expander.Disabled.Arrow.Stroke}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -1442,33 +1607,46 @@
                     <Border Padding="{TemplateBinding Padding}">
                         <Grid Background="Transparent" SnapsToDevicePixels="False">
                             <Grid.RowDefinitions>
-                                <RowDefinition Height="19"/>
-                                <RowDefinition Height="*"/>
+                                <RowDefinition Height="19" />
+                                <RowDefinition Height="*" />
                             </Grid.RowDefinitions>
                             <Grid>
                                 <Grid.LayoutTransform>
                                     <TransformGroup>
                                         <TransformGroup.Children>
                                             <TransformCollection>
-                                                <RotateTransform Angle="90"/>
+                                                <RotateTransform Angle="90" />
                                             </TransformCollection>
                                         </TransformGroup.Children>
                                     </TransformGroup>
                                 </Grid.LayoutTransform>
-                                <Path x:Name="arrow" Data="{StaticResource ExpanderNormalArrow}" HorizontalAlignment="Center" SnapsToDevicePixels="false" Stroke="{StaticResource Expander.Static.Arrow.Stroke}" StrokeThickness="2" VerticalAlignment="Center"/>
+                                <Path
+                                    x:Name="arrow"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    Data="{StaticResource ExpanderNormalArrow}"
+                                    SnapsToDevicePixels="false"
+                                    Stroke="{StaticResource Expander.Static.Arrow.Stroke}"
+                                    StrokeThickness="2" />
                             </Grid>
-                            <ContentPresenter HorizontalAlignment="Center" Margin="0,4,0,0" Grid.Row="1" RecognizesAccessKey="True" SnapsToDevicePixels="True" VerticalAlignment="Top"/>
+                            <ContentPresenter
+                                Grid.Row="1"
+                                Margin="0,4,0,0"
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Top"
+                                RecognizesAccessKey="True"
+                                SnapsToDevicePixels="True" />
                         </Grid>
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsChecked" Value="true">
-                            <Setter Property="Data" TargetName="arrow" Value="{StaticResource ExpanderCheckedArrow}"/>
+                            <Setter TargetName="arrow" Property="Data" Value="{StaticResource ExpanderCheckedArrow}" />
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="true">
-                            <Setter Property="Stroke" TargetName="arrow" Value="{StaticResource Expander.MouseOver.Arrow.Stroke}"/>
+                            <Setter TargetName="arrow" Property="Stroke" Value="{StaticResource Expander.MouseOver.Arrow.Stroke}" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="false">
-                            <Setter Property="Stroke" TargetName="arrow" Value="{StaticResource Expander.Disabled.Arrow.Stroke}"/>
+                            <Setter TargetName="arrow" Property="Stroke" Value="{StaticResource Expander.Disabled.Arrow.Stroke}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -1480,7 +1658,12 @@
             <Setter.Value>
                 <ControlTemplate>
                     <Border>
-                        <Rectangle Margin="0" SnapsToDevicePixels="true" Stroke="Black" StrokeThickness="1" StrokeDashArray="1 2"/>
+                        <Rectangle
+                            Margin="0"
+                            SnapsToDevicePixels="true"
+                            Stroke="Black"
+                            StrokeDashArray="1 2"
+                            StrokeThickness="1" />
                     </Border>
                 </ControlTemplate>
             </Setter.Value>
@@ -1493,22 +1676,35 @@
                     <Border Padding="{TemplateBinding Padding}">
                         <Grid Background="Transparent" SnapsToDevicePixels="False">
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="19"/>
-                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="19" />
+                                <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
-                            <Path x:Name="arrow" Data="{StaticResource ExpanderNormalArrow}" HorizontalAlignment="Center" SnapsToDevicePixels="false" Stroke="{StaticResource Expander.Static.Arrow.Stroke}" StrokeThickness="2" VerticalAlignment="Center"/>
-                            <ContentPresenter Grid.Column="1" HorizontalAlignment="Left" Margin="4,0,0,0" RecognizesAccessKey="True" SnapsToDevicePixels="True" VerticalAlignment="Center"/>
+                            <Path
+                                x:Name="arrow"
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Center"
+                                Data="{StaticResource ExpanderNormalArrow}"
+                                SnapsToDevicePixels="false"
+                                Stroke="{StaticResource Expander.Static.Arrow.Stroke}"
+                                StrokeThickness="2" />
+                            <ContentPresenter
+                                Grid.Column="1"
+                                Margin="4,0,0,0"
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Center"
+                                RecognizesAccessKey="True"
+                                SnapsToDevicePixels="True" />
                         </Grid>
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsChecked" Value="true">
-                            <Setter Property="Data" TargetName="arrow" Value="{StaticResource ExpanderCheckedArrow}"/>
+                            <Setter TargetName="arrow" Property="Data" Value="{StaticResource ExpanderCheckedArrow}" />
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="true">
-                            <Setter Property="Stroke" TargetName="arrow" Value="{StaticResource Expander.MouseOver.Arrow.Stroke}"/>
+                            <Setter TargetName="arrow" Property="Stroke" Value="{StaticResource Expander.MouseOver.Arrow.Stroke}" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="false">
-                            <Setter Property="Stroke" TargetName="arrow" Value="{StaticResource Expander.Disabled.Arrow.Stroke}"/>
+                            <Setter TargetName="arrow" Property="Stroke" Value="{StaticResource Expander.Disabled.Arrow.Stroke}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -1516,73 +1712,76 @@
         </Setter>
     </Style>
     <Style TargetType="{x:Type Expander}">
-        <Setter Property="Foreground" Value="{StaticResource Expander.MouseOver.Arrow.Stroke}"/>
-        <Setter Property="FontFamily" Value="Calibri light"/>
-        <Setter Property="Padding" Value="2"/>
-        <Setter Property="Background" Value="{StaticResource Expander.Background}"/>
-        <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
-        <Setter Property="VerticalContentAlignment" Value="Stretch"/>
-        <Setter Property="BorderBrush" Value="Transparent"/>
-        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="Foreground" Value="{StaticResource Expander.MouseOver.Arrow.Stroke}" />
+        <Setter Property="FontFamily" Value="Calibri light" />
+        <Setter Property="Padding" Value="2" />
+        <Setter Property="Background" Value="{StaticResource Expander.Background}" />
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="VerticalContentAlignment" Value="Stretch" />
+        <Setter Property="BorderBrush" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="1" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Expander}">
-                    <Border BorderBrush="{TemplateBinding BorderBrush}" 
-						BorderThickness="{TemplateBinding BorderThickness}" 
-						Background="{TemplateBinding Background}" 
-						CornerRadius="4" 
-						SnapsToDevicePixels="true">
+                    <Border
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        CornerRadius="4"
+                        SnapsToDevicePixels="true">
                         <DockPanel>
-                            <ToggleButton x:Name="HeaderSite" 
-								ContentTemplate="{TemplateBinding HeaderTemplate}" 
-								ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}" 
-								Content="{TemplateBinding Header}" 
-								DockPanel.Dock="Top" 
-								Foreground="{TemplateBinding Foreground}" 
-								FontWeight="{TemplateBinding FontWeight}" 
-								FocusVisualStyle="{StaticResource ExpanderHeaderFocusVisual}" 
-								FontStyle="{TemplateBinding FontStyle}" 
-								FontStretch="{TemplateBinding FontStretch}" 
-								FontSize="{TemplateBinding FontSize}" 
-								FontFamily="{TemplateBinding FontFamily}" 
-								HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" 
-								IsChecked="{Binding IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" 
-								Margin="5,1,1,1" 
-								MinWidth="0" 
-								MinHeight="0" 
-								Padding="{TemplateBinding Padding}" 
-								Style="{DynamicResource ExpanderToggleButtonStyle}" 
-								VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"/>
-                            <ContentPresenter x:Name="ExpandSite" 
-								DockPanel.Dock="Bottom"
-								Focusable="false" 
-								HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" 
-								Margin="{TemplateBinding Padding}" 
-								Visibility="Collapsed" 
-								VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                            <ToggleButton
+                                x:Name="HeaderSite"
+                                MinWidth="0"
+                                MinHeight="0"
+                                Margin="5,1,1,1"
+                                Padding="{TemplateBinding Padding}"
+                                HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                Content="{TemplateBinding Header}"
+                                ContentTemplate="{TemplateBinding HeaderTemplate}"
+                                ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}"
+                                DockPanel.Dock="Top"
+                                FocusVisualStyle="{StaticResource ExpanderHeaderFocusVisual}"
+                                FontFamily="{TemplateBinding FontFamily}"
+                                FontSize="{TemplateBinding FontSize}"
+                                FontStretch="{TemplateBinding FontStretch}"
+                                FontStyle="{TemplateBinding FontStyle}"
+                                FontWeight="{TemplateBinding FontWeight}"
+                                Foreground="{TemplateBinding Foreground}"
+                                IsChecked="{Binding IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
+                                Style="{DynamicResource ExpanderToggleButtonStyle}" />
+                            <ContentPresenter
+                                x:Name="ExpandSite"
+                                Margin="{TemplateBinding Padding}"
+                                HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                DockPanel.Dock="Bottom"
+                                Focusable="false"
+                                Visibility="Collapsed" />
                         </DockPanel>
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsExpanded" Value="true">
-                            <Setter Property="Visibility" TargetName="ExpandSite" Value="Visible"/>
+                            <Setter TargetName="ExpandSite" Property="Visibility" Value="Visible" />
                         </Trigger>
                         <Trigger Property="ExpandDirection" Value="Right">
-                            <Setter Property="DockPanel.Dock" TargetName="ExpandSite" Value="Right"/>
-                            <Setter Property="DockPanel.Dock" TargetName="HeaderSite" Value="Left"/>
-                            <Setter Property="Style" TargetName="HeaderSite" Value="{StaticResource ExpanderRightHeaderStyle}"/>
+                            <Setter TargetName="ExpandSite" Property="DockPanel.Dock" Value="Right" />
+                            <Setter TargetName="HeaderSite" Property="DockPanel.Dock" Value="Left" />
+                            <Setter TargetName="HeaderSite" Property="Style" Value="{StaticResource ExpanderRightHeaderStyle}" />
                         </Trigger>
                         <Trigger Property="ExpandDirection" Value="Up">
-                            <Setter Property="DockPanel.Dock" TargetName="ExpandSite" Value="Top"/>
-                            <Setter Property="DockPanel.Dock" TargetName="HeaderSite" Value="Bottom"/>
-                            <Setter Property="Style" TargetName="HeaderSite" Value="{StaticResource ExpanderUpHeaderStyle}"/>
+                            <Setter TargetName="ExpandSite" Property="DockPanel.Dock" Value="Top" />
+                            <Setter TargetName="HeaderSite" Property="DockPanel.Dock" Value="Bottom" />
+                            <Setter TargetName="HeaderSite" Property="Style" Value="{StaticResource ExpanderUpHeaderStyle}" />
                         </Trigger>
                         <Trigger Property="ExpandDirection" Value="Left">
-                            <Setter Property="DockPanel.Dock" TargetName="ExpandSite" Value="Left"/>
-                            <Setter Property="DockPanel.Dock" TargetName="HeaderSite" Value="Right"/>
-                            <Setter Property="Style" TargetName="HeaderSite" Value="{StaticResource ExpanderLeftHeaderStyle}"/>
+                            <Setter TargetName="ExpandSite" Property="DockPanel.Dock" Value="Left" />
+                            <Setter TargetName="HeaderSite" Property="DockPanel.Dock" Value="Right" />
+                            <Setter TargetName="HeaderSite" Property="Style" Value="{StaticResource ExpanderLeftHeaderStyle}" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="false">
-                            <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+                            <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -1596,85 +1795,88 @@
                     <Border Padding="{TemplateBinding Padding}">
                         <Grid Background="Transparent" SnapsToDevicePixels="False">
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="8"/>
-                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="8" />
+                                <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
-                            <Path x:Name="arrow"
-								Grid.ColumnSpan="2" 
-								HorizontalAlignment="Left" 
-								Fill="{StaticResource Expander.Static.Arrow.Stroke}" 
-								Stroke="{StaticResource Expander.Static.Arrow.Stroke}" 
-								StrokeThickness="1" 
-								VerticalAlignment="Top" 
-								Data="{StaticResource ExpanderToggleButtonArrow}" 
-								Height="4.5" 
-								Stretch="Fill" 
-								Width="8" 
-								RenderTransformOrigin="0.5,0.5" 
-								Margin="2.068,6.27,0,0">
+                            <Path
+                                x:Name="arrow"
+                                Grid.ColumnSpan="2"
+                                Width="8"
+                                Height="4.5"
+                                Margin="2.068,6.27,0,0"
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Top"
+                                Data="{StaticResource ExpanderToggleButtonArrow}"
+                                Fill="{StaticResource Expander.Static.Arrow.Stroke}"
+                                RenderTransformOrigin="0.5,0.5"
+                                Stretch="Fill"
+                                Stroke="{StaticResource Expander.Static.Arrow.Stroke}"
+                                StrokeThickness="1">
                                 <Path.RenderTransform>
                                     <TransformGroup>
-                                        <RotateTransform Angle="135"/>
-                                        <TranslateTransform X="0.17819090885901012" Y="0.43019090885900946"/>
+                                        <RotateTransform Angle="135" />
+                                        <TranslateTransform X="0.17819090885901012" Y="0.43019090885900946" />
                                     </TransformGroup>
                                 </Path.RenderTransform>
                             </Path>
-                            <ContentPresenter Grid.Column="1" 
-								HorizontalAlignment="Left" 
-								Margin="4,0,0,0" 
-								RecognizesAccessKey="True" 
-								SnapsToDevicePixels="True" 
-								VerticalAlignment="Center"/>
+                            <ContentPresenter
+                                Grid.Column="1"
+                                Margin="4,0,0,0"
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Center"
+                                RecognizesAccessKey="True"
+                                SnapsToDevicePixels="True" />
                         </Grid>
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsChecked" Value="false">
-                            <Setter Property="Margin" TargetName="arrow" Value="-0.526,4.842,0,0"></Setter>
-                            <Setter Property="RenderTransform" TargetName="arrow">
+                            <Setter TargetName="arrow" Property="Margin" Value="-0.526,4.842,0,0" />
+                            <Setter TargetName="arrow" Property="RenderTransform">
                                 <Setter.Value>
                                     <TransformGroup>
-                                        <RotateTransform Angle="90"/>
-                                        <TranslateTransform X="0.17819090885901012" Y="0.43019090885900946"/>
+                                        <RotateTransform Angle="90" />
+                                        <TranslateTransform X="0.17819090885901012" Y="0.43019090885900946" />
                                     </TransformGroup>
                                 </Setter.Value>
                             </Setter>
-                            <Setter Property="Fill" TargetName="arrow" Value="Transparent"/>
+                            <Setter TargetName="arrow" Property="Fill" Value="Transparent" />
                         </Trigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
-                                <Condition Property="IsMouseOver" Value="true"/>
-                                <Condition Property="IsChecked" Value="true"/>
+                                <Condition Property="IsMouseOver" Value="true" />
+                                <Condition Property="IsChecked" Value="true" />
                             </MultiTrigger.Conditions>
-                            <Setter Property="Fill" TargetName="arrow" Value="{StaticResource Expander.MouseOver.Arrow.Stroke}"/>
-                            <Setter Property="Stroke" TargetName="arrow" Value="{StaticResource Expander.MouseOver.Arrow.Stroke}"/>
+                            <Setter TargetName="arrow" Property="Fill" Value="{StaticResource Expander.MouseOver.Arrow.Stroke}" />
+                            <Setter TargetName="arrow" Property="Stroke" Value="{StaticResource Expander.MouseOver.Arrow.Stroke}" />
                         </MultiTrigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
-                                <Condition Property="IsMouseOver" Value="true"/>
-                                <Condition Property="IsChecked" Value="false"/>
+                                <Condition Property="IsMouseOver" Value="true" />
+                                <Condition Property="IsChecked" Value="false" />
                             </MultiTrigger.Conditions>
-                            <Setter Property="Fill" TargetName="arrow" Value="Transparent"/>
-                            <Setter Property="Stroke" TargetName="arrow" Value="{StaticResource Expander.MouseOver.Arrow.Stroke}"/>
+                            <Setter TargetName="arrow" Property="Fill" Value="Transparent" />
+                            <Setter TargetName="arrow" Property="Stroke" Value="{StaticResource Expander.MouseOver.Arrow.Stroke}" />
                         </MultiTrigger>
-                        <Trigger Property="IsEnabled" Value="false"/>
+                        <Trigger Property="IsEnabled" Value="false" />
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
 
-    <!-- CheckBox-->
+    <!--  CheckBox  -->
 
 
     <Style x:Key="EmptyCheckBoxFocusVisual">
         <Setter Property="Control.Template">
             <Setter.Value>
                 <ControlTemplate>
-                    <Rectangle Margin="1" 
-									SnapsToDevicePixels="true" 
-									Stroke="{StaticResource CheckBoxStroke}" 
-									StrokeThickness="1" 
-									StrokeDashArray="1 2"/>
+                    <Rectangle
+                        Margin="1"
+                        SnapsToDevicePixels="true"
+                        Stroke="{StaticResource CheckBoxStroke}"
+                        StrokeDashArray="1 2"
+                        StrokeThickness="1" />
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
@@ -1683,60 +1885,64 @@
         <Setter Property="Control.Template">
             <Setter.Value>
                 <ControlTemplate>
-                    <Rectangle Margin="14,0,0,0"
-									SnapsToDevicePixels="true" 
-									Stroke="{StaticResource CheckBoxStroke}" 
-									StrokeThickness="1" 
-									StrokeDashArray="1 2"/>
+                    <Rectangle
+                        Margin="14,0,0,0"
+                        SnapsToDevicePixels="true"
+                        Stroke="{StaticResource CheckBoxStroke}"
+                        StrokeDashArray="1 2"
+                        StrokeThickness="1" />
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
     <Style TargetType="{x:Type CheckBox}">
-        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}"></Setter>
-        <Setter Property="Background" Value="{StaticResource CheckBoxFillNormal}"/>
-        <Setter Property="BorderBrush" Value="{StaticResource CheckBoxStroke}"/>
-        <Setter Property="FocusVisualStyle" Value="{StaticResource EmptyCheckBoxFocusVisual}"/>
+        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}" />
+        <Setter Property="Background" Value="{StaticResource CheckBoxFillNormal}" />
+        <Setter Property="BorderBrush" Value="{StaticResource CheckBoxStroke}" />
+        <Setter Property="FocusVisualStyle" Value="{StaticResource EmptyCheckBoxFocusVisual}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type CheckBox}">
                     <BulletDecorator Background="Transparent" SnapsToDevicePixels="true">
                         <BulletDecorator.Bullet>
-                            <Border x:Name="CheckBoxBorder"
-                                        Height="12"
-										Width="12"
-										BorderBrush="{TemplateBinding BorderBrush}" 
-										BorderThickness="1"
-										Background="{TemplateBinding Background}">
-                                <Path x:Name="CheckMark"  
-                                            Data="{StaticResource CheckBoxCheckmark}" 
-											Height="Auto" 
-											Width="Auto" 
-											Stretch="Fill" 
-											Fill="{StaticResource ButtonForeground}"
-											Margin="1,1.007,1,1"/>
+                            <Border
+                                x:Name="CheckBoxBorder"
+                                Width="12"
+                                Height="12"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="1">
+                                <Path
+                                    x:Name="CheckMark"
+                                    Width="Auto"
+                                    Height="Auto"
+                                    Margin="1,1.007,1,1"
+                                    Data="{StaticResource CheckBoxCheckmark}"
+                                    Fill="{StaticResource ButtonForeground}"
+                                    Stretch="Fill" />
                             </Border>
                         </BulletDecorator.Bullet>
-                        <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-												Margin="{TemplateBinding Padding}" 
-												RecognizesAccessKey="True" 
-												SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" 
-												VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                        <ContentPresenter
+                            Margin="{TemplateBinding Padding}"
+                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                            RecognizesAccessKey="True"
+                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                     </BulletDecorator>
                     <ControlTemplate.Triggers>
                         <Trigger Property="HasContent" Value="true">
-                            <Setter Property="FocusVisualStyle" Value="{StaticResource CheckRadioFocusVisual}"/>
-                            <Setter Property="Padding" Value="4,0,0,0"/>
+                            <Setter Property="FocusVisualStyle" Value="{StaticResource CheckRadioFocusVisual}" />
+                            <Setter Property="Padding" Value="4,0,0,0" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="false">
-                            <Setter Property="Foreground" Value="{StaticResource CheckBoxDisabledForeground}"/>
-                            <Setter Property="BorderBrush" TargetName="CheckBoxBorder" Value="{StaticResource CheckBoxDisabledStroke}"/>
+                            <Setter Property="Foreground" Value="{StaticResource CheckBoxDisabledForeground}" />
+                            <Setter TargetName="CheckBoxBorder" Property="BorderBrush" Value="{StaticResource CheckBoxDisabledStroke}" />
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter Property="BorderBrush" TargetName="CheckBoxBorder" Value="{StaticResource CheckBoxMouseOverStroke}"/>
+                            <Setter TargetName="CheckBoxBorder" Property="BorderBrush" Value="{StaticResource CheckBoxMouseOverStroke}" />
                         </Trigger>
                         <Trigger Property="IsChecked" Value="false">
-                            <Setter TargetName="CheckMark" Property="Visibility" Value="Collapsed"/>
+                            <Setter TargetName="CheckMark" Property="Visibility" Value="Collapsed" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -1744,66 +1950,70 @@
         </Setter>
     </Style>
 
-    <!-- RadioButton -->
+    <!--  RadioButton  -->
 
 
     <Style x:Key="RadioFocusVisual">
         <Setter Property="Control.Template">
             <Setter.Value>
                 <ControlTemplate>
-                    <Rectangle Margin="14,0,0,0" 
-									SnapsToDevicePixels="true" 
-									Stroke="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" 
-									StrokeThickness="1" 
-									StrokeDashArray="1 2"/>
+                    <Rectangle
+                        Margin="14,0,0,0"
+                        SnapsToDevicePixels="true"
+                        Stroke="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
+                        StrokeDashArray="1 2"
+                        StrokeThickness="1" />
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
     <Style TargetType="{x:Type RadioButton}">
-        <Setter Property="Foreground" Value="{StaticResource RadioButtonForeground}"/>
-        <Setter Property="Background" Value="{StaticResource RadioButtonBackground}"/>
-        <Setter Property="BorderBrush" Value="{StaticResource RadioButtonStroke}"/>
-        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="Foreground" Value="{StaticResource RadioButtonForeground}" />
+        <Setter Property="Background" Value="{StaticResource RadioButtonBackground}" />
+        <Setter Property="BorderBrush" Value="{StaticResource RadioButtonStroke}" />
+        <Setter Property="BorderThickness" Value="1" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type RadioButton}">
                     <BulletDecorator Background="Transparent">
                         <BulletDecorator.Bullet>
-                            <Border x:Name="RadioButtonBorder"
-                                        Width="12"
-										Height="12"
-										CornerRadius="6" 
-										BorderThickness="{TemplateBinding BorderThickness}"
-										BorderBrush="{TemplateBinding BorderBrush}" 
-										Background="{TemplateBinding Background}">
-                                <Border x:Name="RadioMark" 
-                                            Width="6"
-										    Height="6"
-										    CornerRadius="6"
-										    BorderBrush="{StaticResource RadioButtonForeground}" 
-										    Background="{StaticResource RadioButtonForeground}"/>
+                            <Border
+                                x:Name="RadioButtonBorder"
+                                Width="12"
+                                Height="12"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="6">
+                                <Border
+                                    x:Name="RadioMark"
+                                    Width="6"
+                                    Height="6"
+                                    Background="{StaticResource RadioButtonForeground}"
+                                    BorderBrush="{StaticResource RadioButtonForeground}"
+                                    CornerRadius="6" />
                             </Border>
                         </BulletDecorator.Bullet>
-                        <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-												Margin="{TemplateBinding Padding}" 
-												RecognizesAccessKey="True" 
-												VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                        <ContentPresenter
+                            Margin="{TemplateBinding Padding}"
+                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                            RecognizesAccessKey="True" />
                     </BulletDecorator>
                     <ControlTemplate.Triggers>
                         <Trigger Property="HasContent" Value="true">
-                            <Setter Property="FocusVisualStyle" Value="{StaticResource RadioFocusVisual}"/>
-                            <Setter Property="Padding" Value="4,0,0,0"/>
+                            <Setter Property="FocusVisualStyle" Value="{StaticResource RadioFocusVisual}" />
+                            <Setter Property="Padding" Value="4,0,0,0" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="false">
-                            <Setter Property="Foreground" Value="{StaticResource RadioButtonDisabledForeground}"/>
-                            <Setter Property="BorderBrush" TargetName="RadioButtonBorder" Value="{StaticResource RadioButtonDisabledStroke}"/>
+                            <Setter Property="Foreground" Value="{StaticResource RadioButtonDisabledForeground}" />
+                            <Setter TargetName="RadioButtonBorder" Property="BorderBrush" Value="{StaticResource RadioButtonDisabledStroke}" />
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter Property="BorderBrush" TargetName="RadioButtonBorder" Value="{StaticResource RadioButtonMouseOverStroke}"/>
+                            <Setter TargetName="RadioButtonBorder" Property="BorderBrush" Value="{StaticResource RadioButtonMouseOverStroke}" />
                         </Trigger>
                         <Trigger Property="IsChecked" Value="false">
-                            <Setter TargetName="RadioMark" Property="Visibility" Value="Collapsed"/>
+                            <Setter TargetName="RadioMark" Property="Visibility" Value="Collapsed" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -1811,37 +2021,38 @@
         </Setter>
     </Style>
 
-    <!-- ListView -->
+    <!--  ListView  -->
     <Style TargetType="{x:Type ListView}">
-        <Setter Property="Background" Value="{StaticResource ListBackground}"/>
-        <Setter Property="BorderBrush" Value="{StaticResource ListBorder}"/>
-        <Setter Property="BorderThickness" Value="1"/>
-        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto"/>
-        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto"/>
-        <Setter Property="ScrollViewer.CanContentScroll" Value="true"/>
-        <Setter Property="ScrollViewer.PanningMode" Value="Both"/>
-        <Setter Property="Stylus.IsFlicksEnabled" Value="False"/>
-        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="Background" Value="{StaticResource ListBackground}" />
+        <Setter Property="BorderBrush" Value="{StaticResource ListBorder}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />
+        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
+        <Setter Property="ScrollViewer.CanContentScroll" Value="true" />
+        <Setter Property="ScrollViewer.PanningMode" Value="Both" />
+        <Setter Property="Stylus.IsFlicksEnabled" Value="False" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ListView}">
-                    <Border x:Name="Bd"
-								BorderBrush="{TemplateBinding BorderBrush}" 
-								BorderThickness="{TemplateBinding BorderThickness}" 
-								Background="{TemplateBinding Background}" 
-								Padding="1" 
-								SnapsToDevicePixels="true">
-                        <ScrollViewer Focusable="false" Padding="{TemplateBinding Padding}">
-                            <ItemsPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                    <Border
+                        x:Name="Bd"
+                        Padding="1"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        SnapsToDevicePixels="true">
+                        <ScrollViewer Padding="{TemplateBinding Padding}" Focusable="false">
+                            <ItemsPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         </ScrollViewer>
                     </Border>
                     <ControlTemplate.Triggers>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
-                                <Condition Property="IsGrouping" Value="true"/>
+                                <Condition Property="IsGrouping" Value="true" />
                                 <!--<Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false"/>-->
                             </MultiTrigger.Conditions>
-                            <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
+                            <Setter Property="ScrollViewer.CanContentScroll" Value="false" />
                         </MultiTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -1849,27 +2060,30 @@
         </Setter>
     </Style>
     <Style TargetType="{x:Type ListViewItem}">
-        <Setter Property="Background" Value="Transparent"/>
-        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}"/>
-        <Setter Property="HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"/>
-        <Setter Property="VerticalContentAlignment" Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"/>
-        <Setter Property="Padding" Value="2,0,0,0"/>
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}" />
+        <Setter Property="HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
+        <Setter Property="VerticalContentAlignment" Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
+        <Setter Property="Padding" Value="2,0,0,0" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ListViewItem}">
-                    <Border x:Name="Bd" BorderBrush="{TemplateBinding BorderBrush}"
-								BorderThickness="{TemplateBinding BorderThickness}" 
-								Background="{TemplateBinding Background}" 
-								Padding="{TemplateBinding Padding}" 
-								SnapsToDevicePixels="true">
-                        <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" 
-												SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" 
-												VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                    <Border
+                        x:Name="Bd"
+                        Padding="{TemplateBinding Padding}"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        SnapsToDevicePixels="true">
+                        <ContentPresenter
+                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsSelected" Value="true">
-                            <Setter Property="Background" TargetName="Bd" Value="{StaticResource SelectedListItem}"/>
-                            <Setter Property="Foreground" Value="{StaticResource SelectedListItemForeground}"/>
+                            <Setter TargetName="Bd" Property="Background" Value="{StaticResource SelectedListItem}" />
+                            <Setter Property="Foreground" Value="{StaticResource SelectedListItemForeground}" />
                         </Trigger>
                         <!--<MultiTrigger>
 								<MultiTrigger.Conditions>
@@ -1880,14 +2094,14 @@
 								<Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.InactiveSelectionHighlightTextBrushKey}}"/>
 							</MultiTrigger>-->
                         <Trigger Property="IsEnabled" Value="false">
-                            <Setter Property="Foreground" Value="{StaticResource DisabledMenuForeground}"/>
+                            <Setter Property="Foreground" Value="{StaticResource DisabledMenuForeground}" />
                         </Trigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
-                                <Condition Property="IsMouseOver" Value="true"/>
-                                <Condition Property="IsSelected" Value="false"/>
+                                <Condition Property="IsMouseOver" Value="true" />
+                                <Condition Property="IsSelected" Value="false" />
                             </MultiTrigger.Conditions>
-                            <Setter Property="Background" TargetName="Bd" Value="{StaticResource MouseOverListItem}"/>
+                            <Setter TargetName="Bd" Property="Background" Value="{StaticResource MouseOverListItem}" />
                         </MultiTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -1895,30 +2109,32 @@
         </Setter>
     </Style>
 
-    <!-- Label -->
+    <!--  Label  -->
 
     <Style TargetType="{x:Type Label}">
-        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}"/>
-        <Setter Property="Background" Value="Transparent"/>
-        <Setter Property="Padding" Value="5"/>
-        <Setter Property="HorizontalContentAlignment" Value="Left"/>
-        <Setter Property="VerticalContentAlignment" Value="Top"/>
+        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="Padding" Value="5" />
+        <Setter Property="HorizontalContentAlignment" Value="Left" />
+        <Setter Property="VerticalContentAlignment" Value="Top" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Label}">
-                    <Border BorderBrush="{TemplateBinding BorderBrush}" 
-                            BorderThickness="{TemplateBinding BorderThickness}" 
-                            Background="{TemplateBinding Background}" 
-                            Padding="{TemplateBinding Padding}" 
-                            SnapsToDevicePixels="true">
-                        <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                          RecognizesAccessKey="True" 
-                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" 
-                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                    <Border
+                        Padding="{TemplateBinding Padding}"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        SnapsToDevicePixels="true">
+                        <ContentPresenter
+                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                            RecognizesAccessKey="True"
+                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsEnabled" Value="false">
-                            <Setter Property="Foreground" Value="{StaticResource DisabledButtonForeground}"/>
+                            <Setter Property="Foreground" Value="{StaticResource DisabledButtonForeground}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -1926,34 +2142,36 @@
         </Setter>
     </Style>
 
-    <!-- TreeView -->
+    <!--  TreeView  -->
 
     <Style TargetType="{x:Type TreeView}">
-        <Setter Property="Background" Value="{StaticResource TreeViewBackground}"/>
-        <Setter Property="Padding" Value="1"/>
-        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}"/>
-        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto"/>
-        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto"/>
-        <Setter Property="ScrollViewer.PanningMode" Value="Both"/>
-        <Setter Property="Stylus.IsFlicksEnabled" Value="False"/>
-        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="Background" Value="{StaticResource TreeViewBackground}" />
+        <Setter Property="Padding" Value="1" />
+        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}" />
+        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />
+        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
+        <Setter Property="ScrollViewer.PanningMode" Value="Both" />
+        <Setter Property="Stylus.IsFlicksEnabled" Value="False" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type TreeView}">
                     <Border x:Name="Bd" SnapsToDevicePixels="true">
-                        <ScrollViewer x:Name="_tv_scrollviewer_" 
-                                          Background="{TemplateBinding Background}"
-                                          CanContentScroll="false" Focusable="false" 
-                                          HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" 
-                                          Padding="{TemplateBinding Padding}" 
-                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" 
-                                          VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
-                            <ItemsPresenter/>
+                        <ScrollViewer
+                            x:Name="_tv_scrollviewer_"
+                            Padding="{TemplateBinding Padding}"
+                            Background="{TemplateBinding Background}"
+                            CanContentScroll="false"
+                            Focusable="false"
+                            HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                            VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
+                            <ItemsPresenter />
                         </ScrollViewer>
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsEnabled" Value="false">
-                            <Setter Property="Foreground" Value="{StaticResource TreeViewDisabledForeground}"/>
+                            <Setter Property="Foreground" Value="{StaticResource TreeViewDisabledForeground}" />
                         </Trigger>
                         <!--<Trigger Property="VirtualizingPanel.IsVirtualizing" Value="true">
     							<Setter Property="CanContentScroll" TargetName="_tv_scrollviewer_" Value="true"/>
@@ -1978,82 +2196,83 @@
         <Setter Property="Control.Template">
             <Setter.Value>
                 <ControlTemplate>
-                    <Rectangle/>
+                    <Rectangle />
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
     <Style TargetType="{x:Type TreeViewItem}">
-        <Setter Property="Background" Value="Transparent"/>
-		<Setter Property="MinHeight" Value="21"/>
-        <Setter Property="HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"/>
-        <Setter Property="VerticalContentAlignment" Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"/>
-        <Setter Property="Padding" Value="2,4,2,3"/>
-        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}"/>
-        <Setter Property="FocusVisualStyle" Value="{StaticResource TreeViewItemFocusVisual}"/>
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="MinHeight" Value="21" />
+        <Setter Property="HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
+        <Setter Property="VerticalContentAlignment" Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
+        <Setter Property="Padding" Value="2,4,2,3" />
+        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}" />
+        <Setter Property="FocusVisualStyle" Value="{StaticResource TreeViewItemFocusVisual}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type TreeViewItem}">
                     <ControlTemplate.Resources>
-                        <darkBlendTheme:LeftMarginMultiplierConverter Length="15" x:Key="LengthConverter" />
+                        <darkBlendTheme:LeftMarginMultiplierConverter x:Key="LengthConverter" Length="15" />
                     </ControlTemplate.Resources>
                     <StackPanel>
-                        <Border Name="Bd"
-                                      Background="{TemplateBinding Background}"
-                                      Padding="{TemplateBinding Padding}">
-                            <Grid Margin="{Binding Converter={StaticResource LengthConverter},
-                                         RelativeSource={RelativeSource TemplatedParent}}">
+                        <Border
+                            Name="Bd"
+                            Padding="{TemplateBinding Padding}"
+                            Background="{TemplateBinding Background}">
+                            <Grid Margin="{Binding Converter={StaticResource LengthConverter}, RelativeSource={RelativeSource TemplatedParent}}">
                                 <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="15"/>
+                                    <ColumnDefinition Width="15" />
                                     <ColumnDefinition />
                                 </Grid.ColumnDefinitions>
-                                <ToggleButton x:Name="Expander" 
-                                              Grid.Column="0"
-                                              Style="{DynamicResource TreeViewToggleButtonStyle}"
-                                              IsChecked="{Binding Path=IsExpanded,
-                                    RelativeSource={RelativeSource TemplatedParent}}"
-                                              ClickMode="Press"/>
+                                <ToggleButton
+                                    x:Name="Expander"
+                                    Grid.Column="0"
+                                    ClickMode="Press"
+                                    IsChecked="{Binding Path=IsExpanded, RelativeSource={RelativeSource TemplatedParent}}"
+                                    Style="{DynamicResource TreeViewToggleButtonStyle}" />
 
-                                <ContentPresenter x:Name="PART_Header" 
-                                                  Grid.Column="1"
-                                                  ContentSource="Header"
-                                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"/>
+                                <ContentPresenter
+                                    x:Name="PART_Header"
+                                    Grid.Column="1"
+                                    HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                    ContentSource="Header" />
                             </Grid>
                         </Border>
-                        <ItemsPresenter x:Name="ItemsHost"/>
+                        <ItemsPresenter x:Name="ItemsHost" />
                     </StackPanel>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsExpanded" Value="false">
-                            <Setter TargetName="ItemsHost" Property="Visibility" Value="Collapsed"/>
+                            <Setter TargetName="ItemsHost" Property="Visibility" Value="Collapsed" />
                         </Trigger>
                         <Trigger Property="HasItems" Value="false">
-                            <Setter TargetName="Expander" Property="Visibility" Value="Hidden"/>
+                            <Setter TargetName="Expander" Property="Visibility" Value="Hidden" />
                         </Trigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
-                                <Condition Property="HasHeader" Value="false"/>
-                                <Condition Property="Width" Value="Auto"/>
+                                <Condition Property="HasHeader" Value="false" />
+                                <Condition Property="Width" Value="Auto" />
                             </MultiTrigger.Conditions>
-                            
+
                         </MultiTrigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
-                                <Condition Property="HasHeader" Value="false"/>
-                                <Condition Property="Height" Value="Auto"/>
+                                <Condition Property="HasHeader" Value="false" />
+                                <Condition Property="Height" Value="Auto" />
                             </MultiTrigger.Conditions>
-                            <Setter TargetName="PART_Header" Property="MinHeight" Value="21"/>
+                            <Setter TargetName="PART_Header" Property="MinHeight" Value="21" />
                         </MultiTrigger>
                         <Trigger Property="IsSelected" Value="true">
-                            <Setter TargetName="Bd" Property="Background" Value="{StaticResource SelectedListItem}"/>
-                            <Setter Property="Foreground" Value="{StaticResource SelectedListItemForeground}"/>
-                            <Setter Property="Style" TargetName="Expander" Value="{DynamicResource TreeViewSelectedToggleButtonStyle}"/>
+                            <Setter TargetName="Bd" Property="Background" Value="{StaticResource SelectedListItem}" />
+                            <Setter Property="Foreground" Value="{StaticResource SelectedListItemForeground}" />
+                            <Setter TargetName="Expander" Property="Style" Value="{DynamicResource TreeViewSelectedToggleButtonStyle}" />
                         </Trigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
-                                <Condition Property="IsMouseOver" SourceName="Bd" Value="true"/>
-                                <Condition Property="IsSelected" Value="false"/>
+                                <Condition SourceName="Bd" Property="IsMouseOver" Value="true" />
+                                <Condition Property="IsSelected" Value="false" />
                             </MultiTrigger.Conditions>
-                            <Setter Property="Background" TargetName="Bd" Value="{StaticResource MouseOverListItem}"/>
+                            <Setter TargetName="Bd" Property="Background" Value="{StaticResource MouseOverListItem}" />
                         </MultiTrigger>
                         <!--<MultiTrigger>
                             <MultiTrigger.Conditions>
@@ -2064,7 +2283,7 @@
                             <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
                         </MultiTrigger>-->
                         <Trigger Property="IsEnabled" Value="false">
-                            <Setter Property="Foreground" Value="{StaticResource TreeViewDisabledForeground}"/>
+                            <Setter Property="Foreground" Value="{StaticResource TreeViewDisabledForeground}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -2072,75 +2291,77 @@
         </Setter>
     </Style>
     <Style x:Key="TreeViewToggleButtonStyle" TargetType="{x:Type ToggleButton}">
-        <Setter Property="Focusable" Value="False"/>
+        <Setter Property="Focusable" Value="False" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ToggleButton}">
                     <Border Padding="{TemplateBinding Padding}">
                         <Grid Background="Transparent" SnapsToDevicePixels="False">
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="8"/>
-                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="8" />
+                                <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
-                            <Path x:Name="arrow"
-								Grid.ColumnSpan="2" 
-								HorizontalAlignment="Left" 
-								Fill="{StaticResource Expander.Static.Arrow.Stroke}" 
-								Stroke="{StaticResource Expander.Static.Arrow.Stroke}" 
-								StrokeThickness="1" 
-								VerticalAlignment="Top" 
-								Data="{StaticResource ExpanderToggleButtonArrow}" 
-								Height="4.5" 
-								Stretch="Fill" 
-								Width="8" 
-								RenderTransformOrigin="0.5,0.5" 
-								Margin="2.068,6.27,0,0">
+                            <Path
+                                x:Name="arrow"
+                                Grid.ColumnSpan="2"
+                                Width="8"
+                                Height="4.5"
+                                Margin="2.068,6.27,0,0"
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Top"
+                                Data="{StaticResource ExpanderToggleButtonArrow}"
+                                Fill="{StaticResource Expander.Static.Arrow.Stroke}"
+                                RenderTransformOrigin="0.5,0.5"
+                                Stretch="Fill"
+                                Stroke="{StaticResource Expander.Static.Arrow.Stroke}"
+                                StrokeThickness="1">
                                 <Path.RenderTransform>
                                     <TransformGroup>
-                                        <RotateTransform Angle="135"/>
-                                        <TranslateTransform X="0.17819090885901012" Y="0.43019090885900946"/>
+                                        <RotateTransform Angle="135" />
+                                        <TranslateTransform X="0.17819090885901012" Y="0.43019090885900946" />
                                     </TransformGroup>
                                 </Path.RenderTransform>
                             </Path>
-                            <ContentPresenter Grid.Column="1" 
-								HorizontalAlignment="Left" 
-								Margin="4,0,0,0" 
-								RecognizesAccessKey="True" 
-								SnapsToDevicePixels="True" 
-								VerticalAlignment="Center"/>
+                            <ContentPresenter
+                                Grid.Column="1"
+                                Margin="4,0,0,0"
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Center"
+                                RecognizesAccessKey="True"
+                                SnapsToDevicePixels="True" />
                         </Grid>
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsChecked" Value="false">
-                            <Setter Property="Margin" TargetName="arrow" Value="-0.526,4.842,0,0"></Setter>
-                            <Setter Property="RenderTransform" TargetName="arrow">
+                            <Setter TargetName="arrow" Property="Margin" Value="-0.526,4.842,0,0" />
+                            <Setter TargetName="arrow" Property="RenderTransform">
                                 <Setter.Value>
                                     <TransformGroup>
-                                        <RotateTransform Angle="90"/>
-                                        <TranslateTransform X="0.17819090885901012" Y="0.43019090885900946"/>
+                                        <RotateTransform Angle="90" />
+                                        <TranslateTransform X="0.17819090885901012" Y="0.43019090885900946" />
                                     </TransformGroup>
                                 </Setter.Value>
                             </Setter>
-                            <Setter Property="Fill" TargetName="arrow" Value="Transparent"/>
+                            <Setter TargetName="arrow" Property="Fill" Value="Transparent" />
                         </Trigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
-                                <Condition Property="IsMouseOver" Value="true"/>
-                                <Condition Property="IsChecked" Value="true"/>
+                                <Condition Property="IsMouseOver" Value="true" />
+                                <Condition Property="IsChecked" Value="true" />
                             </MultiTrigger.Conditions>
-                            <Setter Property="Fill" TargetName="arrow" Value="{StaticResource Expander.MouseOver.Arrow.Stroke}"/>
-                            <Setter Property="Stroke" TargetName="arrow" Value="{StaticResource Expander.MouseOver.Arrow.Stroke}"/>
+                            <Setter TargetName="arrow" Property="Fill" Value="{StaticResource Expander.MouseOver.Arrow.Stroke}" />
+                            <Setter TargetName="arrow" Property="Stroke" Value="{StaticResource Expander.MouseOver.Arrow.Stroke}" />
                         </MultiTrigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
-                                <Condition Property="IsMouseOver" Value="true"/>
-                                <Condition Property="IsChecked" Value="false"/>
+                                <Condition Property="IsMouseOver" Value="true" />
+                                <Condition Property="IsChecked" Value="false" />
                             </MultiTrigger.Conditions>
-                            <Setter Property="Fill" TargetName="arrow" Value="Transparent"/>
-                            <Setter Property="Stroke" TargetName="arrow" Value="{StaticResource Expander.MouseOver.Arrow.Stroke}"/>
+                            <Setter TargetName="arrow" Property="Fill" Value="Transparent" />
+                            <Setter TargetName="arrow" Property="Stroke" Value="{StaticResource Expander.MouseOver.Arrow.Stroke}" />
                         </MultiTrigger>
                         <Trigger Property="IsEnabled" Value="false">
-                            <Setter Property="Stroke" TargetName="arrow" Value="{StaticResource Expander.Disabled.Arrow.Stroke}"/>
+                            <Setter TargetName="arrow" Property="Stroke" Value="{StaticResource Expander.Disabled.Arrow.Stroke}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -2148,131 +2369,142 @@
         </Setter>
     </Style>
     <Style x:Key="TreeViewSelectedToggleButtonStyle" TargetType="{x:Type ToggleButton}">
-        <Setter Property="Focusable" Value="False"/>
+        <Setter Property="Focusable" Value="False" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ToggleButton}">
                     <Border Padding="{TemplateBinding Padding}">
                         <Grid Background="Transparent" SnapsToDevicePixels="False">
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="8"/>
-                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="8" />
+                                <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
-                            <Path x:Name="arrow"
-								Grid.ColumnSpan="2" 
-								HorizontalAlignment="Left" 
-								Fill="{StaticResource TreeViewBackground}" 
-								Stroke="{StaticResource TreeViewBackground}" 
-								StrokeThickness="1" 
-								VerticalAlignment="Top" 
-								Data="{StaticResource ExpanderToggleButtonArrow}" 
-								Height="4.5" 
-								Stretch="Fill" 
-								Width="8" 
-								RenderTransformOrigin="0.5,0.5" 
-								Margin="2.068,6.27,0,0">
+                            <Path
+                                x:Name="arrow"
+                                Grid.ColumnSpan="2"
+                                Width="8"
+                                Height="4.5"
+                                Margin="2.068,6.27,0,0"
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Top"
+                                Data="{StaticResource ExpanderToggleButtonArrow}"
+                                Fill="{StaticResource TreeViewBackground}"
+                                RenderTransformOrigin="0.5,0.5"
+                                Stretch="Fill"
+                                Stroke="{StaticResource TreeViewBackground}"
+                                StrokeThickness="1">
                                 <Path.RenderTransform>
                                     <TransformGroup>
-                                        <RotateTransform Angle="135"/>
-                                        <TranslateTransform X="0.17819090885901012" Y="0.43019090885900946"/>
+                                        <RotateTransform Angle="135" />
+                                        <TranslateTransform X="0.17819090885901012" Y="0.43019090885900946" />
                                     </TransformGroup>
                                 </Path.RenderTransform>
                             </Path>
-                            <ContentPresenter Grid.Column="1" 
-								HorizontalAlignment="Left" 
-								Margin="4,0,0,0" 
-								RecognizesAccessKey="True" 
-								SnapsToDevicePixels="True" 
-								VerticalAlignment="Center"/>
+                            <ContentPresenter
+                                Grid.Column="1"
+                                Margin="4,0,0,0"
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Center"
+                                RecognizesAccessKey="True"
+                                SnapsToDevicePixels="True" />
                         </Grid>
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsChecked" Value="false">
-                            <Setter Property="Margin" TargetName="arrow" Value="-0.526,4.842,0,0"></Setter>
-                            <Setter Property="RenderTransform" TargetName="arrow">
+                            <Setter TargetName="arrow" Property="Margin" Value="-0.526,4.842,0,0" />
+                            <Setter TargetName="arrow" Property="RenderTransform">
                                 <Setter.Value>
                                     <TransformGroup>
-                                        <RotateTransform Angle="90"/>
-                                        <TranslateTransform X="0.17819090885901012" Y="0.43019090885900946"/>
+                                        <RotateTransform Angle="90" />
+                                        <TranslateTransform X="0.17819090885901012" Y="0.43019090885900946" />
                                     </TransformGroup>
                                 </Setter.Value>
                             </Setter>
-                            <Setter Property="Fill" TargetName="arrow" Value="Transparent"/>
+                            <Setter TargetName="arrow" Property="Fill" Value="Transparent" />
                         </Trigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
-                                <Condition Property="IsMouseOver" Value="true"/>
-                                <Condition Property="IsChecked" Value="true"/>
+                                <Condition Property="IsMouseOver" Value="true" />
+                                <Condition Property="IsChecked" Value="true" />
                             </MultiTrigger.Conditions>
-                            <Setter Property="Fill" TargetName="arrow" Value="Transparent"/>
+                            <Setter TargetName="arrow" Property="Fill" Value="Transparent" />
                         </MultiTrigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
-                                <Condition Property="IsMouseOver" Value="true"/>
-                                <Condition Property="IsChecked" Value="false"/>
+                                <Condition Property="IsMouseOver" Value="true" />
+                                <Condition Property="IsChecked" Value="false" />
                             </MultiTrigger.Conditions>
-                            <Setter Property="Fill" TargetName="arrow" Value="{StaticResource TreeViewBackground}"/>
+                            <Setter TargetName="arrow" Property="Fill" Value="{StaticResource TreeViewBackground}" />
                         </MultiTrigger>
-                        <Trigger Property="IsEnabled" Value="false"/>
+                        <Trigger Property="IsEnabled" Value="false" />
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
 
-    <!-- StatusBar -->
+    <!--  StatusBar  -->
     <Style TargetType="{x:Type StatusBar}">
-        <Setter Property="Margin" Value="1 0 3 0"/>
-        <Setter Property="Height" Value="18"/>
-        <Setter Property="Background" Value="{StaticResource WindowBackgroundBrush}"/>
-        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}"/>
-        <Setter Property="FontFamily" Value="{DynamicResource {x:Static SystemFonts.StatusFontFamilyKey}}"/>
-        <Setter Property="FontSize" Value="{DynamicResource {x:Static SystemFonts.StatusFontSizeKey}}"/>
-        <Setter Property="FontStyle" Value="{DynamicResource {x:Static SystemFonts.StatusFontStyleKey}}"/>
-        <Setter Property="FontWeight" Value="{DynamicResource {x:Static SystemFonts.StatusFontWeightKey}}"/>
+        <Setter Property="Margin" Value="1,0,3,0" />
+        <Setter Property="Height" Value="18" />
+        <Setter Property="Background" Value="{StaticResource WindowBackgroundBrush}" />
+        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}" />
+        <Setter Property="FontFamily" Value="{DynamicResource {x:Static SystemFonts.StatusFontFamilyKey}}" />
+        <Setter Property="FontSize" Value="{DynamicResource {x:Static SystemFonts.StatusFontSizeKey}}" />
+        <Setter Property="FontStyle" Value="{DynamicResource {x:Static SystemFonts.StatusFontStyleKey}}" />
+        <Setter Property="FontWeight" Value="{DynamicResource {x:Static SystemFonts.StatusFontWeightKey}}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type StatusBar}">
-                    <Border BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" Padding="{TemplateBinding Padding}" SnapsToDevicePixels="true">
-                        <ItemsPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                    <Border
+                        Padding="{TemplateBinding Padding}"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        SnapsToDevicePixels="true">
+                        <ItemsPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                     </Border>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
-    
+
     <Style TargetType="{x:Type StatusBarItem}">
-        <Setter Property="Margin" Value="4 0 4 0"/>
-        <Setter Property="Background" Value="Transparent"/>
-        <Setter Property="HorizontalContentAlignment" Value="Left"/>
-        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="Margin" Value="4,0,4,0" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="HorizontalContentAlignment" Value="Left" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type StatusBarItem}">
-                    <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                    <ContentPresenter
+                        HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                        VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsEnabled" Value="false">
-                            <Setter Property="Foreground" Value="{StaticResource TextBoxDisabledForeground}"/>
+                            <Setter Property="Foreground" Value="{StaticResource TextBoxDisabledForeground}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
-    <!-- Menu -->
+    <!--  Menu  -->
 
     <Style TargetType="{x:Type Menu}">
-        <Setter Property="Background" Value="{StaticResource MenuBackground}"/>
-        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}"/>
+        <Setter Property="Background" Value="{StaticResource MenuBackground}" />
+        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Menu}">
-                    <Border BorderBrush="{TemplateBinding BorderBrush}" 
-        					BorderThickness="{TemplateBinding BorderThickness}" 
-        					Background="{TemplateBinding Background}" 
-        					Padding="{TemplateBinding Padding}" 
-        					SnapsToDevicePixels="true">
-                        <ItemsPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                    <Border
+                        Padding="{TemplateBinding Padding}"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        SnapsToDevicePixels="true">
+                        <ItemsPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                     </Border>
                 </ControlTemplate>
             </Setter.Value>
@@ -2280,145 +2512,195 @@
     </Style>
 
     <Style TargetType="{x:Type ContextMenu}">
-        <Setter Property="Background" Value="{StaticResource MenuBackground}"/>
-        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}"/>
+        <Setter Property="Background" Value="{StaticResource MenuBackground}" />
+        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ContextMenu}">
-                    <Border BorderBrush="{StaticResource SubMenuBorderBrush}" 
-        					BorderThickness="{TemplateBinding BorderThickness}" 
-        					Background="{StaticResource SubMenuBackgroundBrush}" 
-        					Padding="{TemplateBinding Padding}" 
-        					SnapsToDevicePixels="true">
-                        <ItemsPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                    <Border
+                        Padding="{TemplateBinding Padding}"
+                        Background="{StaticResource SubMenuBackgroundBrush}"
+                        BorderBrush="{StaticResource SubMenuBorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        SnapsToDevicePixels="true">
+                        <ItemsPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                     </Border>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
-    
+
     <ControlTemplate x:Key="{ComponentResourceKey ResourceId=SubmenuItemTemplateKey, TypeInTargetAssembly={x:Type MenuItem}}" TargetType="{x:Type MenuItem}">
         <Grid SnapsToDevicePixels="true">
-            <Rectangle x:Name="Bg" 
-                           Fill="{TemplateBinding Background}" 
-                           Stroke="{TemplateBinding BorderBrush}" 
-                           StrokeThickness="1"/>
-            <Rectangle x:Name="InnerBorder" Margin="1"/>
+            <Rectangle
+                x:Name="Bg"
+                Fill="{TemplateBinding Background}"
+                Stroke="{TemplateBinding BorderBrush}"
+                StrokeThickness="1" />
+            <Rectangle x:Name="InnerBorder" Margin="1" />
             <Grid>
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition MinWidth="14" SharedSizeGroup="MenuItemIconColumnGroup" Width="Auto"/>
-                    <ColumnDefinition Width="4"/>
-                    <ColumnDefinition Width="*"/>
-                    <ColumnDefinition MinWidth="37"/>
-                    <ColumnDefinition SharedSizeGroup="MenuItemIGTColumnGroup" Width="Auto"/>
-                    <ColumnDefinition Width="17"/>
+                    <ColumnDefinition
+                        Width="Auto"
+                        MinWidth="14"
+                        SharedSizeGroup="MenuItemIconColumnGroup" />
+                    <ColumnDefinition Width="4" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition MinWidth="37" />
+                    <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIGTColumnGroup" />
+                    <ColumnDefinition Width="17" />
                 </Grid.ColumnDefinitions>
-                <ContentPresenter x:Name="Icon" 
-                                      ContentSource="Icon" 
-                                      Margin="1" 
-                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" 
-                                      VerticalAlignment="Center"/>
-                <Border x:Name="GlyphPanel" 
-                            BorderBrush="Transparent"
-							Margin="1" Visibility="Hidden">
-                    <Path x:Name="Glyph" 
-								Data="{StaticResource Checkmark}" 
-								Fill="{StaticResource ForegroundBrush}" 
-								FlowDirection="LeftToRight"
-								Margin="5,0,0,0"
-								VerticalAlignment="Center" 
-								Height="7.5"
-								Stretch="Fill" 
-								Width="7.5"/>
+                <ContentPresenter
+                    x:Name="Icon"
+                    Margin="1"
+                    VerticalAlignment="Center"
+                    ContentSource="Icon"
+                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                <Border
+                    x:Name="GlyphPanel"
+                    Margin="1"
+                    BorderBrush="Transparent"
+                    Visibility="Hidden">
+                    <Path
+                        x:Name="Glyph"
+                        Width="7.5"
+                        Height="7.5"
+                        Margin="5,0,0,0"
+                        VerticalAlignment="Center"
+                        Data="{StaticResource Checkmark}"
+                        Fill="{StaticResource ForegroundBrush}"
+                        FlowDirection="LeftToRight"
+                        Stretch="Fill" />
                 </Border>
-                <ContentPresenter x:Name="Content"  Grid.Column="2" 
-                                      ContentSource="Header"
-                                      Margin="{TemplateBinding Padding}"
-                                      RecognizesAccessKey="True" 
-                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                <TextBlock Grid.Column="4" 
-                               Margin="{TemplateBinding Padding}"
-                               Text="{TemplateBinding InputGestureText}"/>
+                <ContentPresenter
+                    x:Name="Content"
+                    Grid.Column="2"
+                    Margin="{TemplateBinding Padding}"
+                    ContentSource="Header"
+                    RecognizesAccessKey="True"
+                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                <TextBlock
+                    Grid.Column="4"
+                    Margin="{TemplateBinding Padding}"
+                    Text="{TemplateBinding InputGestureText}" />
             </Grid>
         </Grid>
         <ControlTemplate.Triggers>
             <Trigger Property="Icon" Value="{x:Null}">
-                <Setter Property="Visibility" TargetName="Icon" Value="Collapsed"/>
+                <Setter TargetName="Icon" Property="Visibility" Value="Collapsed" />
             </Trigger>
             <Trigger Property="IsChecked" Value="true">
-                <Setter Property="Visibility" TargetName="GlyphPanel" Value="Visible"/>
-                <Setter Property="Visibility" TargetName="Icon" Value="Collapsed"/>
+                <Setter TargetName="GlyphPanel" Property="Visibility" Value="Visible" />
+                <Setter TargetName="Icon" Property="Visibility" Value="Collapsed" />
             </Trigger>
             <Trigger Property="IsHighlighted" Value="true">
-                <Setter Property="Fill" TargetName="Bg" Value="{StaticResource MenuItemSelectionFill}"/>
-                <Setter Property="TextBlock.Foreground" TargetName="Content" Value="{StaticResource MouseOverForegroundBrush}"/>
-                <Setter Property="Fill" TargetName="Glyph" Value="{StaticResource MouseOverForegroundBrush}"/>
+                <Setter TargetName="Bg" Property="Fill" Value="{StaticResource MenuItemSelectionFill}" />
+                <Setter TargetName="Content" Property="TextBlock.Foreground" Value="{StaticResource MouseOverForegroundBrush}" />
+                <Setter TargetName="Glyph" Property="Fill" Value="{StaticResource MouseOverForegroundBrush}" />
             </Trigger>
             <Trigger Property="IsEnabled" Value="false">
-                <Setter Property="Foreground" Value="{StaticResource DisabledMenuForeground}"/>
-                <Setter Property="Fill" TargetName="Glyph" Value="{StaticResource DisabledMenuForeground}"/>
+                <Setter Property="Foreground" Value="{StaticResource DisabledMenuForeground}" />
+                <Setter TargetName="Glyph" Property="Fill" Value="{StaticResource DisabledMenuForeground}" />
             </Trigger>
         </ControlTemplate.Triggers>
     </ControlTemplate>
-    <Style x:Key="MenuScrollButton" BasedOn="{x:Null}" TargetType="{x:Type RepeatButton}">
-        <Setter Property="ClickMode" Value="Hover"/>
-        <Setter Property="MinWidth" Value="0"/>
-        <Setter Property="MinHeight" Value="0"/>
+    <Style
+        x:Key="MenuScrollButton"
+        BasedOn="{x:Null}"
+        TargetType="{x:Type RepeatButton}">
+        <Setter Property="ClickMode" Value="Hover" />
+        <Setter Property="MinWidth" Value="0" />
+        <Setter Property="MinHeight" Value="0" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type RepeatButton}">
-                    <DockPanel x:Name="DPButton" Background="{StaticResource SubMenuRepeatButtonBrush}" SnapsToDevicePixels="true">
-                        <ContentPresenter x:Name="ContentContainer" HorizontalAlignment="Center" Margin="2,0,2,5" VerticalAlignment="Center"/>
+                    <DockPanel
+                        x:Name="DPButton"
+                        Background="{StaticResource SubMenuRepeatButtonBrush}"
+                        SnapsToDevicePixels="true">
+                        <ContentPresenter
+                            x:Name="ContentContainer"
+                            Margin="2,0,2,5"
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center" />
                     </DockPanel>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsPressed" Value="true">
-                            <Setter Property="Background" TargetName="DPButton" Value="{StaticResource SubMenuHoverRepeatButtonBrush}"/>
+                            <Setter TargetName="DPButton" Property="Background" Value="{StaticResource SubMenuHoverRepeatButtonBrush}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
-    <MenuScrollingVisibilityConverter x:Key="MenuScrollingVisibilityConverter"/>
-    <Style x:Key="{ComponentResourceKey ResourceId=MenuScrollViewer, TypeInTargetAssembly={x:Type FrameworkElement}}" BasedOn="{x:Null}" TargetType="{x:Type ScrollViewer}">
-        <Setter Property="HorizontalScrollBarVisibility" Value="Hidden"/>
-        <Setter Property="VerticalScrollBarVisibility" Value="Auto"/>
+    <MenuScrollingVisibilityConverter x:Key="MenuScrollingVisibilityConverter" />
+    <Style
+        x:Key="{ComponentResourceKey ResourceId=MenuScrollViewer,
+                                     TypeInTargetAssembly={x:Type FrameworkElement}}"
+        BasedOn="{x:Null}"
+        TargetType="{x:Type ScrollViewer}">
+        <Setter Property="HorizontalScrollBarVisibility" Value="Hidden" />
+        <Setter Property="VerticalScrollBarVisibility" Value="Auto" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ScrollViewer}">
                     <Grid SnapsToDevicePixels="true">
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
                         <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="*"/>
-                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="Auto" />
                         </Grid.RowDefinitions>
-                        <Border Grid.Column="0" Grid.Row="1">
-                            <ScrollContentPresenter CanContentScroll="{TemplateBinding CanContentScroll}" Margin="{TemplateBinding Padding}"/>
+                        <Border Grid.Row="1" Grid.Column="0">
+                            <ScrollContentPresenter Margin="{TemplateBinding Padding}" CanContentScroll="{TemplateBinding CanContentScroll}" />
                         </Border>
-                        <RepeatButton Grid.Column="0" CommandTarget="{Binding RelativeSource={RelativeSource TemplatedParent}}" Command="{x:Static ScrollBar.LineUpCommand}" Focusable="false" Grid.Row="0" Style="{StaticResource MenuScrollButton}">
+                        <RepeatButton
+                            Grid.Row="0"
+                            Grid.Column="0"
+                            Command="{x:Static ScrollBar.LineUpCommand}"
+                            CommandTarget="{Binding RelativeSource={RelativeSource TemplatedParent}}"
+                            Focusable="false"
+                            Style="{StaticResource MenuScrollButton}">
                             <RepeatButton.Visibility>
-                                <MultiBinding ConverterParameter="0" Converter="{StaticResource MenuScrollingVisibilityConverter}" FallbackValue="Visibility.Collapsed">
-                                    <Binding Path="ComputedVerticalScrollBarVisibility" RelativeSource="{RelativeSource TemplatedParent}"/>
-                                    <Binding Path="VerticalOffset" RelativeSource="{RelativeSource TemplatedParent}"/>
-                                    <Binding Path="ExtentHeight" RelativeSource="{RelativeSource TemplatedParent}"/>
-                                    <Binding Path="ViewportHeight" RelativeSource="{RelativeSource TemplatedParent}"/>
+                                <MultiBinding
+                                    Converter="{StaticResource MenuScrollingVisibilityConverter}"
+                                    ConverterParameter="0"
+                                    FallbackValue="Visibility.Collapsed">
+                                    <Binding Path="ComputedVerticalScrollBarVisibility" RelativeSource="{RelativeSource TemplatedParent}" />
+                                    <Binding Path="VerticalOffset" RelativeSource="{RelativeSource TemplatedParent}" />
+                                    <Binding Path="ExtentHeight" RelativeSource="{RelativeSource TemplatedParent}" />
+                                    <Binding Path="ViewportHeight" RelativeSource="{RelativeSource TemplatedParent}" />
                                 </MultiBinding>
                             </RepeatButton.Visibility>
-                            <Path x:Name="UpArrow" Data="{StaticResource MenuScrollUpArrowGeometry}" Fill="{StaticResource ForegroundBrush}"/>
+                            <Path
+                                x:Name="UpArrow"
+                                Data="{StaticResource MenuScrollUpArrowGeometry}"
+                                Fill="{StaticResource ForegroundBrush}" />
                         </RepeatButton>
-                        <RepeatButton Grid.Column="0" CommandTarget="{Binding RelativeSource={RelativeSource TemplatedParent}}" Command="{x:Static ScrollBar.LineDownCommand}" Focusable="false" Grid.Row="2" Style="{StaticResource MenuScrollButton}">
+                        <RepeatButton
+                            Grid.Row="2"
+                            Grid.Column="0"
+                            Command="{x:Static ScrollBar.LineDownCommand}"
+                            CommandTarget="{Binding RelativeSource={RelativeSource TemplatedParent}}"
+                            Focusable="false"
+                            Style="{StaticResource MenuScrollButton}">
                             <RepeatButton.Visibility>
-                                <MultiBinding ConverterParameter="100" Converter="{StaticResource MenuScrollingVisibilityConverter}" FallbackValue="Visibility.Collapsed">
-                                    <Binding Path="ComputedVerticalScrollBarVisibility" RelativeSource="{RelativeSource TemplatedParent}"/>
-                                    <Binding Path="VerticalOffset" RelativeSource="{RelativeSource TemplatedParent}"/>
-                                    <Binding Path="ExtentHeight" RelativeSource="{RelativeSource TemplatedParent}"/>
-                                    <Binding Path="ViewportHeight" RelativeSource="{RelativeSource TemplatedParent}"/>
+                                <MultiBinding
+                                    Converter="{StaticResource MenuScrollingVisibilityConverter}"
+                                    ConverterParameter="100"
+                                    FallbackValue="Visibility.Collapsed">
+                                    <Binding Path="ComputedVerticalScrollBarVisibility" RelativeSource="{RelativeSource TemplatedParent}" />
+                                    <Binding Path="VerticalOffset" RelativeSource="{RelativeSource TemplatedParent}" />
+                                    <Binding Path="ExtentHeight" RelativeSource="{RelativeSource TemplatedParent}" />
+                                    <Binding Path="ViewportHeight" RelativeSource="{RelativeSource TemplatedParent}" />
                                 </MultiBinding>
                             </RepeatButton.Visibility>
-                            <Path x:Name="DownArrow" Data="{StaticResource MenuScrollDownArrowGeometry}" Fill="{StaticResource ForegroundBrush}"/>
+                            <Path
+                                x:Name="DownArrow"
+                                Data="{StaticResource MenuScrollDownArrowGeometry}"
+                                Fill="{StaticResource ForegroundBrush}" />
                         </RepeatButton>
                     </Grid>
                 </ControlTemplate>
@@ -2427,62 +2709,74 @@
     </Style>
     <ControlTemplate x:Key="{ComponentResourceKey ResourceId=TopLevelHeaderTemplateKey, TypeInTargetAssembly={x:Type MenuItem}}" TargetType="{x:Type MenuItem}">
         <Grid SnapsToDevicePixels="true">
-            <Rectangle x:Name="Bg" 
-							Fill="{TemplateBinding Background}" 
-							Margin="1"/>
+            <Rectangle
+                x:Name="Bg"
+                Margin="1"
+                Fill="{TemplateBinding Background}" />
             <DockPanel>
-                <ContentPresenter x:Name="Icon" 
-										ContentSource="Icon"
-										Margin="4,0,6,0" 
-										SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" 
-										VerticalAlignment="Center"/>
-                <Path x:Name="GlyphPanel" 
-							Data="{StaticResource Checkmark}" 
-							Fill="{TemplateBinding Foreground}" 
-							FlowDirection="LeftToRight" 
-							Visibility="Collapsed"
-							Margin="5,0,0,0"
-							VerticalAlignment="Center" 
-							Height="7.5"
-							Stretch="Fill" 
-							Width="7.5"/>
-                <ContentPresenter x:Name="Content" ContentSource="Header" 
-										Margin="{TemplateBinding Padding}" 
-										RecognizesAccessKey="True" 
-										SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                <ContentPresenter
+                    x:Name="Icon"
+                    Margin="4,0,6,0"
+                    VerticalAlignment="Center"
+                    ContentSource="Icon"
+                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                <Path
+                    x:Name="GlyphPanel"
+                    Width="7.5"
+                    Height="7.5"
+                    Margin="5,0,0,0"
+                    VerticalAlignment="Center"
+                    Data="{StaticResource Checkmark}"
+                    Fill="{TemplateBinding Foreground}"
+                    FlowDirection="LeftToRight"
+                    Stretch="Fill"
+                    Visibility="Collapsed" />
+                <ContentPresenter
+                    x:Name="Content"
+                    Margin="{TemplateBinding Padding}"
+                    ContentSource="Header"
+                    RecognizesAccessKey="True"
+                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
             </DockPanel>
-            <Popup x:Name="PART_Popup"
-						AllowsTransparency="true" 
-						Focusable="false" 
-						HorizontalOffset="1" 
-						IsOpen="{Binding IsSubmenuOpen, RelativeSource={RelativeSource TemplatedParent}}"
-						PopupAnimation="{DynamicResource {x:Static SystemParameters.MenuPopupAnimationKey}}" 
-						Placement="Bottom" 
-						VerticalOffset="-1">
+            <Popup
+                x:Name="PART_Popup"
+                AllowsTransparency="true"
+                Focusable="false"
+                HorizontalOffset="1"
+                IsOpen="{Binding IsSubmenuOpen, RelativeSource={RelativeSource TemplatedParent}}"
+                Placement="Bottom"
+                PopupAnimation="{DynamicResource {x:Static SystemParameters.MenuPopupAnimationKey}}"
+                VerticalOffset="-1">
                 <Border x:Name="Shdw" Background="Transparent">
-                    <Border x:Name="SubMenuBorder" 
-								BorderBrush="{StaticResource SubMenuBorderBrush}" 
-								BorderThickness="1" 
-								Background="{StaticResource SubMenuBackgroundBrush}">
-                        <ScrollViewer x:Name="SubMenuScrollViewer" 
-											Margin="1,0" 
-											Style="{DynamicResource {ComponentResourceKey ResourceId=MenuScrollViewer, TypeInTargetAssembly={x:Type FrameworkElement}}}">
+                    <Border
+                        x:Name="SubMenuBorder"
+                        Background="{StaticResource SubMenuBackgroundBrush}"
+                        BorderBrush="{StaticResource SubMenuBorderBrush}"
+                        BorderThickness="1">
+                        <ScrollViewer
+                            x:Name="SubMenuScrollViewer"
+                            Margin="1,0"
+                            Style="{DynamicResource {ComponentResourceKey ResourceId=MenuScrollViewer,
+                                                                          TypeInTargetAssembly={x:Type FrameworkElement}}}">
                             <Grid RenderOptions.ClearTypeHint="Enabled">
-                                <Canvas HorizontalAlignment="Left" 
-											Height="0" 
-											VerticalAlignment="Top" 
-											Width="0">
-                                    <Rectangle x:Name="OpaqueRect" 
-													Fill="{StaticResource SubMenuBackgroundBrush}" 
-													Height="{Binding ActualHeight, ElementName=SubMenuBorder}" 
-													Width="{Binding ActualWidth, ElementName=SubMenuBorder}"/>
+                                <Canvas
+                                    Width="0"
+                                    Height="0"
+                                    HorizontalAlignment="Left"
+                                    VerticalAlignment="Top">
+                                    <Rectangle
+                                        x:Name="OpaqueRect"
+                                        Width="{Binding ActualWidth, ElementName=SubMenuBorder}"
+                                        Height="{Binding ActualHeight, ElementName=SubMenuBorder}"
+                                        Fill="{StaticResource SubMenuBackgroundBrush}" />
                                 </Canvas>
-                                <ItemsPresenter x:Name="ItemsPresenter" 
-													KeyboardNavigation.DirectionalNavigation="Cycle"
-													Grid.IsSharedSizeScope="true" 
-													Margin="2" 
-													SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-													KeyboardNavigation.TabNavigation="Cycle"/>
+                                <ItemsPresenter
+                                    x:Name="ItemsPresenter"
+                                    Margin="2"
+                                    Grid.IsSharedSizeScope="true"
+                                    KeyboardNavigation.DirectionalNavigation="Cycle"
+                                    KeyboardNavigation.TabNavigation="Cycle"
+                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                             </Grid>
                         </ScrollViewer>
                     </Border>
@@ -2491,170 +2785,194 @@
         </Grid>
         <ControlTemplate.Triggers>
             <Trigger Property="IsSuspendingPopupAnimation" Value="true">
-                <Setter Property="PopupAnimation" TargetName="PART_Popup" Value="None"/>
+                <Setter TargetName="PART_Popup" Property="PopupAnimation" Value="None" />
             </Trigger>
             <Trigger Property="Icon" Value="{x:Null}">
-                <Setter Property="Visibility" TargetName="Icon" Value="Collapsed"/>
+                <Setter TargetName="Icon" Property="Visibility" Value="Collapsed" />
             </Trigger>
             <Trigger Property="IsChecked" Value="true">
-                <Setter Property="Visibility" TargetName="GlyphPanel" Value="Visible"/>
-                <Setter Property="Visibility" TargetName="Icon" Value="Collapsed"/>
+                <Setter TargetName="GlyphPanel" Property="Visibility" Value="Visible" />
+                <Setter TargetName="Icon" Property="Visibility" Value="Collapsed" />
             </Trigger>
-            <Trigger Property="HasDropShadow" SourceName="PART_Popup" Value="true">
-                <Setter Property="Margin" TargetName="Shdw" Value="0,0,5,5"/>
-                <Setter Property="Background" TargetName="Shdw" Value="#71000000"/>
+            <Trigger SourceName="PART_Popup" Property="HasDropShadow" Value="true">
+                <Setter TargetName="Shdw" Property="Margin" Value="0,0,5,5" />
+                <Setter TargetName="Shdw" Property="Background" Value="#71000000" />
             </Trigger>
             <Trigger Property="IsHighlighted" Value="true">
-                <Setter Property="Fill" TargetName="Bg" Value="{StaticResource MenuItemPressedFill}"/>
-                <Setter Property="TextBlock.Foreground" TargetName="Content" Value="{StaticResource MouseOverForegroundBrush}"/>
-                <Setter Property="Fill" TargetName="GlyphPanel" Value="{StaticResource MouseOverForegroundBrush}"/>
+                <Setter TargetName="Bg" Property="Fill" Value="{StaticResource MenuItemPressedFill}" />
+                <Setter TargetName="Content" Property="TextBlock.Foreground" Value="{StaticResource MouseOverForegroundBrush}" />
+                <Setter TargetName="GlyphPanel" Property="Fill" Value="{StaticResource MouseOverForegroundBrush}" />
             </Trigger>
             <Trigger Property="IsKeyboardFocused" Value="true">
-                <Setter Property="Fill" TargetName="Bg" Value="{StaticResource MenuItemPressedFill}"/>
+                <Setter TargetName="Bg" Property="Fill" Value="{StaticResource MenuItemPressedFill}" />
             </Trigger>
             <Trigger Property="IsSubmenuOpen" Value="true">
-                <Setter Property="Fill" TargetName="Bg" Value="{StaticResource MenuItemPressedFill}"/>
+                <Setter TargetName="Bg" Property="Fill" Value="{StaticResource MenuItemPressedFill}" />
             </Trigger>
             <Trigger Property="IsEnabled" Value="false">
-                <Setter Property="Foreground" Value="{StaticResource DisabledMenuForeground}"/>
-                <Setter Property="Fill" TargetName="GlyphPanel" Value="{StaticResource DisabledMenuForeground}"/>
+                <Setter Property="Foreground" Value="{StaticResource DisabledMenuForeground}" />
+                <Setter TargetName="GlyphPanel" Property="Fill" Value="{StaticResource DisabledMenuForeground}" />
             </Trigger>
-            <Trigger Property="ScrollViewer.CanContentScroll" SourceName="SubMenuScrollViewer" Value="false">
-                <Setter Property="Canvas.Top" TargetName="OpaqueRect" Value="{Binding VerticalOffset, ElementName=SubMenuScrollViewer}"/>
-                <Setter Property="Canvas.Left" TargetName="OpaqueRect" Value="{Binding HorizontalOffset, ElementName=SubMenuScrollViewer}"/>
+            <Trigger SourceName="SubMenuScrollViewer" Property="ScrollViewer.CanContentScroll" Value="false">
+                <Setter TargetName="OpaqueRect" Property="Canvas.Top" Value="{Binding VerticalOffset, ElementName=SubMenuScrollViewer}" />
+                <Setter TargetName="OpaqueRect" Property="Canvas.Left" Value="{Binding HorizontalOffset, ElementName=SubMenuScrollViewer}" />
             </Trigger>
         </ControlTemplate.Triggers>
     </ControlTemplate>
     <ControlTemplate x:Key="{ComponentResourceKey ResourceId=TopLevelItemTemplateKey, TypeInTargetAssembly={x:Type MenuItem}}" TargetType="{x:Type MenuItem}">
         <Grid SnapsToDevicePixels="true">
-            <Rectangle x:Name="Bg"
-							Fill="{TemplateBinding Background}"
-							Margin="1"/>
+            <Rectangle
+                x:Name="Bg"
+                Margin="1"
+                Fill="{TemplateBinding Background}" />
             <DockPanel>
-                <ContentPresenter x:Name="Icon"
-										ContentSource="Icon"
-										Margin="4,0,6,0"
-										SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-										VerticalAlignment="Center"/>
-                <Path x:Name="GlyphPanel"
-							Data="{StaticResource Checkmark}"
-							Fill="{TemplateBinding Foreground}"
-							FlowDirection="LeftToRight"
-							Margin="5,0,0,0"
-							VerticalAlignment="Center" 
-							Height="7.5"
-							Stretch="Fill" 
-							Width="7.5"
-							Visibility="Collapsed"/>
-                <ContentPresenter ContentSource="Header"
-										Margin="{TemplateBinding Padding}"
-										RecognizesAccessKey="True"
-										SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                <ContentPresenter
+                    x:Name="Icon"
+                    Margin="4,0,6,0"
+                    VerticalAlignment="Center"
+                    ContentSource="Icon"
+                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                <Path
+                    x:Name="GlyphPanel"
+                    Width="7.5"
+                    Height="7.5"
+                    Margin="5,0,0,0"
+                    VerticalAlignment="Center"
+                    Data="{StaticResource Checkmark}"
+                    Fill="{TemplateBinding Foreground}"
+                    FlowDirection="LeftToRight"
+                    Stretch="Fill"
+                    Visibility="Collapsed" />
+                <ContentPresenter
+                    Margin="{TemplateBinding Padding}"
+                    ContentSource="Header"
+                    RecognizesAccessKey="True"
+                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
             </DockPanel>
         </Grid>
         <ControlTemplate.Triggers>
             <Trigger Property="Icon" Value="{x:Null}">
-                <Setter Property="Visibility" TargetName="Icon" Value="Collapsed"/>
+                <Setter TargetName="Icon" Property="Visibility" Value="Collapsed" />
             </Trigger>
             <Trigger Property="IsChecked" Value="true">
-                <Setter Property="Visibility" TargetName="GlyphPanel" Value="Visible"/>
-                <Setter Property="Visibility" TargetName="Icon" Value="Collapsed"/>
+                <Setter TargetName="GlyphPanel" Property="Visibility" Value="Visible" />
+                <Setter TargetName="Icon" Property="Visibility" Value="Collapsed" />
             </Trigger>
             <Trigger Property="IsHighlighted" Value="true">
-                <Setter Property="Fill" TargetName="Bg" Value="{StaticResource MenuItemSelectionFill}"/>
-                <Setter Property="TextBlock.Foreground" Value="{StaticResource MouseOverForegroundBrush}"/>
-                <Setter Property="Fill" TargetName="GlyphPanel" Value="{StaticResource MouseOverForegroundBrush}"/>
+                <Setter TargetName="Bg" Property="Fill" Value="{StaticResource MenuItemSelectionFill}" />
+                <Setter Property="TextBlock.Foreground" Value="{StaticResource MouseOverForegroundBrush}" />
+                <Setter TargetName="GlyphPanel" Property="Fill" Value="{StaticResource MouseOverForegroundBrush}" />
             </Trigger>
             <Trigger Property="IsKeyboardFocused" Value="true">
-                <Setter Property="Fill" TargetName="Bg" Value="{StaticResource MenuItemPressedFill}"/>
+                <Setter TargetName="Bg" Property="Fill" Value="{StaticResource MenuItemPressedFill}" />
             </Trigger>
             <Trigger Property="IsEnabled" Value="false">
-                <Setter Property="Foreground" Value="{StaticResource DisabledMenuForeground}"/>
-                <Setter Property="Fill" TargetName="GlyphPanel" Value="{StaticResource DisabledMenuForeground}"/>
+                <Setter Property="Foreground" Value="{StaticResource DisabledMenuForeground}" />
+                <Setter TargetName="GlyphPanel" Property="Fill" Value="{StaticResource DisabledMenuForeground}" />
             </Trigger>
         </ControlTemplate.Triggers>
     </ControlTemplate>
 
     <ControlTemplate x:Key="{ComponentResourceKey ResourceId=SubmenuHeaderTemplateKey, TypeInTargetAssembly={x:Type MenuItem}}" TargetType="{x:Type MenuItem}">
         <Grid SnapsToDevicePixels="true">
-            <Rectangle x:Name="Bg" Fill="{TemplateBinding Background}"
-							Stroke="{TemplateBinding BorderBrush}" 
-							StrokeThickness="1"/>
+            <Rectangle
+                x:Name="Bg"
+                Fill="{TemplateBinding Background}"
+                Stroke="{TemplateBinding BorderBrush}"
+                StrokeThickness="1" />
             <Grid>
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition MinWidth="14" SharedSizeGroup="MenuItemIconColumnGroup" Width="Auto"/>
-                    <ColumnDefinition Width="4"/>
-                    <ColumnDefinition Width="*"/>
-                    <ColumnDefinition MinWidth="37"/>
-                    <ColumnDefinition SharedSizeGroup="MenuItemIGTColumnGroup" Width="Auto"/>
-                    <ColumnDefinition Width="17"/>
+                    <ColumnDefinition
+                        Width="Auto"
+                        MinWidth="14"
+                        SharedSizeGroup="MenuItemIconColumnGroup" />
+                    <ColumnDefinition Width="4" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition MinWidth="37" />
+                    <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIGTColumnGroup" />
+                    <ColumnDefinition Width="17" />
                 </Grid.ColumnDefinitions>
-                <ContentPresenter x:Name="Icon"
-										ContentSource="Icon"
-										Margin="1" 
-										SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-										VerticalAlignment="Center"/>
-                <Border x:Name="GlyphPanel" 
-							Background="Transparent"
-							Margin="1" 
-							Visibility="Hidden">
-                    <Path x:Name="Glyph" 
-								Data="{StaticResource Checkmark}"
-								Fill="{StaticResource ForegroundBrush}" 
-								FlowDirection="LeftToRight" 
-								Margin="5,0,0,0"
-								VerticalAlignment="Center" 
-								Height="7.5"
-								Stretch="Fill" 
-								Width="7.5"/>
+                <ContentPresenter
+                    x:Name="Icon"
+                    Margin="1"
+                    VerticalAlignment="Center"
+                    ContentSource="Icon"
+                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                <Border
+                    x:Name="GlyphPanel"
+                    Margin="1"
+                    Background="Transparent"
+                    Visibility="Hidden">
+                    <Path
+                        x:Name="Glyph"
+                        Width="7.5"
+                        Height="7.5"
+                        Margin="5,0,0,0"
+                        VerticalAlignment="Center"
+                        Data="{StaticResource Checkmark}"
+                        Fill="{StaticResource ForegroundBrush}"
+                        FlowDirection="LeftToRight"
+                        Stretch="Fill" />
                 </Border>
-                <ContentPresenter x:Name="Content" Grid.Column="2"
-										ContentSource="Header" 
-										Margin="{TemplateBinding Padding}" 
-										RecognizesAccessKey="True" 
-										SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                <TextBlock  Grid.Column="4"
-								Margin="{TemplateBinding Padding}" 
-								Text="{TemplateBinding InputGestureText}"
-								Visibility="Collapsed"/>
-                <Path x:Name="RightArrowPath" Grid.Column="5" 
-							Data="{StaticResource RightArrow}"
-							Fill="{TemplateBinding Foreground}" 
-							Margin="4,0,0,0" 
-							VerticalAlignment="Center"/>
+                <ContentPresenter
+                    x:Name="Content"
+                    Grid.Column="2"
+                    Margin="{TemplateBinding Padding}"
+                    ContentSource="Header"
+                    RecognizesAccessKey="True"
+                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                <TextBlock
+                    Grid.Column="4"
+                    Margin="{TemplateBinding Padding}"
+                    Text="{TemplateBinding InputGestureText}"
+                    Visibility="Collapsed" />
+                <Path
+                    x:Name="RightArrowPath"
+                    Grid.Column="5"
+                    Margin="4,0,0,0"
+                    VerticalAlignment="Center"
+                    Data="{StaticResource RightArrow}"
+                    Fill="{TemplateBinding Foreground}" />
             </Grid>
-            <Popup x:Name="PART_Popup" 
-						AllowsTransparency="true" 
-						Focusable="false" 
-						HorizontalOffset="-2" 
-						IsOpen="{Binding IsSubmenuOpen, RelativeSource={RelativeSource TemplatedParent}}" 
-						PopupAnimation="{DynamicResource {x:Static SystemParameters.MenuPopupAnimationKey}}"
-						Placement="Right" 
-						VerticalOffset="-3">
+            <Popup
+                x:Name="PART_Popup"
+                AllowsTransparency="true"
+                Focusable="false"
+                HorizontalOffset="-2"
+                IsOpen="{Binding IsSubmenuOpen, RelativeSource={RelativeSource TemplatedParent}}"
+                Placement="Right"
+                PopupAnimation="{DynamicResource {x:Static SystemParameters.MenuPopupAnimationKey}}"
+                VerticalOffset="-3">
                 <Border x:Name="Shdw" Background="Transparent">
-                    <Border x:Name="SubMenuBorder" 
-								BorderBrush="{StaticResource SubMenuBorderBrush}"
-								BorderThickness="1"
-								Background="{StaticResource SubMenuBackgroundBrush}">
-                        <ScrollViewer x:Name="SubMenuScrollViewer" 
-											Margin="1,0" 
-											Style="{DynamicResource {ComponentResourceKey ResourceId=MenuScrollViewer, TypeInTargetAssembly={x:Type FrameworkElement}}}">
+                    <Border
+                        x:Name="SubMenuBorder"
+                        Background="{StaticResource SubMenuBackgroundBrush}"
+                        BorderBrush="{StaticResource SubMenuBorderBrush}"
+                        BorderThickness="1">
+                        <ScrollViewer
+                            x:Name="SubMenuScrollViewer"
+                            Margin="1,0"
+                            Style="{DynamicResource {ComponentResourceKey ResourceId=MenuScrollViewer,
+                                                                          TypeInTargetAssembly={x:Type FrameworkElement}}}">
                             <Grid RenderOptions.ClearTypeHint="Enabled">
-                                <Canvas HorizontalAlignment="Left"
-											Height="0"
-											VerticalAlignment="Top"
-											Width="0">
-                                    <Rectangle x:Name="OpaqueRect"	
-													Fill="{StaticResource SubMenuBackgroundBrush}" 
-													Height="{Binding ActualHeight, ElementName=SubMenuBorder}"
-													Width="{Binding ActualWidth, ElementName=SubMenuBorder}"/>
+                                <Canvas
+                                    Width="0"
+                                    Height="0"
+                                    HorizontalAlignment="Left"
+                                    VerticalAlignment="Top">
+                                    <Rectangle
+                                        x:Name="OpaqueRect"
+                                        Width="{Binding ActualWidth, ElementName=SubMenuBorder}"
+                                        Height="{Binding ActualHeight, ElementName=SubMenuBorder}"
+                                        Fill="{StaticResource SubMenuBackgroundBrush}" />
                                 </Canvas>
-                                <ItemsPresenter x:Name="ItemsPresenter" 
-													KeyboardNavigation.DirectionalNavigation="Cycle"
-													Grid.IsSharedSizeScope="true" 
-													Margin="2" 
-													SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-													KeyboardNavigation.TabNavigation="Cycle"/>
+                                <ItemsPresenter
+                                    x:Name="ItemsPresenter"
+                                    Margin="2"
+                                    Grid.IsSharedSizeScope="true"
+                                    KeyboardNavigation.DirectionalNavigation="Cycle"
+                                    KeyboardNavigation.TabNavigation="Cycle"
+                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                             </Grid>
                         </ScrollViewer>
                     </Border>
@@ -2663,113 +2981,118 @@
         </Grid>
         <ControlTemplate.Triggers>
             <Trigger Property="IsSuspendingPopupAnimation" Value="true">
-                <Setter Property="PopupAnimation" TargetName="PART_Popup" Value="None"/>
+                <Setter TargetName="PART_Popup" Property="PopupAnimation" Value="None" />
             </Trigger>
             <Trigger Property="Icon" Value="{x:Null}">
-                <Setter Property="Visibility" TargetName="Icon" Value="Collapsed"/>
+                <Setter TargetName="Icon" Property="Visibility" Value="Collapsed" />
             </Trigger>
             <Trigger Property="IsChecked" Value="true">
-                <Setter Property="Visibility" TargetName="GlyphPanel" Value="Visible"/>
-                <Setter Property="Visibility" TargetName="Icon" Value="Collapsed"/>
+                <Setter TargetName="GlyphPanel" Property="Visibility" Value="Visible" />
+                <Setter TargetName="Icon" Property="Visibility" Value="Collapsed" />
             </Trigger>
-            <Trigger Property="HasDropShadow" SourceName="PART_Popup" Value="true">
-                <Setter Property="Margin" TargetName="Shdw" Value="0,0,5,5"/>
-                <Setter Property="Background" TargetName="Shdw" Value="#71000000"/>
+            <Trigger SourceName="PART_Popup" Property="HasDropShadow" Value="true">
+                <Setter TargetName="Shdw" Property="Margin" Value="0,0,5,5" />
+                <Setter TargetName="Shdw" Property="Background" Value="#71000000" />
             </Trigger>
             <Trigger Property="IsHighlighted" Value="true">
-                <Setter Property="Fill" TargetName="Bg" Value="{StaticResource MenuItemSelectionFill}"/>
-                <Setter Property="TextBlock.Foreground" TargetName="Content" Value="{StaticResource MouseOverForegroundBrush}"/>
-                <Setter Property="Fill" TargetName="RightArrowPath" Value="{StaticResource MouseOverForegroundBrush}"/>
-                <Setter Property="Fill" TargetName="Glyph" Value="{StaticResource MouseOverForegroundBrush}"/>
+                <Setter TargetName="Bg" Property="Fill" Value="{StaticResource MenuItemSelectionFill}" />
+                <Setter TargetName="Content" Property="TextBlock.Foreground" Value="{StaticResource MouseOverForegroundBrush}" />
+                <Setter TargetName="RightArrowPath" Property="Fill" Value="{StaticResource MouseOverForegroundBrush}" />
+                <Setter TargetName="Glyph" Property="Fill" Value="{StaticResource MouseOverForegroundBrush}" />
             </Trigger>
             <Trigger Property="IsEnabled" Value="false">
-                <Setter Property="Foreground" Value="{StaticResource DisabledMenuForeground}"/>
-                <Setter Property="Fill" TargetName="Glyph" Value="{StaticResource DisabledMenuForeground}"/>
+                <Setter Property="Foreground" Value="{StaticResource DisabledMenuForeground}" />
+                <Setter TargetName="Glyph" Property="Fill" Value="{StaticResource DisabledMenuForeground}" />
             </Trigger>
-            <Trigger Property="ScrollViewer.CanContentScroll" SourceName="SubMenuScrollViewer" Value="false">
-                <Setter Property="Canvas.Top" TargetName="OpaqueRect" Value="{Binding VerticalOffset, ElementName=SubMenuScrollViewer}"/>
-                <Setter Property="Canvas.Left" TargetName="OpaqueRect" Value="{Binding HorizontalOffset, ElementName=SubMenuScrollViewer}"/>
+            <Trigger SourceName="SubMenuScrollViewer" Property="ScrollViewer.CanContentScroll" Value="false">
+                <Setter TargetName="OpaqueRect" Property="Canvas.Top" Value="{Binding VerticalOffset, ElementName=SubMenuScrollViewer}" />
+                <Setter TargetName="OpaqueRect" Property="Canvas.Left" Value="{Binding HorizontalOffset, ElementName=SubMenuScrollViewer}" />
             </Trigger>
         </ControlTemplate.Triggers>
     </ControlTemplate>
     <Style TargetType="{x:Type MenuItem}">
-        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}"></Setter>
-        <Setter Property="HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"/>
-        <Setter Property="VerticalContentAlignment" Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"/>
-        <Setter Property="Background" Value="Transparent"/>
-        <Setter Property="ScrollViewer.PanningMode" Value="Both"/>
-        <Setter Property="MinHeight" Value="21"/>
-        <Setter Property="Stylus.IsFlicksEnabled" Value="False"/>
-        <Setter Property="Template" Value="{DynamicResource {ComponentResourceKey ResourceId=SubmenuItemTemplateKey, TypeInTargetAssembly={x:Type MenuItem}}}"/>
+        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}" />
+        <Setter Property="HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
+        <Setter Property="VerticalContentAlignment" Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="ScrollViewer.PanningMode" Value="Both" />
+        <Setter Property="MinHeight" Value="21" />
+        <Setter Property="Stylus.IsFlicksEnabled" Value="False" />
+        <Setter Property="Template" Value="{DynamicResource {ComponentResourceKey ResourceId=SubmenuItemTemplateKey, TypeInTargetAssembly={x:Type MenuItem}}}" />
         <Style.Triggers>
             <Trigger Property="Role" Value="TopLevelHeader">
-                <Setter Property="Height" Value="25"/>
-                <Setter Property="Padding" Value="7,6,8,3"/>
-                <Setter Property="Template" Value="{DynamicResource {ComponentResourceKey ResourceId=TopLevelHeaderTemplateKey, TypeInTargetAssembly={x:Type MenuItem}}}"/>
+                <Setter Property="Height" Value="25" />
+                <Setter Property="Padding" Value="7,6,8,3" />
+                <Setter Property="Template" Value="{DynamicResource {ComponentResourceKey ResourceId=TopLevelHeaderTemplateKey, TypeInTargetAssembly={x:Type MenuItem}}}" />
             </Trigger>
             <Trigger Property="Role" Value="TopLevelItem">
-                <Setter Property="Height" Value="25"/>
-                <Setter Property="Padding" Value="7,6,8,3"/>
-                <Setter Property="Template" Value="{DynamicResource {ComponentResourceKey ResourceId=TopLevelItemTemplateKey, TypeInTargetAssembly={x:Type MenuItem}}}"/>
+                <Setter Property="Height" Value="25" />
+                <Setter Property="Padding" Value="7,6,8,3" />
+                <Setter Property="Template" Value="{DynamicResource {ComponentResourceKey ResourceId=TopLevelItemTemplateKey, TypeInTargetAssembly={x:Type MenuItem}}}" />
             </Trigger>
             <Trigger Property="Role" Value="SubmenuHeader">
-                <Setter Property="Height" Value="21"/>
-                <Setter Property="Padding" Value="2,4,2,2"/>
-                <Setter Property="Template" Value="{DynamicResource {ComponentResourceKey ResourceId=SubmenuHeaderTemplateKey, TypeInTargetAssembly={x:Type MenuItem}}}"/>
+                <Setter Property="Height" Value="21" />
+                <Setter Property="Padding" Value="2,4,2,2" />
+                <Setter Property="Template" Value="{DynamicResource {ComponentResourceKey ResourceId=SubmenuHeaderTemplateKey, TypeInTargetAssembly={x:Type MenuItem}}}" />
             </Trigger>
             <Trigger Property="Role" Value="SubmenuItem">
-                <Setter Property="Height" Value="21"/>
-                <Setter Property="Padding" Value="2,4,2,2"/>
+                <Setter Property="Height" Value="21" />
+                <Setter Property="Padding" Value="2,4,2,2" />
             </Trigger>
         </Style.Triggers>
     </Style>
-    
-    <!-- Separator -->
+
+    <!--  Separator  -->
     <Style x:Key="{x:Static MenuItem.SeparatorStyleKey}" TargetType="{x:Type Separator}">
-        <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Separator}">
-                    <Grid Margin="3,2,3,2" SnapsToDevicePixels="true" UseLayoutRounding="False">
-                        <Rectangle Fill="{StaticResource MenuSeparatorBrush}" Height="1"/>
+                    <Grid
+                        Margin="3,2,3,2"
+                        SnapsToDevicePixels="true"
+                        UseLayoutRounding="False">
+                        <Rectangle Height="1" Fill="{StaticResource MenuSeparatorBrush}" />
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
-    
-    <!-- ListBox -->
+
+    <!--  ListBox  -->
 
     <Style TargetType="{x:Type ListBox}">
-        <Setter Property="Background" Value="{StaticResource ListBackground}"/>
-        <Setter Property="BorderBrush" Value="{StaticResource ListBorder}"/>
-        <Setter Property="BorderThickness" Value="1"/>
-        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}"/>
-        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto"/>
-        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto"/>
-        <Setter Property="ScrollViewer.CanContentScroll" Value="true"/>
-        <Setter Property="ScrollViewer.PanningMode" Value="Both"/>
-        <Setter Property="Stylus.IsFlicksEnabled" Value="False"/>
-        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="Background" Value="{StaticResource ListBackground}" />
+        <Setter Property="BorderBrush" Value="{StaticResource ListBorder}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}" />
+        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />
+        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
+        <Setter Property="ScrollViewer.CanContentScroll" Value="true" />
+        <Setter Property="ScrollViewer.PanningMode" Value="Both" />
+        <Setter Property="Stylus.IsFlicksEnabled" Value="False" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ListBox}">
-                    <Border x:Name="Bd" BorderBrush="{TemplateBinding BorderBrush}"
-                                BorderThickness="{TemplateBinding BorderThickness}"
-                                Background="{TemplateBinding Background}"
-                                Padding="1"
-                                SnapsToDevicePixels="true">
-                        <ScrollViewer Focusable="false" Padding="{TemplateBinding Padding}">
-                            <ItemsPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                    <Border
+                        x:Name="Bd"
+                        Padding="1"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        SnapsToDevicePixels="true">
+                        <ScrollViewer Padding="{TemplateBinding Padding}" Focusable="false">
+                            <ItemsPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         </ScrollViewer>
                     </Border>
                     <ControlTemplate.Triggers>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
-                                <Condition Property="IsGrouping" Value="true"/>
+                                <Condition Property="IsGrouping" Value="true" />
                                 <!--<Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false"/>-->
                             </MultiTrigger.Conditions>
-                            <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
+                            <Setter Property="ScrollViewer.CanContentScroll" Value="false" />
                         </MultiTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -2777,27 +3100,29 @@
         </Setter>
     </Style>
     <Style TargetType="{x:Type ListBoxItem}">
-        <Setter Property="Background" Value="Transparent"/>
-        <Setter Property="HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"/>
-        <Setter Property="VerticalContentAlignment" Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"/>
-        <Setter Property="Padding" Value="2,0,0,0"/>
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
+        <Setter Property="VerticalContentAlignment" Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
+        <Setter Property="Padding" Value="2,0,0,0" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ListBoxItem}">
-                    <Border x:Name="Bd"
-                                BorderBrush="{TemplateBinding BorderBrush}" 
-                                BorderThickness="{TemplateBinding BorderThickness}" 
-                                Background="{TemplateBinding Background}" 
-                                Padding="{TemplateBinding Padding}" 
-                                SnapsToDevicePixels="true">
-                        <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" 
-                                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" 
-                                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                    <Border
+                        x:Name="Bd"
+                        Padding="{TemplateBinding Padding}"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        SnapsToDevicePixels="true">
+                        <ContentPresenter
+                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsSelected" Value="true">
-                            <Setter Property="Background" TargetName="Bd" Value="{StaticResource SelectedListItem}"/>
-                            <Setter Property="Foreground" Value="{StaticResource SelectedListItemForeground}"/>
+                            <Setter TargetName="Bd" Property="Background" Value="{StaticResource SelectedListItem}" />
+                            <Setter Property="Foreground" Value="{StaticResource SelectedListItemForeground}" />
                         </Trigger>
                         <!--<MultiTrigger>
 								<MultiTrigger.Conditions>
@@ -2809,184 +3134,213 @@
 							</MultiTrigger>-->
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
-                                <Condition Property="IsMouseOver" Value="true"/>
-                                <Condition Property="IsSelected" Value="false"/>
+                                <Condition Property="IsMouseOver" Value="true" />
+                                <Condition Property="IsSelected" Value="false" />
                             </MultiTrigger.Conditions>
-                            <Setter Property="Background" TargetName="Bd" Value="{StaticResource MouseOverListItem}"/>
+                            <Setter TargetName="Bd" Property="Background" Value="{StaticResource MouseOverListItem}" />
                         </MultiTrigger>
                         <Trigger Property="IsEnabled" Value="false">
-                            <Setter Property="Foreground" Value="{StaticResource DisabledMenuForeground}"/>
+                            <Setter Property="Foreground" Value="{StaticResource DisabledMenuForeground}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
-    
-    <!-- GroupBox -->
-    <BorderGapMaskConverter x:Key="BorderGapMaskConverter"/>
+
+    <!--  GroupBox  -->
+    <BorderGapMaskConverter x:Key="BorderGapMaskConverter" />
     <Style TargetType="{x:Type GroupBox}">
-        <Setter Property="BorderBrush" Value="Transparent"/>
-        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}"/>
-        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="BorderBrush" Value="Transparent" />
+        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}" />
+        <Setter Property="BorderThickness" Value="1" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type GroupBox}">
                     <Grid SnapsToDevicePixels="true">
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="6"/>
-                            <ColumnDefinition Width="Auto"/>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="6"/>
+                            <ColumnDefinition Width="6" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="6" />
                         </Grid.ColumnDefinitions>
                         <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="*"/>
-                            <RowDefinition Height="6"/>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="6" />
                         </Grid.RowDefinitions>
-                        <Border BorderBrush="Transparent"
-                                    BorderThickness="{TemplateBinding BorderThickness}"
-                                    Background="{TemplateBinding Background}"
-                                    Grid.ColumnSpan="4" 
-                                    Grid.Column="0"
-                                    CornerRadius="3"
-                                    Grid.Row="1"
-                                    Grid.RowSpan="3">
+                        <Border
+                            Grid.Row="1"
+                            Grid.RowSpan="3"
+                            Grid.Column="0"
+                            Grid.ColumnSpan="4"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="Transparent"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="3">
                             <!--<Border Grid.ColumnSpan="4"
 									CornerRadius="3"
 									Grid.Row="1"
 									Grid.RowSpan="3">-->
                             <Border.OpacityMask>
-                                <MultiBinding ConverterParameter="7" Converter="{StaticResource BorderGapMaskConverter}">
-                                    <Binding ElementName="Header" Path="ActualWidth"/>
-                                    <Binding Path="ActualWidth" RelativeSource="{RelativeSource Self}"/>
-                                    <Binding Path="ActualHeight" RelativeSource="{RelativeSource Self}"/>
+                                <MultiBinding Converter="{StaticResource BorderGapMaskConverter}" ConverterParameter="7">
+                                    <Binding ElementName="Header" Path="ActualWidth" />
+                                    <Binding Path="ActualWidth" RelativeSource="{RelativeSource Self}" />
+                                    <Binding Path="ActualHeight" RelativeSource="{RelativeSource Self}" />
                                 </MultiBinding>
                             </Border.OpacityMask>
-                            <Border BorderBrush="{TemplateBinding BorderBrush}"
-										BorderThickness="{TemplateBinding BorderThickness}"
-										CornerRadius="3">
+                            <Border
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="3">
                                 <!--<Border BorderBrush="White"
 											BorderThickness="{TemplateBinding BorderThickness}"
 											CornerRadius="4"/>-->
                             </Border>
                         </Border>
-                        <Border x:Name="Header"
-									Grid.Column="1"
-									Padding="3,1,3,0"
-									Grid.Row="0"
-									Grid.RowSpan="2">
-                            <ContentPresenter ContentSource="Header"
-													RecognizesAccessKey="True"
-													SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                        <Border
+                            x:Name="Header"
+                            Grid.Row="0"
+                            Grid.RowSpan="2"
+                            Grid.Column="1"
+                            Padding="3,1,3,0">
+                            <ContentPresenter
+                                ContentSource="Header"
+                                RecognizesAccessKey="True"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         </Border>
-                        <ContentPresenter Grid.ColumnSpan="2"
-												Grid.Column="1"
-												Margin="{TemplateBinding Padding}"
-												Grid.Row="2"
-												SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                        <ContentPresenter
+                            Grid.Row="2"
+                            Grid.Column="1"
+                            Grid.ColumnSpan="2"
+                            Margin="{TemplateBinding Padding}"
+                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
-    
-    <!-- DataGrid styles -->
-    
-    <!-- DataGridSelectAllButtonStyle -->
+
+    <!--  DataGrid styles  -->
+
+    <!--  DataGridSelectAllButtonStyle  -->
     <Style x:Key="{ComponentResourceKey ResourceId=DataGridSelectAllButtonStyle, TypeInTargetAssembly={x:Type DataGrid}}" TargetType="{x:Type Button}">
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Button}">
                     <Grid>
-                        <Rectangle x:Name="Border" Fill="{StaticResource DataGridHeaderBackgroundBrush}"
-                                   SnapsToDevicePixels="True"/>
-                        <Polygon x:Name="Arrow" Fill="Black" HorizontalAlignment="Right" Margin="8,8,3,3"
-                                 Opacity="0.15" Points="0,10 10,10 10,0" Stretch="Uniform" VerticalAlignment="Bottom"/>
+                        <Rectangle
+                            x:Name="Border"
+                            Fill="{StaticResource DataGridHeaderBackgroundBrush}"
+                            SnapsToDevicePixels="True" />
+                        <Polygon
+                            x:Name="Arrow"
+                            Margin="8,8,3,3"
+                            HorizontalAlignment="Right"
+                            VerticalAlignment="Bottom"
+                            Fill="Black"
+                            Opacity="0.15"
+                            Points="0,10 10,10 10,0"
+                            Stretch="Uniform" />
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter Property="Stroke" TargetName="Border" Value="{StaticResource DataGridHeaderMouseOverBrush}"/>
+                            <Setter TargetName="Border" Property="Stroke" Value="{StaticResource DataGridHeaderMouseOverBrush}" />
                         </Trigger>
                         <Trigger Property="IsPressed" Value="True">
-                            <Setter Property="Fill" TargetName="Border" Value="{StaticResource DataGridHeaderMouseOverBrush}"/>
+                            <Setter TargetName="Border" Property="Fill" Value="{StaticResource DataGridHeaderMouseOverBrush}" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
-                            <Setter Property="Visibility" TargetName="Arrow" Value="Collapsed"/>
+                            <Setter TargetName="Arrow" Property="Visibility" Value="Collapsed" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
-    
-    <!-- DataGrid -->
+
+    <!--  DataGrid  -->
     <Style TargetType="{x:Type DataGrid}">
         <Setter Property="RowHeight" Value="22" />
-        <Setter Property="HorizontalGridLinesBrush" Value="{DynamicResource GridLinesBrush}"/>
-        <Setter Property="VerticalGridLinesBrush" Value="{DynamicResource GridLinesBrush}"/>
-        <Setter Property="Background" Value="{DynamicResource DataGridBackgroundBrush}"/>
-        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
-        <Setter Property="BorderBrush" Value="{DynamicResource DataGridHeaderBorderBrush}"/>
-        <Setter Property="BorderThickness" Value="1"/>
-        <Setter Property="RowDetailsVisibilityMode" Value="VisibleWhenSelected"/>
-        <Setter Property="ScrollViewer.CanContentScroll" Value="true"/>
-        <Setter Property="ScrollViewer.PanningMode" Value="Both"/>
-        <Setter Property="Stylus.IsFlicksEnabled" Value="False"/>
+        <Setter Property="HorizontalGridLinesBrush" Value="{DynamicResource GridLinesBrush}" />
+        <Setter Property="VerticalGridLinesBrush" Value="{DynamicResource GridLinesBrush}" />
+        <Setter Property="Background" Value="{DynamicResource DataGridBackgroundBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource DataGridHeaderBorderBrush}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="RowDetailsVisibilityMode" Value="VisibleWhenSelected" />
+        <Setter Property="ScrollViewer.CanContentScroll" Value="true" />
+        <Setter Property="ScrollViewer.PanningMode" Value="Both" />
+        <Setter Property="Stylus.IsFlicksEnabled" Value="False" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type DataGrid}">
-                    <Border BorderBrush="{TemplateBinding BorderBrush}"
-								BorderThickness="{TemplateBinding BorderThickness}"
-								Background="{TemplateBinding Background}"
-								Padding="{TemplateBinding Padding}"
-								SnapsToDevicePixels="True">
+                    <Border
+                        Padding="{TemplateBinding Padding}"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        SnapsToDevicePixels="True">
                         <ScrollViewer x:Name="DG_ScrollViewer" Focusable="false">
                             <ScrollViewer.Template>
                                 <ControlTemplate TargetType="{x:Type ScrollViewer}">
                                     <Grid>
                                         <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="Auto"/>
-                                            <ColumnDefinition Width="*"/>
-                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="Auto" />
                                         </Grid.ColumnDefinitions>
                                         <Grid.RowDefinitions>
-                                            <RowDefinition Height="Auto"/>
-                                            <RowDefinition Height="*"/>
-                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto" />
+                                            <RowDefinition Height="*" />
+                                            <RowDefinition Height="Auto" />
                                         </Grid.RowDefinitions>
-                                        <Button Command="{x:Static DataGrid.SelectAllCommand}"
-    											Focusable="false"
-    											Style="{DynamicResource {ComponentResourceKey ResourceId=DataGridSelectAllButtonStyle, TypeInTargetAssembly={x:Type DataGrid}}}"
-    											Visibility="{Binding HeadersVisibility, ConverterParameter={x:Static DataGridHeadersVisibility.All}, Converter={x:Static DataGrid.HeadersVisibilityConverter}, RelativeSource={RelativeSource AncestorType={x:Type DataGrid}}}"
-    											Width="{Binding CellsPanelHorizontalOffset, RelativeSource={RelativeSource AncestorType={x:Type DataGrid}}}"/>
-                                        <DataGridColumnHeadersPresenter x:Name="PART_ColumnHeadersPresenter"
-    											Grid.Column="1"
-    											Visibility="{Binding HeadersVisibility, ConverterParameter={x:Static DataGridHeadersVisibility.Column}, Converter={x:Static DataGrid.HeadersVisibilityConverter}, RelativeSource={RelativeSource AncestorType={x:Type DataGrid}}}"/>
-                                        <ScrollContentPresenter x:Name="PART_ScrollContentPresenter"
-    											CanContentScroll="{TemplateBinding CanContentScroll}"
-    											Grid.ColumnSpan="2" Grid.Row="1"/>
-                                        <ScrollBar x:Name="PART_VerticalScrollBar" Grid.Column="2" Maximum="{TemplateBinding ScrollableHeight}"
-    											Orientation="Vertical" Grid.Row="1"
-    											Visibility="{TemplateBinding ComputedVerticalScrollBarVisibility}"
-    											Value="{Binding VerticalOffset, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}"
-    											ViewportSize="{TemplateBinding ViewportHeight}"
-    											Style="{StaticResource VerticalScrollBarStyle}"/>
-                                        <Grid Grid.Column="1" Grid.Row="2">
+                                        <Button
+                                            Width="{Binding CellsPanelHorizontalOffset, RelativeSource={RelativeSource AncestorType={x:Type DataGrid}}}"
+                                            Command="{x:Static DataGrid.SelectAllCommand}"
+                                            Focusable="false"
+                                            Style="{DynamicResource {ComponentResourceKey ResourceId=DataGridSelectAllButtonStyle,
+                                                                                          TypeInTargetAssembly={x:Type DataGrid}}}"
+                                            Visibility="{Binding HeadersVisibility, ConverterParameter={x:Static DataGridHeadersVisibility.All}, Converter={x:Static DataGrid.HeadersVisibilityConverter}, RelativeSource={RelativeSource AncestorType={x:Type DataGrid}}}" />
+                                        <DataGridColumnHeadersPresenter
+                                            x:Name="PART_ColumnHeadersPresenter"
+                                            Grid.Column="1"
+                                            Visibility="{Binding HeadersVisibility, ConverterParameter={x:Static DataGridHeadersVisibility.Column}, Converter={x:Static DataGrid.HeadersVisibilityConverter}, RelativeSource={RelativeSource AncestorType={x:Type DataGrid}}}" />
+                                        <ScrollContentPresenter
+                                            x:Name="PART_ScrollContentPresenter"
+                                            Grid.Row="1"
+                                            Grid.ColumnSpan="2"
+                                            CanContentScroll="{TemplateBinding CanContentScroll}" />
+                                        <ScrollBar
+                                            x:Name="PART_VerticalScrollBar"
+                                            Grid.Row="1"
+                                            Grid.Column="2"
+                                            Maximum="{TemplateBinding ScrollableHeight}"
+                                            Orientation="Vertical"
+                                            Style="{StaticResource VerticalScrollBarStyle}"
+                                            ViewportSize="{TemplateBinding ViewportHeight}"
+                                            Visibility="{TemplateBinding ComputedVerticalScrollBarVisibility}"
+                                            Value="{Binding VerticalOffset, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}" />
+                                        <Grid Grid.Row="2" Grid.Column="1">
                                             <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="{Binding NonFrozenColumnsViewportHorizontalOffset, RelativeSource={RelativeSource AncestorType={x:Type DataGrid}}}"/>
-                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="{Binding NonFrozenColumnsViewportHorizontalOffset, RelativeSource={RelativeSource AncestorType={x:Type DataGrid}}}" />
+                                                <ColumnDefinition Width="*" />
                                             </Grid.ColumnDefinitions>
-                                            <ScrollBar x:Name="PART_HorizontalScrollBar" Grid.Column="1" Maximum="{TemplateBinding ScrollableWidth}"
-    												Orientation="Horizontal" Visibility="{TemplateBinding ComputedHorizontalScrollBarVisibility}"
-    												Value="{Binding HorizontalOffset, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}"
-    												ViewportSize="{TemplateBinding ViewportWidth}" Style="{StaticResource HorisontalScrollBarStyle}"/>
+                                            <ScrollBar
+                                                x:Name="PART_HorizontalScrollBar"
+                                                Grid.Column="1"
+                                                Maximum="{TemplateBinding ScrollableWidth}"
+                                                Orientation="Horizontal"
+                                                Style="{StaticResource HorisontalScrollBarStyle}"
+                                                ViewportSize="{TemplateBinding ViewportWidth}"
+                                                Visibility="{TemplateBinding ComputedHorizontalScrollBarVisibility}"
+                                                Value="{Binding HorizontalOffset, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}" />
                                         </Grid>
                                     </Grid>
                                 </ControlTemplate>
                             </ScrollViewer.Template>
-                            <ItemsPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                            <ItemsPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         </ScrollViewer>
                     </Border>
                 </ControlTemplate>
@@ -2995,116 +3349,131 @@
         <Style.Triggers>
             <MultiTrigger>
                 <MultiTrigger.Conditions>
-                    <Condition Property="IsGrouping" Value="true"/>
+                    <Condition Property="IsGrouping" Value="true" />
                     <!--<Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false"/>-->
                 </MultiTrigger.Conditions>
-                <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
+                <Setter Property="ScrollViewer.CanContentScroll" Value="false" />
             </MultiTrigger>
         </Style.Triggers>
     </Style>
-    
-    <!-- ColumnHeaderGripperStyle -->
+
+    <!--  ColumnHeaderGripperStyle  -->
     <Style x:Key="ColumnHeaderGripperStyle" TargetType="{x:Type Thumb}">
-        <Setter Property="Width" Value="8"/>
-        <Setter Property="Background" Value="Transparent"/>
-        <Setter Property="Cursor" Value="SizeWE"/>
+        <Setter Property="Width" Value="8" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="Cursor" Value="SizeWE" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Thumb}">
-                    <Border Background="{TemplateBinding Background}" Padding="{TemplateBinding Padding}"/>
+                    <Border Padding="{TemplateBinding Padding}" Background="{TemplateBinding Background}" />
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
-    
-    <!-- DataGridColumnHeader -->
+
+    <!--  DataGridColumnHeader  -->
     <Style TargetType="{x:Type DataGridColumnHeader}">
-        <Setter Property="VerticalContentAlignment" Value="Center"/>
-        <Setter Property="BorderThickness" Value="1 1 0 1"/>
-        <Setter Property="BorderBrush" Value="{DynamicResource DataGridHeaderBorderBrush}"/>
-        <Setter Property="Background" Value="{DynamicResource DataGridHeaderBackgroundBrush}"/>
-        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
-        <Setter Property="Padding" Value="3"/>
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="BorderThickness" Value="1,1,0,1" />
+        <Setter Property="BorderBrush" Value="{DynamicResource DataGridHeaderBorderBrush}" />
+        <Setter Property="Background" Value="{DynamicResource DataGridHeaderBackgroundBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}" />
+        <Setter Property="Padding" Value="3" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type DataGridColumnHeader}">
                     <Grid>
-                        <Border BorderBrush="{TemplateBinding BorderBrush}"
-														 BorderThickness="{TemplateBinding BorderThickness}"
-														 Background="{TemplateBinding Background}"
-														 Padding="{TemplateBinding Padding}">
-                            <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                              RecognizesAccessKey="True"
-                                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                        <Border
+                            Padding="{TemplateBinding Padding}"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}">
+                            <ContentPresenter
+                                HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                RecognizesAccessKey="True"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         </Border>
-                        <Thumb x:Name="PART_LeftHeaderGripper" HorizontalAlignment="Left"
-									Style="{StaticResource ColumnHeaderGripperStyle}"/>
-                        <Thumb x:Name="PART_RightHeaderGripper" HorizontalAlignment="Right" 
-									Style="{StaticResource ColumnHeaderGripperStyle}"/>
+                        <Thumb
+                            x:Name="PART_LeftHeaderGripper"
+                            HorizontalAlignment="Left"
+                            Style="{StaticResource ColumnHeaderGripperStyle}" />
+                        <Thumb
+                            x:Name="PART_RightHeaderGripper"
+                            HorizontalAlignment="Right"
+                            Style="{StaticResource ColumnHeaderGripperStyle}" />
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter Property="Background" Value="{StaticResource DataGridHeaderMouseOverBrush}"/>
-                            <Setter Property="Foreground" Value="Black"/>
+                            <Setter Property="Background" Value="{StaticResource DataGridHeaderMouseOverBrush}" />
+                            <Setter Property="Foreground" Value="Black" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
-    
-    <!-- DataGridRow -->
+
+    <!--  DataGridRow  -->
     <Style TargetType="{x:Type DataGridRow}">
-        <Setter Property="Background" Value="{DynamicResource DataGridRowBackgroundBrush}"/>
-        <Setter Property="SnapsToDevicePixels" Value="true"/>
-        <Setter Property="Padding" Value="0"/>
-        <Setter Property="BorderBrush" Value="Transparent"/>
-        <Setter Property="Border.CornerRadius" Value="3"/>
-        <Setter Property="Validation.ErrorTemplate" Value="{x:Null}"/>
+        <Setter Property="Background" Value="{DynamicResource DataGridRowBackgroundBrush}" />
+        <Setter Property="SnapsToDevicePixels" Value="true" />
+        <Setter Property="Padding" Value="0" />
+        <Setter Property="BorderBrush" Value="Transparent" />
+        <Setter Property="Border.CornerRadius" Value="3" />
+        <Setter Property="Validation.ErrorTemplate" Value="{x:Null}" />
         <Setter Property="ValidationErrorTemplate">
             <Setter.Value>
                 <ControlTemplate>
-                    <TextBlock Foreground="Red" Margin="2,0,0,0" Text="!" VerticalAlignment="Center"/>
+                    <TextBlock
+                        Margin="2,0,0,0"
+                        VerticalAlignment="Center"
+                        Foreground="Red"
+                        Text="!" />
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type DataGridRow}">
-                    <Border x:Name="DGR_Border"
-                            BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="0"
-                            Background="{TemplateBinding Background}"
-                            CornerRadius="{TemplateBinding Border.CornerRadius}"
-                            SnapsToDevicePixels="True">
+                    <Border
+                        x:Name="DGR_Border"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="0"
+                        CornerRadius="{TemplateBinding Border.CornerRadius}"
+                        SnapsToDevicePixels="True">
                         <SelectiveScrollingGrid>
                             <SelectiveScrollingGrid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto"/>
-                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="*" />
                             </SelectiveScrollingGrid.ColumnDefinitions>
                             <SelectiveScrollingGrid.RowDefinitions>
-                                <RowDefinition Height="*"/>
-                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="*" />
+                                <RowDefinition Height="Auto" />
                             </SelectiveScrollingGrid.RowDefinitions>
-                            <DataGridCellsPresenter Grid.Column="1"
-                                                    ItemsPanel="{TemplateBinding ItemsPanel}"
-                                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                            <DataGridDetailsPresenter Grid.Column="1" Grid.Row="1"
-                                                      SelectiveScrollingGrid.SelectiveScrollingOrientation="{Binding AreRowDetailsFrozen, ConverterParameter={x:Static SelectiveScrollingOrientation.Vertical}, Converter={x:Static DataGrid.RowDetailsScrollingConverter}, RelativeSource={RelativeSource AncestorType={x:Type DataGrid}}}"
-													  Visibility="{TemplateBinding DetailsVisibility}"/>
-                            <DataGridRowHeader Grid.RowSpan="2"
-                                               SelectiveScrollingGrid.SelectiveScrollingOrientation="Vertical"
-                                               Visibility="{Binding HeadersVisibility, ConverterParameter={x:Static DataGridHeadersVisibility.Row}, Converter={x:Static DataGrid.HeadersVisibilityConverter}, RelativeSource={RelativeSource AncestorType={x:Type DataGrid}}}" />
+                            <DataGridCellsPresenter
+                                Grid.Column="1"
+                                ItemsPanel="{TemplateBinding ItemsPanel}"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                            <DataGridDetailsPresenter
+                                Grid.Row="1"
+                                Grid.Column="1"
+                                SelectiveScrollingGrid.SelectiveScrollingOrientation="{Binding AreRowDetailsFrozen, ConverterParameter={x:Static SelectiveScrollingOrientation.Vertical}, Converter={x:Static DataGrid.RowDetailsScrollingConverter}, RelativeSource={RelativeSource AncestorType={x:Type DataGrid}}}"
+                                Visibility="{TemplateBinding DetailsVisibility}" />
+                            <DataGridRowHeader
+                                Grid.RowSpan="2"
+                                SelectiveScrollingGrid.SelectiveScrollingOrientation="Vertical"
+                                Visibility="{Binding HeadersVisibility, ConverterParameter={x:Static DataGridHeadersVisibility.Row}, Converter={x:Static DataGrid.HeadersVisibilityConverter}, RelativeSource={RelativeSource AncestorType={x:Type DataGrid}}}" />
                         </SelectiveScrollingGrid>
                     </Border>
                     <ControlTemplate.Triggers>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
-                                <Condition Property="IsMouseOver" Value="true"/>
-                                <Condition Property="IsSelected" Value="false"/>
+                                <Condition Property="IsMouseOver" Value="true" />
+                                <Condition Property="IsSelected" Value="false" />
                             </MultiTrigger.Conditions>
-                            <Setter Property="Background" TargetName="DGR_Border" Value="{StaticResource MouseOverListItem}"/>
+                            <Setter TargetName="DGR_Border" Property="Background" Value="{StaticResource MouseOverListItem}" />
                         </MultiTrigger>
                         <Trigger Property="IsSelected" Value="True">
                             <Setter TargetName="DGR_Border" Property="Background" Value="{StaticResource DataGridRowSelectedBrush}" />
@@ -3116,96 +3485,107 @@
         </Setter>
         <Style.Triggers>
             <Trigger Property="IsNewItem" Value="True">
-                <Setter Property="Margin" Value="{Binding NewItemMargin, RelativeSource={RelativeSource AncestorType={x:Type DataGrid}}}"/>
+                <Setter Property="Margin" Value="{Binding NewItemMargin, RelativeSource={RelativeSource AncestorType={x:Type DataGrid}}}" />
             </Trigger>
             <Trigger Property="IsSelected" Value="True">
-                <Setter Property="Background" Value="{DynamicResource DataGridRowSelectedBrush}"/>
-                <Setter Property="Foreground" Value="Black"/>
+                <Setter Property="Background" Value="{DynamicResource DataGridRowSelectedBrush}" />
+                <Setter Property="Foreground" Value="Black" />
             </Trigger>
         </Style.Triggers>
     </Style>
-    
-    <!-- DataGridCell -->
+
+    <!--  DataGridCell  -->
     <Style TargetType="{x:Type DataGridCell}">
-        <Setter Property="Background" Value="Transparent"/>
-        <Setter Property="BorderBrush" Value="Transparent"/>
-        <Setter Property="BorderThickness" Value="0"/>
-        <Setter Property="Padding" Value="5,0,5,0"/>
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderBrush" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="Padding" Value="5,0,5,0" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type DataGridCell}">
-                    <Border x:Name="Border" BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness}"
-                            Background="{TemplateBinding Background}"
-                            SnapsToDevicePixels="True">
-                        <ContentPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-												VerticalAlignment="Center"
-												Margin="{TemplateBinding Padding}"/>
+                    <Border
+                        x:Name="Border"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        SnapsToDevicePixels="True">
+                        <ContentPresenter
+                            Margin="{TemplateBinding Padding}"
+                            VerticalAlignment="Center"
+                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                     </Border>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
         <Style.Triggers>
             <Trigger Property="IsSelected" Value="True">
-                <Setter Property="Background" Value="Transparent"/>
-                <Setter Property="Foreground" Value="Black"/>
-                <Setter Property="BorderBrush" Value="Transparent"/>
+                <Setter Property="Background" Value="Transparent" />
+                <Setter Property="Foreground" Value="Black" />
+                <Setter Property="BorderBrush" Value="Transparent" />
             </Trigger>
             <Trigger Property="IsKeyboardFocusWithin" Value="True">
-                <Setter Property="BorderBrush" Value="{DynamicResource {x:Static DataGrid.FocusBorderBrushKey}}"/>
+                <Setter Property="BorderBrush" Value="{DynamicResource {x:Static DataGrid.FocusBorderBrushKey}}" />
             </Trigger>
             <MultiTrigger>
                 <MultiTrigger.Conditions>
-                    <Condition Property="IsSelected" Value="true"/>
-                    <Condition Property="Selector.IsSelectionActive" Value="false"/>
+                    <Condition Property="IsSelected" Value="true" />
+                    <Condition Property="Selector.IsSelectionActive" Value="false" />
                 </MultiTrigger.Conditions>
-                <Setter Property="Background" Value="{StaticResource DataGridRowSelectedBrush}"/>
+                <Setter Property="Background" Value="{StaticResource DataGridRowSelectedBrush}" />
             </MultiTrigger>
             <Trigger Property="IsEnabled" Value="false">
-                <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+                <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" />
             </Trigger>
         </Style.Triggers>
     </Style>
-    
-    <!-- RowHeaderGripperStyle -->
+
+    <!--  RowHeaderGripperStyle  -->
     <Style x:Key="RowHeaderGripperStyle" TargetType="{x:Type Thumb}">
-        <Setter Property="Height" Value="8"/>
-        <Setter Property="Background" Value="Transparent"/>
-        <Setter Property="Cursor" Value="SizeNS"/>
+        <Setter Property="Height" Value="8" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="Cursor" Value="SizeNS" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Thumb}">
-                    <Border Background="{TemplateBinding Background}"
-								Padding="{TemplateBinding Padding}"/>
+                    <Border Padding="{TemplateBinding Padding}" Background="{TemplateBinding Background}" />
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
-    
-    <!-- DataGridRowHeader -->
+
+    <!--  DataGridRowHeader  -->
     <Style TargetType="{x:Type DataGridRowHeader}">
-        <Setter Property="Background" Value="{DynamicResource DataGridBackgroundBrush}"/>
-        <Setter Property="BorderBrush" Value="{DynamicResource DataGridBackgroundBrush}"/>
-        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="Background" Value="{DynamicResource DataGridBackgroundBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource DataGridBackgroundBrush}" />
+        <Setter Property="BorderThickness" Value="1" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type DataGridRowHeader}">
                     <Grid>
-                        <Border BorderBrush="{TemplateBinding BorderBrush}"
-                                BorderThickness="{TemplateBinding BorderThickness}"
-                                Background="{TemplateBinding Background}"
-                                Padding="{TemplateBinding Padding}">
+                        <Border
+                            Padding="{TemplateBinding Padding}"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}">
                             <StackPanel Orientation="Horizontal">
-                                <ContentPresenter RecognizesAccessKey="True"
-                                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                                  VerticalAlignment="Center"/>
-                                <Control SnapsToDevicePixels="false"
-                                         Template="{Binding ValidationErrorTemplate, RelativeSource={RelativeSource AncestorType={x:Type DataGridRow}}}"
-                                         Visibility="{Binding (Validation.HasError), Converter={StaticResource bool2VisibilityConverter}, RelativeSource={RelativeSource AncestorType={x:Type DataGridRow}}}"/>
+                                <ContentPresenter
+                                    VerticalAlignment="Center"
+                                    RecognizesAccessKey="True"
+                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                                <Control
+                                    SnapsToDevicePixels="false"
+                                    Template="{Binding ValidationErrorTemplate, RelativeSource={RelativeSource AncestorType={x:Type DataGridRow}}}"
+                                    Visibility="{Binding (Validation.HasError), Converter={StaticResource bool2VisibilityConverter}, RelativeSource={RelativeSource AncestorType={x:Type DataGridRow}}}" />
                             </StackPanel>
                         </Border>
-                        <Thumb x:Name="PART_TopHeaderGripper" Style="{StaticResource RowHeaderGripperStyle}" VerticalAlignment="Top"/>
-                        <Thumb x:Name="PART_BottomHeaderGripper" Style="{StaticResource RowHeaderGripperStyle}" VerticalAlignment="Bottom"/>
+                        <Thumb
+                            x:Name="PART_TopHeaderGripper"
+                            VerticalAlignment="Top"
+                            Style="{StaticResource RowHeaderGripperStyle}" />
+                        <Thumb
+                            x:Name="PART_BottomHeaderGripper"
+                            VerticalAlignment="Bottom"
+                            Style="{StaticResource RowHeaderGripperStyle}" />
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>

--- a/Wabbajack/View Models/Compilers/MO2CompilerVM.cs
+++ b/Wabbajack/View Models/Compilers/MO2CompilerVM.cs
@@ -40,13 +40,13 @@ namespace Wabbajack
         {
             this.ModlistLocation = new FilePickerVM()
             {
-                DoExistsCheck = true,
+                ExistCheckOption = FilePickerVM.ExistCheckOptions.On,
                 PathType = FilePickerVM.PathTypeOptions.File,
                 PromptTitle = "Select Modlist"
             };
             this.DownloadLocation = new FilePickerVM()
             {
-                DoExistsCheck = true,
+                ExistCheckOption = FilePickerVM.ExistCheckOptions.On,
                 PathType = FilePickerVM.PathTypeOptions.Folder,
                 PromptTitle = "Select Download Location",
             };

--- a/Wabbajack/View Models/Compilers/ModlistSettingsEditorVM.cs
+++ b/Wabbajack/View Models/Compilers/ModlistSettingsEditorVM.cs
@@ -36,7 +36,7 @@ namespace Wabbajack
             this.settings = settings;
             this.ImagePath = new FilePickerVM()
             {
-                DoExistsCheck = false,
+                ExistCheckOption = FilePickerVM.ExistCheckOptions.IfNotEmpty,
                 PathType = FilePickerVM.PathTypeOptions.File,
                 Filters =
                 {
@@ -46,7 +46,7 @@ namespace Wabbajack
             this.ReadMeText = new FilePickerVM()
             {
                 PathType = FilePickerVM.PathTypeOptions.File,
-                DoExistsCheck = false,
+                ExistCheckOption = FilePickerVM.ExistCheckOptions.IfNotEmpty,
             };
         }
 

--- a/Wabbajack/View Models/Compilers/VortexCompilerVM.cs
+++ b/Wabbajack/View Models/Compilers/VortexCompilerVM.cs
@@ -53,19 +53,19 @@ namespace Wabbajack
         {
             this.GameLocation = new FilePickerVM()
             {
-                DoExistsCheck = true,
+                ExistCheckOption = FilePickerVM.ExistCheckOptions.On,
                 PathType = FilePickerVM.PathTypeOptions.Folder,
                 PromptTitle = "Select Game Folder Location"
             };
             this.DownloadsLocation = new FilePickerVM()
             {
-                DoExistsCheck = true,
+                ExistCheckOption = FilePickerVM.ExistCheckOptions.On,
                 PathType = FilePickerVM.PathTypeOptions.Folder,
                 PromptTitle = "Select Downloads Folder"
             };
             this.StagingLocation = new FilePickerVM()
             {
-                DoExistsCheck = true,
+                ExistCheckOption = FilePickerVM.ExistCheckOptions.On,
                 PathType = FilePickerVM.PathTypeOptions.Folder,
                 PromptTitle = "Select Staging Folder"
             };

--- a/Wabbajack/View Models/InstallerVM.cs
+++ b/Wabbajack/View Models/InstallerVM.cs
@@ -99,7 +99,7 @@ namespace Wabbajack
 
             this.Location = new FilePickerVM()
             {
-                DoExistsCheck = false,
+                ExistCheckOption = FilePickerVM.ExistCheckOptions.Off,
                 PathType = FilePickerVM.PathTypeOptions.Folder,
                 PromptTitle = "Select Installation Directory",
             };
@@ -107,7 +107,7 @@ namespace Wabbajack
                 .Select(x => Utils.IsDirectoryPathValid(x));
             this.DownloadLocation = new FilePickerVM()
             {
-                DoExistsCheck = false,
+                ExistCheckOption = FilePickerVM.ExistCheckOptions.Off,
                 PathType = FilePickerVM.PathTypeOptions.Folder,
                 PromptTitle = "Select a location for MO2 downloads",
             };

--- a/Wabbajack/Views/Common/DetailImageView.xaml
+++ b/Wabbajack/Views/Common/DetailImageView.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl
+﻿<local:UserControlRx
     x:Class="Wabbajack.DetailImageView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -97,7 +97,8 @@
             FontWeight="Bold"
             Style="{StaticResource BackgroundBlurStyle}"
             Text="{Binding Title, Mode=OneWay, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}}"
-            TextWrapping="WrapWithOverflow">
+            TextWrapping="WrapWithOverflow"
+            Visibility="{Binding ShowTitle, Mode=OneWay, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}, Converter={StaticResource bool2VisibilityHiddenConverter}}">
             <TextBlock.Effect>
                 <BlurEffect Radius="85" />
             </TextBlock.Effect>
@@ -113,7 +114,8 @@
             FontSize="30"
             FontWeight="Bold"
             Style="{StaticResource BackgroundBlurStyle}"
-            TextWrapping="WrapWithOverflow">
+            TextWrapping="WrapWithOverflow"
+            Visibility="{Binding ShowAuthor, Mode=OneWay, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}, Converter={StaticResource bool2VisibilityHiddenConverter}}">
             <TextBlock.Effect>
                 <BlurEffect Radius="55" />
             </TextBlock.Effect>
@@ -130,7 +132,8 @@
             FontSize="65"
             FontWeight="Bold"
             Text="{Binding Title, Mode=OneWay, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}}"
-            TextWrapping="WrapWithOverflow">
+            TextWrapping="WrapWithOverflow"
+            Visibility="{Binding ShowTitle, Mode=OneWay, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}, Converter={StaticResource bool2VisibilityHiddenConverter}}">
             <TextBlock.Effect>
                 <DropShadowEffect />
             </TextBlock.Effect>
@@ -142,7 +145,8 @@
             FontFamily="Lucida Sans"
             FontSize="30"
             FontWeight="Bold"
-            TextWrapping="Wrap">
+            TextWrapping="Wrap"
+            Visibility="{Binding ShowAuthor, Mode=OneWay, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}, Converter={StaticResource bool2VisibilityHiddenConverter}}">
             <TextBlock.Effect>
                 <DropShadowEffect />
             </TextBlock.Effect>
@@ -163,7 +167,8 @@
             Style="{StaticResource BackgroundBlurStyle}"
             Text="{Binding Description, Mode=OneWay, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}}"
             TextAlignment="Right"
-            TextWrapping="Wrap">
+            TextWrapping="Wrap"
+            Visibility="{Binding ShowDescription, Mode=OneWay, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}, Converter={StaticResource bool2VisibilityHiddenConverter}}">
             <TextBlock.Effect>
                 <BlurEffect Radius="55" />
             </TextBlock.Effect>
@@ -179,7 +184,8 @@
             FontSize="16"
             Text="{Binding Description, Mode=OneWay, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}}"
             TextAlignment="Right"
-            TextWrapping="Wrap">
+            TextWrapping="Wrap"
+            Visibility="{Binding ShowDescription, Mode=OneWay, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}, Converter={StaticResource bool2VisibilityHiddenConverter}}">
             <TextBlock.Effect>
                 <DropShadowEffect />
             </TextBlock.Effect>
@@ -192,4 +198,4 @@
             Grid.ColumnSpan="2"
             Fill="Transparent" />
     </Grid>
-</UserControl>
+</local:UserControlRx>

--- a/Wabbajack/Views/Common/DetailImageView.xaml.cs
+++ b/Wabbajack/Views/Common/DetailImageView.xaml.cs
@@ -1,6 +1,8 @@
-﻿using System;
+﻿using ReactiveUI;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reactive.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
@@ -18,7 +20,7 @@ namespace Wabbajack
     /// <summary>
     /// Interaction logic for DetailImageView.xaml
     /// </summary>
-    public partial class DetailImageView : UserControl
+    public partial class DetailImageView : UserControlRx
     {
         public ImageSource Image
         {
@@ -42,7 +44,7 @@ namespace Wabbajack
             set => SetValue(TitleProperty, value);
         }
         public static readonly DependencyProperty TitleProperty = DependencyProperty.Register(nameof(Title), typeof(string), typeof(DetailImageView),
-             new FrameworkPropertyMetadata(default(string), FrameworkPropertyMetadataOptions.BindsTwoWayByDefault));
+             new FrameworkPropertyMetadata(default(string), FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, WireNotifyPropertyChanged));
 
         public string Author
         {
@@ -50,7 +52,7 @@ namespace Wabbajack
             set => SetValue(AuthorProperty, value);
         }
         public static readonly DependencyProperty AuthorProperty = DependencyProperty.Register(nameof(Author), typeof(string), typeof(DetailImageView),
-             new FrameworkPropertyMetadata(default(string), FrameworkPropertyMetadataOptions.BindsTwoWayByDefault));
+             new FrameworkPropertyMetadata(default(string), FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, WireNotifyPropertyChanged));
 
         public string Description
         {
@@ -58,11 +60,32 @@ namespace Wabbajack
             set => SetValue(DescriptionProperty, value);
         }
         public static readonly DependencyProperty DescriptionProperty = DependencyProperty.Register(nameof(Description), typeof(string), typeof(DetailImageView),
-             new FrameworkPropertyMetadata(default(string), FrameworkPropertyMetadataOptions.BindsTwoWayByDefault));
+             new FrameworkPropertyMetadata(default(string), FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, WireNotifyPropertyChanged));
+
+        private readonly ObservableAsPropertyHelper<bool> _ShowAuthor;
+        public bool ShowAuthor => _ShowAuthor.Value;
+
+        private readonly ObservableAsPropertyHelper<bool> _ShowDescription;
+        public bool ShowDescription => _ShowDescription.Value;
+
+        private readonly ObservableAsPropertyHelper<bool> _ShowTitle;
+        public bool ShowTitle => _ShowTitle.Value;
 
         public DetailImageView()
         {
             InitializeComponent();
+
+            this._ShowAuthor = this.WhenAny(x => x.Author)
+                .Select(x => !string.IsNullOrWhiteSpace(x))
+                .ToProperty(this, nameof(this.ShowAuthor));
+
+            this._ShowDescription = this.WhenAny(x => x.Description)
+                .Select(x => !string.IsNullOrWhiteSpace(x))
+                .ToProperty(this, nameof(this.ShowDescription));
+
+            this._ShowTitle = this.WhenAny(x => x.Title)
+                .Select(x => !string.IsNullOrWhiteSpace(x))
+                .ToProperty(this, nameof(this.ShowTitle));
         }
     }
 }

--- a/Wabbajack/Views/Common/FilePicker.xaml
+++ b/Wabbajack/Views/Common/FilePicker.xaml
@@ -10,36 +10,90 @@
     d:DesignWidth="400"
     BorderBrush="{StaticResource DarkBackgroundBrush}"
     mc:Ignorable="d">
-    <Grid>
+    <Grid ClipToBounds="True">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="36" />
         </Grid.ColumnDefinitions>
+        <Border
+            x:Name="BackgroundCornerFillIn"
+            Grid.Column="0"
+            Grid.ColumnSpan="2"
+            Margin="0,0,5,0"
+            Background="{StaticResource TextBoxBackground}"
+            CornerRadius="3" />
         <TextBox
             Grid.Column="0"
-            Margin="0,0,-4,0"
+            Margin="5,0,-2,0"
             VerticalContentAlignment="Center"
             Background="{StaticResource DarkBackgroundBrush}"
             Text="{Binding TargetPath, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
             Visibility="{Binding ShowTextBoxInput}" />
-        <icon:PackIconMaterial
-            Margin="0,4,4,4"
-            Padding="0,3"
-            HorizontalAlignment="Right"
-            VerticalAlignment="Center"
-            Foreground="{StaticResource WarningBrush}"
-            Kind="Circle"
-            ToolTip="{Binding ErrorTooltip}"
-            Visibility="{Binding InError, Converter={StaticResource bool2VisibilityConverter}}" />
-        <Button
-            Grid.Column="1"
-            Command="{Binding SetTargetPathCommand}"
-            ToolTip="Set target path">
-            <icon:PackIconMaterial
-                Width="16"
-                Height="12"
-                Margin="4"
-                Kind="DotsHorizontal" />
-        </Button>
+        <Grid Grid.Column="1" HorizontalAlignment="Right">
+            <Border
+                Margin="3,1,0,1"
+                HorizontalAlignment="Right"
+                Background="{StaticResource WarningBrush}"
+                CornerRadius="3"
+                ToolTip="{Binding ErrorTooltip}">
+                <Border.Style>
+                    <Style TargetType="Border">
+                        <Setter Property="Width" Value="25" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding InError}" Value="True">
+                                <DataTrigger.EnterActions>
+                                    <BeginStoryboard>
+                                        <Storyboard>
+                                            <DoubleAnimation
+                                                Storyboard.TargetProperty="Width"
+                                                To="33"
+                                                Duration="0:0:0.1">
+                                                <DoubleAnimation.EasingFunction>
+                                                    <ExponentialEase EasingMode="EaseOut" />
+                                                </DoubleAnimation.EasingFunction>
+                                            </DoubleAnimation>
+                                        </Storyboard>
+                                    </BeginStoryboard>
+                                </DataTrigger.EnterActions>
+                                <DataTrigger.ExitActions>
+                                    <BeginStoryboard>
+                                        <Storyboard>
+                                            <DoubleAnimation
+                                                Storyboard.TargetProperty="Width"
+                                                To="25"
+                                                Duration="0:0:0.1">
+                                                <DoubleAnimation.EasingFunction>
+                                                    <ExponentialEase EasingMode="EaseOut" />
+                                                </DoubleAnimation.EasingFunction>
+                                            </DoubleAnimation>
+                                        </Storyboard>
+                                    </BeginStoryboard>
+                                </DataTrigger.ExitActions>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Border.Style>
+            </Border>
+            <Border
+                Width="30"
+                HorizontalAlignment="Left"
+                Background="{StaticResource TextBoxBackground}"
+                CornerRadius="3">
+                <Button Command="{Binding SetTargetPathCommand}" ToolTip="Set target path">
+                    <icon:PackIconMaterial
+                        Width="16"
+                        Height="12"
+                        Margin="4"
+                        Kind="DotsHorizontal" />
+                </Button>
+                <Border.Effect>
+                    <DropShadowEffect
+                        BlurRadius="3"
+                        Direction="0"
+                        Opacity="0.5"
+                        ShadowDepth="2" />
+                </Border.Effect>
+            </Border>
+        </Grid>
     </Grid>
 </UserControl>

--- a/Wabbajack/Views/Common/FilePicker.xaml
+++ b/Wabbajack/Views/Common/FilePicker.xaml
@@ -24,7 +24,7 @@
             CornerRadius="3" />
         <TextBox
             Grid.Column="0"
-            Margin="5,0,-2,0"
+            Margin="5,1,-2,1"
             VerticalContentAlignment="Center"
             Background="{StaticResource DarkBackgroundBrush}"
             Text="{Binding TargetPath, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"

--- a/Wabbajack/Views/Compilers/CompilerView.xaml
+++ b/Wabbajack/Views/Compilers/CompilerView.xaml
@@ -85,7 +85,10 @@
                         <Setter Property="FontSize" Value="15" />
                         <Setter Property="Margin" Value="0,0,0,6" />
                     </Style>
-                    <Style x:Key="PickerStyle" TargetType="local:FilePicker">
+                    <Style
+                        x:Key="PickerStyle"
+                        BasedOn="{StaticResource MainFilePickerStyle}"
+                        TargetType="local:FilePicker">
                         <Setter Property="Margin" Value="0,0,0,6" />
                     </Style>
                 </StackPanel.Resources>

--- a/Wabbajack/Views/Compilers/VortexCompilerConfigView.xaml
+++ b/Wabbajack/Views/Compilers/VortexCompilerConfigView.xaml
@@ -46,7 +46,7 @@
             ToolTip="The game you wish to target">
             <ComboBox.ItemTemplate>
                 <DataTemplate>
-                    <TextBlock Text="{Binding DisplayName}" />
+                    <TextBlock Margin="6,2" Text="{Binding DisplayName}" />
                 </DataTemplate>
             </ComboBox.ItemTemplate>
         </ComboBox>


### PR DESCRIPTION
- Button Styling.  Teal border and glow on hover.  Slight teal tint on click.  Not amazing looking, but a little better.
- Resaved Styles.xaml /w the XAML formatter tool, just to get it standard so the tool can be used without accidentally remodifying the whole thing every time you touch it.
- Detail view (slideshow) shadows hide if there's no text
- FilePicker error display changed to pop out the side, instead of covering text as it was before
- FilePicker check exists if path not empty option.  Certain items should only be an error state if a path was attempted, but didn't exist.
- Minor margin adjustments