### PR TITLE
Change KnownFoldersType to Downloads instead of DownloadsLocalized, f…

### DIFF
--- a/Wabbajack.Lib/Downloaders/ManualDownloader.cs
+++ b/Wabbajack.Lib/Downloaders/ManualDownloader.cs
@@ -30,7 +30,7 @@ namespace Wabbajack.Lib.Downloaders
 
         public ManualDownloader()
         {
-            _downloadfolder = new KnownFolder(KnownFolderType.DownloadsLocalized);
+            _downloadfolder = new KnownFolder(KnownFolderType.Downloads);
             _watcher = new FileSystemWatcher(_downloadfolder.Path);
             _watcher.Created += _watcher_Created;
             _watcher.Changed += _watcher_Changed;


### PR DESCRIPTION
Should fix modlist install Windows 7 crash and Windows 10 builds below build nr 1511.