### PR TITLE
Better selection of patch file sources

### DIFF
--- a/Wabbajack.Common/Utils.cs
+++ b/Wabbajack.Common/Utils.cs
@@ -420,6 +420,19 @@ namespace Wabbajack.Common
             }
         }
 
+        /// <summary>
+        /// A combination of .Select(func).Where(v => v != default). So select and filter default values.
+        /// </summary>
+        /// <typeparam name="TIn"></typeparam>
+        /// <typeparam name="TOut"></typeparam>
+        /// <param name="coll"></param>
+        /// <param name="func"></param>
+        /// <returns></returns>
+        public static IEnumerable<TOut> Keep<TIn, TOut>(this IEnumerable<TIn> coll, Func<TIn, TOut> func) where TOut : IComparable<TOut>
+        {
+            return coll.Select(func).Where(v => v.CompareTo(default) != 0);
+        }
+
         public static byte[] ReadAll(this Stream ins)
         {
             using (var ms = new MemoryStream())

--- a/Wabbajack.Lib/MO2Compiler.cs
+++ b/Wabbajack.Lib/MO2Compiler.cs
@@ -23,6 +23,7 @@ namespace Wabbajack.Lib
         public string MO2Folder;
 
         public string MO2Profile;
+        public Dictionary<string, dynamic> ModMetas { get; set; }
 
         public MO2Compiler(string mo2Folder)
         {
@@ -142,6 +143,13 @@ namespace Wabbajack.Lib
                 })
                 .ToList();
 
+            ModMetas = Directory.EnumerateDirectories(Path.Combine(MO2Folder, "mods"))
+                .Keep(f =>
+                {
+                    var path = Path.Combine(f, "meta.ini");
+                    return File.Exists(path) ? (f, path.LoadIniFile()) : default;
+                }).ToDictionary(f => f.f + "\\", v => v.Item2);
+
             IndexedFiles = IndexedArchives.SelectMany(f => f.File.ThisAndAllChildren)
                 .OrderBy(f => f.NestingFactor)
                 .GroupBy(f => f.Hash)
@@ -253,6 +261,7 @@ namespace Wabbajack.Lib
             Info("Done Building Modlist");
             return true;
         }
+
 
         private void IncludeArchiveMetadata()
         {

--- a/Wabbajack.Test/SanityTests.cs
+++ b/Wabbajack.Test/SanityTests.cs
@@ -156,11 +156,19 @@ namespace Wabbajack.Test
             var profile = utils.AddProfile();
             var mod = utils.AddMod();
             var ini = utils.AddModFile(mod, @"foo.ini", 10);
+            var meta = utils.AddModFile(mod, "meta.ini");
+
             utils.Configure();
 
 
-            utils.AddManualDownload(
+            var archive = utils.AddManualDownload(
                 new Dictionary<string, byte[]> { { "/baz/foo.ini", File.ReadAllBytes(ini) } });
+
+            File.WriteAllLines(meta, new[]
+            {
+                "[General]",
+                $"installationFile={archive}",
+            });
 
             // Modify after creating mod archive in the downloads folder
             File.WriteAllText(ini, "Wabbajack, Wabbajack, Wabbajack!");


### PR DESCRIPTION
We now select patch file sources based on the following criteria:

1) we look in the meta.ini for a `installationFile` entry and use a file in that archive with a matching name
2) we order all possible matching files by nesting factor (so choose files in BSAs last), and then by the most recently modified archive date.
