### PR TITLE
Optimize modlists before installation. Also fixed an async bug in VFS.

### DIFF
--- a/Wabbajack.Lib/MO2Compiler.cs
+++ b/Wabbajack.Lib/MO2Compiler.cs
@@ -305,7 +305,7 @@ namespace Wabbajack.Lib
         private void BuildArchivePatches(string archive_sha, IEnumerable<PatchedFromArchive> group,
             Dictionary<string, string> absolute_paths)
         {
-            using (var files = VFS.StageWith(group.Select(g => VFS.Index.FileForArchiveHashPath(g.ArchiveHashPath))).Result)
+            using (var files = VFS.StageWith(group.Select(g => VFS.Index.FileForArchiveHashPath(g.ArchiveHashPath))))
             {
                 var by_path = files.GroupBy(f => string.Join("|", f.FilesInFullPath.Skip(1).Select(i => i.Name)))
                     .ToDictionary(f => f.Key, f => f.First());

--- a/Wabbajack.Lib/MO2Installer.cs
+++ b/Wabbajack.Lib/MO2Installer.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Windows;
+using System.Windows.Forms.VisualStyles;
 using Wabbajack.Common;
 using Wabbajack.Lib.Downloaders;
 using Wabbajack.Lib.NexusApi;
@@ -17,6 +18,8 @@ namespace Wabbajack.Lib
 {
     public class MO2Installer : AInstaller
     {
+        public bool WarnOnOverwrite { get; set; } = true;
+        
         public MO2Installer(string archive, ModList mod_list, string output_folder)
         {
             ModManager = ModManager.MO2;
@@ -52,7 +55,7 @@ namespace Wabbajack.Lib
             Directory.CreateDirectory(OutputFolder);
             Directory.CreateDirectory(DownloadFolder);
 
-            if (Directory.Exists(Path.Combine(OutputFolder, "mods")))
+            if (Directory.Exists(Path.Combine(OutputFolder, "mods")) && WarnOnOverwrite)
             {
                 if (MessageBox.Show(
                         "There already appears to be a Mod Organizer 2 install in this folder, are you sure you wish to continue" +
@@ -66,6 +69,7 @@ namespace Wabbajack.Lib
                 }
             }
 
+            OptimizeModlist();
 
             HashArchives();
             DownloadArchives();
@@ -98,6 +102,7 @@ namespace Wabbajack.Lib
             //AskToEndorse();
             return true;
         }
+
 
         private void InstallIncludedDownloadMetas()
         {

--- a/Wabbajack.Test/ACompilerTest.cs
+++ b/Wabbajack.Test/ACompilerTest.cs
@@ -57,6 +57,7 @@ namespace Wabbajack.Test
         {
             var modlist = MO2Installer.LoadFromFile(compiler.ModListOutputFile);
             var installer = new MO2Installer(compiler.ModListOutputFile, modlist, utils.InstallFolder);
+            installer.WarnOnOverwrite = false;
             installer.DownloadFolder = utils.DownloadsFolder;
             installer.GameFolder = utils.GameFolder;
             installer.Begin().Wait();

--- a/Wabbajack.Test/SanityTests.cs
+++ b/Wabbajack.Test/SanityTests.cs
@@ -55,6 +55,55 @@ namespace Wabbajack.Test
             utils.VerifyInstalledFile(mod, @"Data\scripts\test.pex.copy");
         }
 
+        [TestMethod]
+        public void TestUpdating()
+        {
+
+            var profile = utils.AddProfile();
+            var mod = utils.AddMod();
+            var unchanged = utils.AddModFile(mod, @"Data\scripts\unchanged.pex", 10);
+            var deleted = utils.AddModFile(mod, @"Data\scripts\deleted.pex", 10);
+            var modified = utils.AddModFile(mod, @"Data\scripts\modified.pex", 10);
+
+            utils.Configure();
+
+            utils.AddManualDownload(
+                new Dictionary<string, byte[]>
+                {
+                    { "/baz/unchanged.pex", File.ReadAllBytes(unchanged) },
+                    { "/baz/deleted.pex", File.ReadAllBytes(deleted) },
+                    { "/baz/modified.pex", File.ReadAllBytes(modified) },
+                });
+
+            CompileAndInstall(profile);
+
+            utils.VerifyInstalledFile(mod, @"Data\scripts\unchanged.pex");
+            utils.VerifyInstalledFile(mod, @"Data\scripts\deleted.pex");
+            utils.VerifyInstalledFile(mod, @"Data\scripts\modified.pex");
+
+            var unchanged_path = utils.PathOfInstalledFile(mod, @"Data\scripts\unchanged.pex");
+            var deleted_path = utils.PathOfInstalledFile(mod, @"Data\scripts\deleted.pex");
+            var modified_path = utils.PathOfInstalledFile(mod, @"Data\scripts\modified.pex");
+
+
+            var unchanged_modified = File.GetLastWriteTime(unchanged_path);
+            var modified_modified = File.GetLastWriteTime(modified_path);
+
+            File.WriteAllText(modified_path, "random data");
+            File.Delete(deleted_path);
+
+            CompileAndInstall(profile);
+
+            utils.VerifyInstalledFile(mod, @"Data\scripts\unchanged.pex");
+            utils.VerifyInstalledFile(mod, @"Data\scripts\deleted.pex");
+            utils.VerifyInstalledFile(mod, @"Data\scripts\modified.pex");
+
+            Assert.AreEqual(unchanged_modified, File.GetLastWriteTime(unchanged_path));
+            Assert.AreNotEqual(modified_modified, File.GetLastWriteTime(modified_path));
+
+
+        }
+
 
         [TestMethod]
         public void CleanedESMTest()

--- a/Wabbajack.Test/TestUtils.cs
+++ b/Wabbajack.Test/TestUtils.cs
@@ -182,6 +182,11 @@ namespace Wabbajack.Test
             }
         }
 
+        public string PathOfInstalledFile(string mod, string file)
+        {
+            return Path.Combine(InstallFolder, "mods", mod, file);
+        }
+
         public void VerifyAllFiles()
         {
             foreach (var dest_file in Directory.EnumerateFiles(InstallFolder, "*", DirectoryEnumerationOptions.Recursive))

--- a/Wabbajack.VirtualFileSystem/Context.cs
+++ b/Wabbajack.VirtualFileSystem/Context.cs
@@ -139,7 +139,7 @@ namespace Wabbajack.VirtualFileSystem
                 {
                     var magic = Encoding.ASCII.GetString(br.ReadBytes(Encoding.ASCII.GetBytes(Magic).Length));
                     var fileVersion = br.ReadUInt64();
-                    if (fileVersion != FileVersion || magic != magic)
+                    if (fileVersion != FileVersion || magic != Magic)
                         throw new InvalidDataException("Bad Data Format");
 
                     var numFiles = br.ReadUInt64();
@@ -223,7 +223,7 @@ namespace Wabbajack.VirtualFileSystem
             }
         }
 
-        public async Task<DisposableList<VirtualFile>> StageWith(IEnumerable<VirtualFile> files)
+        public DisposableList<VirtualFile> StageWith(IEnumerable<VirtualFile> files)
         {
             return new DisposableList<VirtualFile>(Stage(files), files);
         }


### PR DESCRIPTION
Runs a few routines before installing a new modlist. Checks to see if a file already exists on disk, if it's the right size, and if the hash matches what's expected (in that order). If all those things match, the file is removed from the list of install directives. If all the directives for an archive are removed, the archive is also removed from the list. 

This approach doesn't work for the following types of files, and as such these will always be re-installed in an update:

* Remapped .ini/.json/.yaml files. They're modified on the installer's machine, so the hashes never match
* Created BSAs - BSA creation is non-deterministic so the hashes will probably not match if the BSA is compressed
* TEMP_BSA_FILES - These files are deleted after installation, so they'll be re-installed, BSAs regenerated, and then they'll be deleted. 

But even then, this should cut out a large number of required installed files. 