### PR TITLE
Clearer compiler interface

### DIFF
--- a/Wabbajack.Common/WorkQueue.cs
+++ b/Wabbajack.Common/WorkQueue.cs
@@ -23,17 +23,16 @@ namespace Wabbajack.Common
         private static readonly Subject<CPUStatus> _Status = new Subject<CPUStatus>();
         public IObservable<CPUStatus> Status => _Status;
 
-        public static int ThreadCount { get; } = Environment.ProcessorCount;
         public static List<Thread> Threads { get; private set; }
 
-        public WorkQueue()
+        public WorkQueue(int threadCount = 0)
         {
-            StartThreads();
+            StartThreads(threadCount == 0 ? Environment.ProcessorCount : threadCount);
         }
 
-        private void StartThreads()
+        private void StartThreads(int threadCount)
         {
-            Threads = Enumerable.Range(0, ThreadCount)
+            Threads = Enumerable.Range(0, threadCount)
                 .Select(idx =>
                 {
                     var thread = new Thread(() => ThreadBody(idx));

--- a/Wabbajack.Lib/ABatchProcessor.cs
+++ b/Wabbajack.Lib/ABatchProcessor.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reactive.Subjects;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using ReactiveUI;
+using Wabbajack.Common;
+using Wabbajack.VirtualFileSystem;
+
+namespace Wabbajack.Lib
+{
+    public abstract class ABatchProcessor : IBatchProcessor
+    {
+        public WorkQueue Queue { get; private set; }
+        private bool _configured = false;
+
+        public void Dispose()
+        {
+            Queue?.Shutdown();
+        }
+
+        public Context VFS { get; private set; }
+
+        protected StatusUpdateTracker UpdateTracker { get; private set; }
+
+        private Subject<float> _percentCompleted { get; set; } = new Subject<float>();
+
+        /// <summary>
+        /// The current progress of the entire processing system on a scale of 0.0 to 1.0
+        /// </summary>
+        public IObservable<float> PercentCompleted { get; }
+
+        private Subject<string> _textStatus { get; set; } = new Subject<string>();
+
+        /// <summary>
+        /// The current status of the processor as a text string
+        /// </summary>
+        public IObservable<string> TextStatus { get; }
+
+        private Subject<CPUStatus> _QueueStatus { get; set; } = new Subject<CPUStatus>();
+        public IObservable<CPUStatus> QueueStatus { get; }
+
+        private Subject<bool> _IsRunning { get; set; } = new Subject<bool>();
+        public IObservable<bool> IsRunning { get; }
+        
+        private Thread _processorThread { get; set; }
+
+        protected ABatchProcessor()
+        {
+            QueueStatus = _QueueStatus;
+        }
+
+        protected void ConfigureProcessor(int steps, int threads = 0)
+        {
+            if (_configured)
+                throw new InvalidDataException("Can't configure a processor twice");
+            Queue = new WorkQueue(threads);
+            UpdateTracker = new StatusUpdateTracker(steps);
+            Queue.Status.Subscribe(_QueueStatus);
+            UpdateTracker.Progress.Subscribe(_percentCompleted);
+            UpdateTracker.StepName.Subscribe(_textStatus);
+            VFS = new Context(Queue) { UpdateTracker = UpdateTracker };
+            _configured = true;
+        }
+
+        protected abstract bool _Begin();
+        public Task<bool> Begin()
+        {
+            _IsRunning.OnNext(true);
+            var _tcs = new TaskCompletionSource<bool>();
+            if (_processorThread != null)
+            {
+                throw new InvalidDataException("Can't start the processor twice");
+            }
+
+            _processorThread = new Thread(() =>
+            {
+                try
+                {
+                    _tcs.SetResult(_Begin());
+                }
+                catch (Exception ex)
+                {
+                    _tcs.SetException(ex);
+                }
+                finally
+                {
+                    _IsRunning.OnNext(false);
+                }
+            });
+            _processorThread.Priority = ThreadPriority.BelowNormal;
+            _processorThread.Start();
+            return _tcs.Task;
+        }
+
+        public void Terminate()
+        {
+            Queue?.Shutdown();
+            _processorThread?.Abort();
+            _IsRunning.OnNext(false);
+        }
+    }
+}

--- a/Wabbajack.Lib/ACompiler.cs
+++ b/Wabbajack.Lib/ACompiler.cs
@@ -17,14 +17,10 @@ using Path = Alphaleonis.Win32.Filesystem.Path;
 
 namespace Wabbajack.Lib
 {
-    public abstract class ACompiler
+    public abstract class ACompiler : ABatchProcessor
     {
         public string ModListName, ModListAuthor, ModListDescription, ModListImage, ModListWebsite, ModListReadme;
         public string WabbajackVersion;
-
-        public StatusUpdateTracker UpdateTracker { get; protected set; }
-
-        public WorkQueue Queue { get; protected set; }
 
         protected static string _vfsCacheName = "vfs_compile_cache.bin";
         /// <summary>
@@ -34,14 +30,14 @@ namespace Wabbajack.Lib
         public IObservable<(string, float)> ProgressUpdates => _progressUpdates;
         protected readonly Subject<(string, float)> _progressUpdates = new Subject<(string, float)>();
 
-        public Context VFS { get; internal set; }
-
         public ModManager ModManager;
 
         public string GamePath;
 
         public string ModListOutputFolder;
         public string ModListOutputFile;
+
+        public bool ShowReportWhenFinished { get; set; } = true;
 
         public List<Archive> SelectedArchives = new List<Archive>();
         public List<Directive> InstallDirectives = new List<Directive>();
@@ -128,7 +124,7 @@ namespace Wabbajack.Lib
 
         public void ShowReport()
         {
-            //if (!ShowReportWhenFinished) return;
+            if (!ShowReportWhenFinished) return;
 
             var file = Path.GetTempFileName() + ".html";
             File.WriteAllText(file, ModList.ReportHTML);
@@ -207,8 +203,6 @@ namespace Wabbajack.Lib
             return null;
         }
 
-        public abstract bool Compile();
-
         public Directive RunStack(IEnumerable<ICompilationStep> stack, RawSourceFile source)
         {
             Utils.Status($"Compiling {source.Path}");
@@ -223,11 +217,5 @@ namespace Wabbajack.Lib
 
         public abstract IEnumerable<ICompilationStep> GetStack();
         public abstract IEnumerable<ICompilationStep> MakeStack();
-
-        protected ACompiler()
-        {
-            ProgressUpdates.Subscribe(itm => Utils.Log($"{itm.Item2} - {itm.Item1}"));
-            Queue = new WorkQueue();
-        }
     }
 }

--- a/Wabbajack.Lib/AInstaller.cs
+++ b/Wabbajack.Lib/AInstaller.cs
@@ -12,13 +12,9 @@ using Path = Alphaleonis.Win32.Filesystem.Path;
 
 namespace Wabbajack.Lib
 {
-    public abstract class AInstaller
+    public abstract class AInstaller : ABatchProcessor
     {
         public bool IgnoreMissingFiles { get; internal set; } = false;
-
-        public StatusUpdateTracker UpdateTracker { get; protected set; }
-        public WorkQueue Queue { get; protected set; }
-        public Context VFS { get; internal set; }
 
         public string OutputFolder { get; set; }
         public string DownloadFolder { get; set; }
@@ -28,13 +24,6 @@ namespace Wabbajack.Lib
         public string ModListArchive { get; internal set; }
         public ModList ModList { get; internal set; }
         public Dictionary<string, string> HashedArchives { get; set; }
-
-        protected AInstaller()
-        {
-            Queue = new WorkQueue();
-        }
-
-        public abstract void Install();
 
         public void Info(string msg)
         {

--- a/Wabbajack.Lib/CompilationSteps/DeconstructBSAs.cs
+++ b/Wabbajack.Lib/CompilationSteps/DeconstructBSAs.cs
@@ -13,11 +13,11 @@ namespace Wabbajack.Lib.CompilationSteps
         private readonly IEnumerable<string> _include_directly;
         private readonly List<ICompilationStep> _microstack;
         private readonly List<ICompilationStep> _microstackWithInclude;
-        private readonly Compiler _mo2Compiler;
+        private readonly MO2Compiler _mo2Compiler;
 
         public DeconstructBSAs(ACompiler compiler) : base(compiler)
         {
-            _mo2Compiler = (Compiler) compiler;
+            _mo2Compiler = (MO2Compiler) compiler;
             _include_directly = _mo2Compiler.ModInis.Where(kv =>
                 {
                     var general = kv.Value.General;

--- a/Wabbajack.Lib/CompilationSteps/IgnoreDisabledMods.cs
+++ b/Wabbajack.Lib/CompilationSteps/IgnoreDisabledMods.cs
@@ -9,11 +9,11 @@ namespace Wabbajack.Lib.CompilationSteps
     public class IgnoreDisabledMods : ACompilationStep
     {
         private readonly IEnumerable<string> _allEnabledMods;
-        private readonly Compiler _mo2Compiler;
+        private readonly MO2Compiler _mo2Compiler;
 
         public IgnoreDisabledMods(ACompiler compiler) : base(compiler)
         {
-            _mo2Compiler = (Compiler) compiler;
+            _mo2Compiler = (MO2Compiler) compiler;
             var alwaysEnabled = _mo2Compiler.ModInis.Where(f => IsAlwaysEnabled(f.Value)).Select(f => f.Key).ToHashSet();
 
             _allEnabledMods = _mo2Compiler.SelectedProfiles

--- a/Wabbajack.Lib/CompilationSteps/IncludeOtherProfiles.cs
+++ b/Wabbajack.Lib/CompilationSteps/IncludeOtherProfiles.cs
@@ -8,11 +8,11 @@ namespace Wabbajack.Lib.CompilationSteps
     public class IgnoreOtherProfiles : ACompilationStep
     {
         private readonly IEnumerable<string> _profiles;
-        private readonly Compiler _mo2Compiler;
+        private readonly MO2Compiler _mo2Compiler;
 
         public IgnoreOtherProfiles(ACompiler compiler) : base(compiler)
         {
-            _mo2Compiler = (Compiler) compiler;
+            _mo2Compiler = (MO2Compiler) compiler;
 
                 _profiles = _mo2Compiler.SelectedProfiles
                 .Select(p => Path.Combine("profiles", p) + "\\")

--- a/Wabbajack.Lib/CompilationSteps/IncludeStubbedConfigfiles.cs
+++ b/Wabbajack.Lib/CompilationSteps/IncludeStubbedConfigfiles.cs
@@ -7,11 +7,11 @@ namespace Wabbajack.Lib.CompilationSteps
 {
     public class IncludeStubbedConfigFiles : ACompilationStep
     {
-        private readonly Compiler _mo2Compiler;
+        private readonly MO2Compiler _mo2Compiler;
 
         public IncludeStubbedConfigFiles(ACompiler compiler) : base(compiler)
         {
-            _mo2Compiler = (Compiler) compiler;
+            _mo2Compiler = (MO2Compiler) compiler;
         }
 
         public override Directive Run(RawSourceFile source)

--- a/Wabbajack.Lib/CompilationSteps/IncludeTaggedMods.cs
+++ b/Wabbajack.Lib/CompilationSteps/IncludeTaggedMods.cs
@@ -9,11 +9,11 @@ namespace Wabbajack.Lib.CompilationSteps
     {
         private readonly IEnumerable<string> _includeDirectly;
         private readonly string _tag;
-        private readonly Compiler _mo2Compiler;
+        private readonly MO2Compiler _mo2Compiler;
 
         public IncludeTaggedMods(ACompiler compiler, string tag) : base(compiler)
         {
-            _mo2Compiler = (Compiler) compiler;
+            _mo2Compiler = (MO2Compiler) compiler;
             _tag = tag;
             _includeDirectly = _mo2Compiler.ModInis.Where(kv =>
             {

--- a/Wabbajack.Lib/CompilationSteps/IncludeThisProfile.cs
+++ b/Wabbajack.Lib/CompilationSteps/IncludeThisProfile.cs
@@ -9,11 +9,11 @@ namespace Wabbajack.Lib.CompilationSteps
     public class IncludeThisProfile : ACompilationStep
     {
         private readonly IEnumerable<string> _correctProfiles;
-        private readonly Compiler _mo2Compiler;
+        private readonly MO2Compiler _mo2Compiler;
 
         public IncludeThisProfile(ACompiler compiler) : base(compiler)
         {
-            _mo2Compiler = (Compiler) compiler;
+            _mo2Compiler = (MO2Compiler) compiler;
             _correctProfiles = _mo2Compiler.SelectedProfiles.Select(p => Path.Combine("profiles", p) + "\\").ToList();
         }
 

--- a/Wabbajack.Lib/CompilationSteps/PatchStockESMs.cs
+++ b/Wabbajack.Lib/CompilationSteps/PatchStockESMs.cs
@@ -8,11 +8,11 @@ namespace Wabbajack.Lib.CompilationSteps
 {
     public class PatchStockESMs : ACompilationStep
     {
-        private readonly Compiler _mo2Compiler;
+        private readonly MO2Compiler _mo2Compiler;
 
         public PatchStockESMs(ACompiler compiler) : base(compiler)
         {
-            _mo2Compiler = (Compiler) compiler;
+            _mo2Compiler = (MO2Compiler) compiler;
         }
 
         public override Directive Run(RawSourceFile source)

--- a/Wabbajack.Lib/Compiler.cs
+++ b/Wabbajack.Lib/Compiler.cs
@@ -29,8 +29,6 @@ namespace Wabbajack.Lib
 
         public Compiler(string mo2_folder)
         {
-            UpdateTracker = new StatusUpdateTracker(10);
-            VFS = new Context(Queue) {UpdateTracker = UpdateTracker};
             ModManager = ModManager.MO2;
 
             MO2Folder = mo2_folder;
@@ -39,13 +37,9 @@ namespace Wabbajack.Lib
 
             ModListOutputFolder = "output_folder";
             ModListOutputFile = MO2Profile + ExtensionManager.Extension;
-            VFS.ProgressUpdates.Debounce(new TimeSpan(0, 0, 0, 0, 100))
-                .Subscribe(itm => _progressUpdates.OnNext(itm));
         }
 
         public dynamic MO2Ini { get; }
-
-        public bool ShowReportWhenFinished { get; set; } = true;
 
         public bool IgnoreMissingFiles { get; set; }
 
@@ -71,8 +65,9 @@ namespace Wabbajack.Lib
 
         public HashSet<string> SelectedProfiles { get; set; } = new HashSet<string>();
 
-        public override bool Compile()
+        protected override bool _Begin()
         {
+            ConfigureProcessor(10);
             UpdateTracker.Reset();
             UpdateTracker.NextStep("Gathering information");
             Info("Looking for other profiles");

--- a/Wabbajack.Lib/IBatchProcessor.cs
+++ b/Wabbajack.Lib/IBatchProcessor.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Wabbajack.Common;
+
+namespace Wabbajack.Lib
+{
+    /// <summary>
+    /// Wabbajack runs mostly as a batch processor of sorts, we have a list of tasks we need to perform
+    /// and the Compilers/Installers run throught those tasks one at a time. At any given moment the processor
+    /// will be using multiple threads to complete that task. This interface defines a common implementation of
+    /// all reporting functionality of both the compilers and installers.
+    ///
+    /// These processors are disposible because they contain WorkQueues which must be properly shutdown to keep
+    /// from leaking threads. 
+    /// </summary>
+    public interface IBatchProcessor : IDisposable
+    {
+        /// <summary>
+        /// The current progress of the entire processing system on a scale of 0.0 to 1.0
+        /// </summary>
+        IObservable<float> PercentCompleted { get; }
+
+        /// <summary>
+        /// The current status of the processor as a text string
+        /// </summary>
+        IObservable<string> TextStatus { get; }
+        
+        /// <summary>
+        /// The status of the processor's work queue
+        /// </summary>
+        IObservable<CPUStatus> QueueStatus { get; }
+
+        IObservable<bool> IsRunning { get; }
+
+        /// <summary>
+        /// Begin processing
+        /// </summary>
+        Task<bool> Begin();
+
+        /// <summary>
+        /// Terminate any processing currently in progress by the processor. The processor should be disposed of
+        /// after calling this function as processing cannot be resumed and the tasks may be half completed.
+        /// Should only be called while IsRunning = true;
+        /// </summary>
+        void Terminate();
+    }
+}

--- a/Wabbajack.Lib/Installer.cs
+++ b/Wabbajack.Lib/Installer.cs
@@ -19,8 +19,6 @@ namespace Wabbajack.Lib
     {
         public Installer(string archive, ModList mod_list, string output_folder)
         {
-            UpdateTracker = new StatusUpdateTracker(10);
-            VFS = new Context(Queue) {UpdateTracker = UpdateTracker};
             ModManager = ModManager.MO2;
             ModListArchive = archive;
             OutputFolder = output_folder;
@@ -30,8 +28,9 @@ namespace Wabbajack.Lib
 
         public string GameFolder { get; set; }
 
-        public override void Install()
+        protected override bool _Begin()
         {
+            ConfigureProcessor(10);
             var game = GameRegistry.Games[ModList.GameType];
 
             if (GameFolder == null)
@@ -44,7 +43,7 @@ namespace Wabbajack.Lib
                     "game location up in the windows registry but were unable to find it, please make sure you launch the game once before running this installer. ",
                     "Could not find game location", MessageBoxButton.OK);
                 Utils.Log("Exiting because we couldn't find the game folder.");
-                return;
+                return false;
             }
 
             ValidateGameESMs();
@@ -63,7 +62,7 @@ namespace Wabbajack.Lib
                         MessageBoxImage.Exclamation) == MessageBoxResult.No)
                 {
                     Utils.Log("Existing installation at the request of the user, existing mods folder found.");
-                    return;
+                    return false;
                 }
             }
 
@@ -97,6 +96,7 @@ namespace Wabbajack.Lib
             // Removed until we decide if we want this functionality
             // Nexus devs weren't sure this was a good idea, I (halgari) agree.
             //AskToEndorse();
+            return true;
         }
 
         private void InstallIncludedDownloadMetas()

--- a/Wabbajack.Lib/MO2Compiler.cs
+++ b/Wabbajack.Lib/MO2Compiler.cs
@@ -16,18 +16,16 @@ using Path = Alphaleonis.Win32.Filesystem.Path;
 
 namespace Wabbajack.Lib
 {
-    public class Compiler : ACompiler
+    public class MO2Compiler : ACompiler
     {
 
         private string _mo2DownloadsFolder;
-
-        public Dictionary<string, IEnumerable<IndexedFileMatch>> DirectMatchIndex;
         
         public string MO2Folder;
 
         public string MO2Profile;
 
-        public Compiler(string mo2_folder)
+        public MO2Compiler(string mo2_folder)
         {
             ModManager = ModManager.MO2;
 

--- a/Wabbajack.Lib/MO2Installer.cs
+++ b/Wabbajack.Lib/MO2Installer.cs
@@ -15,9 +15,9 @@ using Path = Alphaleonis.Win32.Filesystem.Path;
 
 namespace Wabbajack.Lib
 {
-    public class Installer : AInstaller
+    public class MO2Installer : AInstaller
     {
-        public Installer(string archive, ModList mod_list, string output_folder)
+        public MO2Installer(string archive, ModList mod_list, string output_folder)
         {
             ModManager = ModManager.MO2;
             ModListArchive = archive;

--- a/Wabbajack.Lib/ReportBuilder.cs
+++ b/Wabbajack.Lib/ReportBuilder.cs
@@ -46,9 +46,9 @@ namespace Wabbajack.Lib
 
         public void Build(ACompiler c, ModList lst)
         {
-            Compiler compiler = null;
+            MO2Compiler compiler = null;
             if (lst.ModManager == ModManager.MO2)
-                compiler = (Compiler) c;
+                compiler = (MO2Compiler) c;
 
             Text($"### {lst.Name} by {lst.Author} - Installation Summary");
             Text($"Build with Wabbajack Version {lst.WabbajackVersion}");

--- a/Wabbajack.Lib/VortexCompiler.cs
+++ b/Wabbajack.Lib/VortexCompiler.cs
@@ -38,9 +38,6 @@ namespace Wabbajack.Lib
 
         public VortexCompiler(Game game, string gamePath, string vortexFolder, string downloadsFolder, string stagingFolder)
         {
-            UpdateTracker = new StatusUpdateTracker(10);
-            VFS = new Context(Queue) {UpdateTracker = UpdateTracker};
-
             ModManager = ModManager.Vortex;
             Game = game;
 
@@ -54,8 +51,9 @@ namespace Wabbajack.Lib
             ActiveArchives = new List<string>();
         }
 
-        public override bool Compile()
+        protected override bool _Begin()
         {
+            ConfigureProcessor(10);
             if (string.IsNullOrEmpty(ModListName))
                 ModListName = $"Vortex ModList for {Game.ToString()}";
             ModListOutputFile = $"{ModListName}{ExtensionManager.Extension}";

--- a/Wabbajack.Lib/VortexInstaller.cs
+++ b/Wabbajack.Lib/VortexInstaller.cs
@@ -13,8 +13,6 @@ namespace Wabbajack.Lib
 
         public VortexInstaller(string archive, ModList modList)
         {
-            UpdateTracker = new StatusUpdateTracker(10);
-            VFS = new Context(Queue) {UpdateTracker = UpdateTracker};
             ModManager = ModManager.Vortex;
             ModListArchive = archive;
             ModList = modList;
@@ -25,8 +23,9 @@ namespace Wabbajack.Lib
             GameInfo = GameRegistry.Games[ModList.GameType];
         }
 
-        public override void Install()
+        protected override bool _Begin()
         {
+            ConfigureProcessor(10);
             Directory.CreateDirectory(DownloadFolder);
 
             HashArchives();
@@ -52,6 +51,7 @@ namespace Wabbajack.Lib
             //InstallIncludedDownloadMetas();
 
             Info("Installation complete! You may exit the program.");
+            return true;
         }
 
         private void InstallIncludedFiles()

--- a/Wabbajack.Lib/Wabbajack.Lib.csproj
+++ b/Wabbajack.Lib/Wabbajack.Lib.csproj
@@ -78,6 +78,7 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ABatchProcessor.cs" />
     <Compile Include="ACompiler.cs" />
     <Compile Include="AInstaller.cs" />
     <Compile Include="CerasConfig.cs" />
@@ -125,6 +126,7 @@
     <Compile Include="Downloaders\MEGADownloader.cs" />
     <Compile Include="Downloaders\ModDBDownloader.cs" />
     <Compile Include="Downloaders\NexusDownloader.cs" />
+    <Compile Include="IBatchProcessor.cs" />
     <Compile Include="Installer.cs" />
     <Compile Include="ModListRegistry\ModListMetadata.cs" />
     <Compile Include="NexusApi\Dtos.cs" />

--- a/Wabbajack.Lib/Wabbajack.Lib.csproj
+++ b/Wabbajack.Lib/Wabbajack.Lib.csproj
@@ -111,7 +111,7 @@
     <Compile Include="CompilationSteps\IStackStep.cs" />
     <Compile Include="CompilationSteps\PatchStockESMs.cs" />
     <Compile Include="CompilationSteps\Serialization.cs" />
-    <Compile Include="Compiler.cs" />
+    <Compile Include="MO2Compiler.cs" />
     <Compile Include="Data.cs" />
     <Compile Include="Downloaders\AbstractDownloadState.cs" />
     <Compile Include="Downloaders\DownloadDispatcher.cs" />
@@ -127,7 +127,7 @@
     <Compile Include="Downloaders\ModDBDownloader.cs" />
     <Compile Include="Downloaders\NexusDownloader.cs" />
     <Compile Include="IBatchProcessor.cs" />
-    <Compile Include="Installer.cs" />
+    <Compile Include="MO2Installer.cs" />
     <Compile Include="ModListRegistry\ModListMetadata.cs" />
     <Compile Include="NexusApi\Dtos.cs" />
     <Compile Include="NexusApi\NexusApi.cs" />

--- a/Wabbajack.Lib/zEditIntegration.cs
+++ b/Wabbajack.Lib/zEditIntegration.cs
@@ -14,11 +14,11 @@ namespace Wabbajack.Lib
 {
     public class zEditIntegration
     {
-        private static Compiler _mo2Compiler;
+        private static MO2Compiler _mo2Compiler;
 
         public static string FindzEditPath(ACompiler compiler)
         {
-            _mo2Compiler = (Compiler) compiler;
+            _mo2Compiler = (MO2Compiler) compiler;
             var executables = _mo2Compiler.MO2Ini.customExecutables;
             if (executables.size == null) return null;
 
@@ -141,7 +141,7 @@ namespace Wabbajack.Lib
             public string dataFolder;
         }
 
-        public static void VerifyMerges(Compiler compiler)
+        public static void VerifyMerges(MO2Compiler compiler)
         {
             var by_name = compiler.InstallDirectives.ToDictionary(f => f.To);
 
@@ -160,7 +160,7 @@ namespace Wabbajack.Lib
             }
         }
 
-        public static void GenerateMerges(Installer installer)
+        public static void GenerateMerges(MO2Installer installer)
         {
             installer.ModList
                 .Directives

--- a/Wabbajack.Test.ListValidation/ListValidation.cs
+++ b/Wabbajack.Test.ListValidation/ListValidation.cs
@@ -64,7 +64,7 @@ namespace Wabbajack.Test.ListValidation
 
             Log($"Loading {modlist_path}");
 
-            var installer = Installer.LoadFromFile(modlist_path);
+            var installer = MO2Installer.LoadFromFile(modlist_path);
 
             Log($"{installer.Archives.Count} archives to validate");
 

--- a/Wabbajack.Test/ACompilerTest.cs
+++ b/Wabbajack.Test/ACompilerTest.cs
@@ -32,7 +32,7 @@ namespace Wabbajack.Test
             utils.Dispose();
         }
 
-        protected Compiler ConfigureAndRunCompiler(string profile)
+        protected MO2Compiler ConfigureAndRunCompiler(string profile)
         {
             var compiler = MakeCompiler();
             compiler.MO2Profile = profile;
@@ -41,9 +41,9 @@ namespace Wabbajack.Test
             return compiler;
         }
 
-        protected Compiler MakeCompiler()
+        protected MO2Compiler MakeCompiler()
         {
-            var compiler = new Compiler(utils.MO2Folder);
+            var compiler = new MO2Compiler(utils.MO2Folder);
             return compiler;
         }
         protected ModList CompileAndInstall(string profile)
@@ -53,10 +53,10 @@ namespace Wabbajack.Test
             return compiler.ModList;
         }
 
-        protected void Install(Compiler compiler)
+        protected void Install(MO2Compiler compiler)
         {
-            var modlist = Installer.LoadFromFile(compiler.ModListOutputFile);
-            var installer = new Installer(compiler.ModListOutputFile, modlist, utils.InstallFolder);
+            var modlist = MO2Installer.LoadFromFile(compiler.ModListOutputFile);
+            var installer = new MO2Installer(compiler.ModListOutputFile, modlist, utils.InstallFolder);
             installer.DownloadFolder = utils.DownloadsFolder;
             installer.GameFolder = utils.GameFolder;
             installer.Begin().Wait();

--- a/Wabbajack.Test/ACompilerTest.cs
+++ b/Wabbajack.Test/ACompilerTest.cs
@@ -37,7 +37,7 @@ namespace Wabbajack.Test
             var compiler = MakeCompiler();
             compiler.MO2Profile = profile;
             compiler.ShowReportWhenFinished = false;
-            Assert.IsTrue(compiler.Compile());
+            Assert.IsTrue(compiler.Begin().Result);
             return compiler;
         }
 
@@ -59,7 +59,7 @@ namespace Wabbajack.Test
             var installer = new Installer(compiler.ModListOutputFile, modlist, utils.InstallFolder);
             installer.DownloadFolder = utils.DownloadsFolder;
             installer.GameFolder = utils.GameFolder;
-            installer.Install();
+            installer.Begin().Wait();
         }
     }
 }

--- a/Wabbajack.Test/AVortexCompilerTest.cs
+++ b/Wabbajack.Test/AVortexCompilerTest.cs
@@ -60,8 +60,8 @@ namespace Wabbajack.Test
 
         protected void Install(VortexCompiler vortexCompiler)
         {
-            var modList = Installer.LoadFromFile(vortexCompiler.ModListOutputFile);
-            var installer = new Installer(vortexCompiler.ModListOutputFile, modList, utils.InstallFolder)
+            var modList = MO2Installer.LoadFromFile(vortexCompiler.ModListOutputFile);
+            var installer = new MO2Installer(vortexCompiler.ModListOutputFile, modList, utils.InstallFolder)
             {
                 DownloadFolder = utils.DownloadsFolder,
                 GameFolder = utils.GameFolder,

--- a/Wabbajack.Test/AVortexCompilerTest.cs
+++ b/Wabbajack.Test/AVortexCompilerTest.cs
@@ -37,7 +37,7 @@ namespace Wabbajack.Test
             vortexCompiler.DownloadsFolder = utils.DownloadsFolder;
             vortexCompiler.StagingFolder = utils.InstallFolder;
             Directory.CreateDirectory(utils.InstallFolder);
-            Assert.IsTrue(vortexCompiler.Compile());
+            Assert.IsTrue(vortexCompiler.Begin().Result);
             return vortexCompiler;
         }
 
@@ -66,7 +66,7 @@ namespace Wabbajack.Test
                 DownloadFolder = utils.DownloadsFolder,
                 GameFolder = utils.GameFolder,
             };
-            installer.Install();
+            installer.Begin().Wait();
         }
     }
 }

--- a/Wabbajack.Test/EndToEndTests.cs
+++ b/Wabbajack.Test/EndToEndTests.cs
@@ -73,7 +73,7 @@ namespace Wabbajack.Test
             if (Directory.Exists(loot_folder))
                 Directory.Delete(loot_folder, true);
 
-            var compiler = new Compiler(utils.InstallFolder);
+            var compiler = new MO2Compiler(utils.InstallFolder);
             compiler.MO2DownloadsFolder = Path.Combine(utils.DownloadsFolder);
             compiler.MO2Profile = profile;
             compiler.ShowReportWhenFinished = false;
@@ -144,18 +144,18 @@ namespace Wabbajack.Test
             return compiler.ModList;
         }
 
-        private void Install(Compiler compiler)
+        private void Install(MO2Compiler compiler)
         {
-            var modlist = Installer.LoadFromFile(compiler.ModListOutputFile);
-            var installer = new Installer(compiler.ModListOutputFile, modlist, utils.InstallFolder);
+            var modlist = MO2Installer.LoadFromFile(compiler.ModListOutputFile);
+            var installer = new MO2Installer(compiler.ModListOutputFile, modlist, utils.InstallFolder);
             installer.DownloadFolder = utils.DownloadsFolder;
             installer.GameFolder = utils.GameFolder;
             installer.Begin().Wait();
         }
 
-        private Compiler ConfigureAndRunCompiler(string profile)
+        private MO2Compiler ConfigureAndRunCompiler(string profile)
         {
-            var compiler = new Compiler(utils.MO2Folder);
+            var compiler = new MO2Compiler(utils.MO2Folder);
             compiler.MO2Profile = profile;
             compiler.ShowReportWhenFinished = false;
             Assert.IsTrue(compiler.Begin().Result);

--- a/Wabbajack.Test/EndToEndTests.cs
+++ b/Wabbajack.Test/EndToEndTests.cs
@@ -77,7 +77,7 @@ namespace Wabbajack.Test
             compiler.MO2DownloadsFolder = Path.Combine(utils.DownloadsFolder);
             compiler.MO2Profile = profile;
             compiler.ShowReportWhenFinished = false;
-            Assert.IsTrue(compiler.Compile());
+            Assert.IsTrue(compiler.Begin().Result);
 
         }
 
@@ -150,7 +150,7 @@ namespace Wabbajack.Test
             var installer = new Installer(compiler.ModListOutputFile, modlist, utils.InstallFolder);
             installer.DownloadFolder = utils.DownloadsFolder;
             installer.GameFolder = utils.GameFolder;
-            installer.Install();
+            installer.Begin().Wait();
         }
 
         private Compiler ConfigureAndRunCompiler(string profile)
@@ -158,7 +158,7 @@ namespace Wabbajack.Test
             var compiler = new Compiler(utils.MO2Folder);
             compiler.MO2Profile = profile;
             compiler.ShowReportWhenFinished = false;
-            Assert.IsTrue(compiler.Compile());
+            Assert.IsTrue(compiler.Begin().Result);
             return compiler;
         }
     }

--- a/Wabbajack.Test/SanityTests.cs
+++ b/Wabbajack.Test/SanityTests.cs
@@ -77,8 +77,8 @@ namespace Wabbajack.Test
 
             // Update the file and verify that it throws an error.
             utils.GenerateRandomFileData(game_file, 20);
-            var exception = Assert.ThrowsException<Exception>(() => Install(compiler));
-            Assert.AreEqual(exception.Message, "Game ESM hash doesn't match, is the ESM already cleaned? Please verify your local game files.");
+            var exception = Assert.ThrowsException<AggregateException>(() => Install(compiler));
+            Assert.AreEqual(exception.InnerExceptions.First().Message, "Game ESM hash doesn't match, is the ESM already cleaned? Please verify your local game files.");
 
 
         }

--- a/Wabbajack/View Models/Compilers/ISubCompilerVM.cs
+++ b/Wabbajack/View Models/Compilers/ISubCompilerVM.cs
@@ -13,6 +13,7 @@ namespace Wabbajack
     {
         IReactiveCommand BeginCommand { get; }
         bool Compiling { get; }
+
         ModlistSettingsEditorVM ModlistSettings { get; }
         StatusUpdateTracker StatusTracker { get;}
         void Unload();

--- a/Wabbajack/View Models/Compilers/MO2CompilerVM.cs
+++ b/Wabbajack/View Models/Compilers/MO2CompilerVM.cs
@@ -120,12 +120,11 @@ namespace Wabbajack
                         Utils.Log($"Compiler error: {ex.ExceptionToString()}");
                         return;
                     }
-                    await Task.Run(() =>
+                    await Task.Run(async () =>
                     {
                         try
                         {
-                            this.StatusTracker = compiler.UpdateTracker;
-                            compiler.Compile();
+                            await compiler.Begin();
                         }
                         catch (Exception ex)
                         {

--- a/Wabbajack/View Models/Compilers/MO2CompilerVM.cs
+++ b/Wabbajack/View Models/Compilers/MO2CompilerVM.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
+using System.Reactive.Subjects;
 using System.Text;
 using System.Threading.Tasks;
 using Wabbajack.Common;
@@ -100,10 +101,10 @@ namespace Wabbajack
                     .ObserveOnGuiThread(),
                 execute: async () =>
                 {
-                    Compiler compiler;
+                    MO2Compiler compiler;
                     try
                     {
-                        compiler = new Compiler(this.Mo2Folder)
+                        compiler = new MO2Compiler(this.Mo2Folder)
                         {
                             MO2Profile = this.MOProfile,
                             ModListName = this.ModlistSettings.ModListName,
@@ -113,6 +114,10 @@ namespace Wabbajack
                             ModListWebsite = this.ModlistSettings.Website,
                             ModListReadme = this.ModlistSettings.ReadMeText.TargetPath,
                         };
+                        // TODO: USE RX HERE
+                        compiler.TextStatus.Subscribe(Utils.Log);
+                        // TODO: Where do we bind this?
+                        //compiler.QueueStatus.Subscribe(_cpuStatus);
                     }
                     catch (Exception ex)
                     {
@@ -120,22 +125,22 @@ namespace Wabbajack
                         Utils.Log($"Compiler error: {ex.ExceptionToString()}");
                         return;
                     }
-                    await Task.Run(async () =>
+
+                    try
                     {
-                        try
-                        {
-                            await compiler.Begin();
-                        }
-                        catch (Exception ex)
-                        {
-                            while (ex.InnerException != null) ex = ex.InnerException;
-                            Utils.Log($"Compiler error: {ex.ExceptionToString()}");
-                        }
-                        finally
-                        {
-                            this.StatusTracker = null;
-                        }
-                    });
+                        await compiler.Begin();
+                    }
+                    catch (Exception ex)
+                    {
+                        while (ex.InnerException != null) ex = ex.InnerException;
+                        Utils.Log($"Compiler error: {ex.ExceptionToString()}");
+                    }
+                    finally
+                    {
+                        this.StatusTracker = null;
+                        compiler.Dispose();
+                    }
+                    
                 });
             this._Compiling = this.BeginCommand.IsExecuting
                 .ToProperty(this, nameof(this.Compiling));
@@ -190,7 +195,7 @@ namespace Wabbajack
                 {
                     try
                     {
-                        var tmp_compiler = new Compiler(this.Mo2Folder);
+                        var tmp_compiler = new MO2Compiler(this.Mo2Folder);
                         this.DownloadLocation.TargetPath = tmp_compiler.MO2DownloadsFolder;
                     }
                     catch (Exception ex)

--- a/Wabbajack/View Models/Compilers/VortexCompilerVM.cs
+++ b/Wabbajack/View Models/Compilers/VortexCompilerVM.cs
@@ -106,12 +106,11 @@ namespace Wabbajack
                         Utils.Log($"Compiler error: {ex.ExceptionToString()}");
                         return;
                     }
-                    await Task.Run(() =>
+                    await Task.Run(async () =>
                     {
                         try
                         {
-                            this.StatusTracker = compiler.UpdateTracker;
-                            compiler.Compile();
+                            await compiler.Begin();
                         }
                         catch (Exception ex)
                         {

--- a/Wabbajack/View Models/InstallerVM.cs
+++ b/Wabbajack/View Models/InstallerVM.cs
@@ -9,6 +9,7 @@ using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reflection;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Media.Imaging;
 using Wabbajack.Common;
@@ -295,11 +296,11 @@ namespace Wabbajack
             {
                 DownloadFolder = DownloadLocation.TargetPath
             };
-            var th = new Thread(() =>
+            Task.Run(async () =>
             {
                 try
                 {
-                    installer.Install();
+                    await installer.Begin();
                 }
                 catch (Exception ex)
                 {
@@ -313,11 +314,7 @@ namespace Wabbajack
 
                     this.Installing = false;
                 }
-            })
-            {
-                Priority = ThreadPriority.BelowNormal
-            };
-            th.Start();
+            });
         }
     }
 }

--- a/Wabbajack/View Models/InstallerVM.cs
+++ b/Wabbajack/View Models/InstallerVM.cs
@@ -132,7 +132,7 @@ namespace Wabbajack
                 .Select(modListPath =>
                 {
                     if (modListPath == null) return default(ModListVM);
-                    var modList = Installer.LoadFromFile(modListPath);
+                    var modList = MO2Installer.LoadFromFile(modListPath);
                     if (modList == null)
                     {
                         MessageBox.Show("Invalid Modlist, or file not found.", "Invalid Modlist", MessageBoxButton.OK,
@@ -292,7 +292,7 @@ namespace Wabbajack
         {
             this.Installing = true;
             this.InstallingMode = true;
-            var installer = new Installer(this.ModListPath, this.ModList.SourceModList, Location.TargetPath)
+            var installer = new MO2Installer(this.ModListPath, this.ModList.SourceModList, Location.TargetPath)
             {
                 DownloadFolder = DownloadLocation.TargetPath
             };

--- a/Wabbajack/View Models/MainWindowVM.cs
+++ b/Wabbajack/View Models/MainWindowVM.cs
@@ -83,9 +83,10 @@ namespace Wabbajack
 
             // Compile progress updates and populate ObservableCollection
             /*
-            WorkQueue.Status
+            _Compiler.WhenAny(c => c.Value.Compiler.)
                 .ObserveOn(RxApp.TaskpoolScheduler)
-                .ToObservableChangeSet(x => x.ID)
+                .ToObservableChangeSet(x => x.)
+                /*
                 .Batch(TimeSpan.FromMilliseconds(250), RxApp.TaskpoolScheduler)
                 .EnsureUniqueChanges()
                 .ObserveOn(RxApp.MainThreadScheduler)


### PR DESCRIPTION
All 4 of the compilers/installers have a standard interface: we create them, we tell them to start running (in a separate thread) we get their status, we want to terminate them, and we want to clean up their work when we're done. 

I'm abstracting all that behind a IBatchProcessor and ABatchProcessor. So you can inherit from ABatchProcessor, implement one method, and have access to a work queue and all the step tracking, and queue info will be exposed via Rx streams.
So not a big change, but it should make the interface with the UI much cleaner

@Noggog `IBatchProcessor` Now contains 4 Rx IObservables: 

* `IObservable<float> PercentCompleted { get; }` - Overall completion status of the processor on a scale of 0.0 to 1.0, still working on the functionality of this, but you should see events on this stream
* `IObservable<string> TextStatus { get; }` - Description of the current status of the processor, like "analyzing game files" or "creating patches"
* `IObservable<CPUStatus> QueueStatus { get; }` - Stream of CPUStatus structures, like we used to get from the global WorkQueue
* `IObservable<bool> IsRunning { get; }` - True/False depending on the state of the processor

Should be fairly simple to wire these into the UI, but my Rx-fu is too weak to figure it out atm. I'm hoping that having all these exposed via a common interface will help you abstract the UI a bit more. 