### PR TITLE
CPU status display maintenance

### DIFF
--- a/Wabbajack/View Models/Compilers/CompilerVM.cs
+++ b/Wabbajack/View Models/Compilers/CompilerVM.cs
@@ -32,6 +32,9 @@ namespace Wabbajack
         private readonly ObservableAsPropertyHelper<StatusUpdateTracker> _CurrentStatusTracker;
         public StatusUpdateTracker CurrentStatusTracker => _CurrentStatusTracker.Value;
 
+        private readonly ObservableAsPropertyHelper<bool> _Compiling;
+        public bool Compiling => _Compiling.Value;
+
         public CompilerVM(MainWindowVM mainWindowVM)
         {
             this.MWVM = mainWindowVM;
@@ -93,6 +96,11 @@ namespace Wabbajack
                     return null;
                 })
                 .ToProperty(this, nameof(this.Image));
+
+            this._Compiling = this.WhenAny(x => x.Compiler.ActiveCompilation)
+                .Select(compilation => compilation != null)
+                .ObserveOnGuiThread()
+                .ToProperty(this, nameof(this.Compiling));
         }
     }
 }

--- a/Wabbajack/View Models/Compilers/ISubCompilerVM.cs
+++ b/Wabbajack/View Models/Compilers/ISubCompilerVM.cs
@@ -6,13 +6,14 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using Wabbajack.Common;
+using Wabbajack.Lib;
 
 namespace Wabbajack
 {
     public interface ISubCompilerVM
     {
         IReactiveCommand BeginCommand { get; }
-        bool Compiling { get; }
+        ACompiler ActiveCompilation { get; }
 
         ModlistSettingsEditorVM ModlistSettings { get; }
         StatusUpdateTracker StatusTracker { get;}

--- a/Wabbajack/View Models/InstallerVM.cs
+++ b/Wabbajack/View Models/InstallerVM.cs
@@ -300,7 +300,7 @@ namespace Wabbajack
             };
 
             // Compile progress updates and populate ObservableCollection
-            installer.QueueStatus
+            var subscription = installer.QueueStatus
                 .ObserveOn(RxApp.TaskpoolScheduler)
                 .ToObservableChangeSet(x => x.ID)
                 .Batch(TimeSpan.FromMilliseconds(250), RxApp.TaskpoolScheduler)
@@ -308,8 +308,7 @@ namespace Wabbajack
                 .ObserveOn(RxApp.MainThreadScheduler)
                 .Sort(SortExpressionComparer<CPUStatus>.Ascending(s => s.ID), SortOptimisations.ComparesImmutableValuesOnly)
                 .Bind(this.MWVM.StatusList)
-                .Subscribe()
-                .DisposeWith(this.CompositeDisposable);
+                .Subscribe();
 
             Task.Run(async () =>
             {
@@ -326,6 +325,9 @@ namespace Wabbajack
                 }
                 finally
                 {
+                    // Dispose of CPU tracking systems
+                    subscription.Dispose();
+                    this.MWVM.StatusList.Clear();
 
                     this.Installing = false;
                 }

--- a/Wabbajack/Views/Compilers/CompilerView.xaml
+++ b/Wabbajack/Views/Compilers/CompilerView.xaml
@@ -64,7 +64,7 @@
             Margin="5"
             Background="Transparent"
             HorizontalScrollBarVisibility="Disabled"
-            IsEnabled="{Binding Compiler.Compiling, Converter={StaticResource InverseBooleanConverter}}"
+            IsEnabled="{Binding Compiling, Converter={StaticResource InverseBooleanConverter}}"
             VerticalScrollBarVisibility="Auto">
             <StackPanel
                 Margin="0,5,0,0"
@@ -152,7 +152,7 @@
                 Margin="35,0,35,0"
                 VerticalAlignment="Center"
                 ClipToBounds="False"
-                Visibility="{Binding Compiler.Compiling, Converter={StaticResource bool2VisibilityConverter}, ConverterParameter=False}">
+                Visibility="{Binding Compiling, Converter={StaticResource bool2VisibilityConverter}, ConverterParameter=False}">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="*" />
                     <RowDefinition Height="Auto" />
@@ -218,7 +218,7 @@
             Grid.Column="0"
             Grid.ColumnSpan="5"
             Margin="5"
-            Visibility="{Binding Compiler.Compiling, Converter={StaticResource bool2VisibilityConverter}, FallbackValue=Hidden}">
+            Visibility="{Binding Compiling, Converter={StaticResource bool2VisibilityConverter}, FallbackValue=Hidden}">
             <local:LogCpuView DataContext="{Binding MWVM}" />
         </Grid>
     </Grid>


### PR DESCRIPTION
Fixes CPU display on the GUI
- Bugfix for installVM not disposing of its temporary subscription.  Would only be a problem in a world where someone installed two things in the same app instance.
- ISubCompilerVM refactor to expose ActiveCompilation
- CompilerVM hooked onto ActiveCompilation to retrieve the CPU status items to display