### PR TITLE
Compilation fixes

### DIFF
--- a/Compression.BSA.Test/BSATests.cs
+++ b/Compression.BSA.Test/BSATests.cs
@@ -64,8 +64,8 @@ namespace Compression.BSA.Test
             using (var client = new NexusApiClient())
             {
                 var results = client.GetModFiles(info.Item1, info.Item2);
-                var file = results.FirstOrDefault(f => f.is_primary) ??
-                           results.OrderByDescending(f => f.uploaded_timestamp).First();
+                var file = results.files.FirstOrDefault(f => f.is_primary) ??
+                           results.files.OrderByDescending(f => f.uploaded_timestamp).First();
                 var src = Path.Combine(_stagingFolder, file.file_name);
 
                 if (File.Exists(src)) return src;

--- a/Wabbajack.CacheServer/NexusCacheModule.cs
+++ b/Wabbajack.CacheServer/NexusCacheModule.cs
@@ -85,7 +85,9 @@ namespace Wabbajack.CacheServer
                 var client = new HttpClient();
                 var builder = new UriBuilder(url) {Host = "localhost", Port = Request.Url.Port ?? 80};
                 client.DefaultRequestHeaders.Add("apikey", Request.Headers["apikey"]);
-                return client.GetStringSync(builder.Uri.ToString());
+                client.GetStringSync(builder.Uri.ToString());
+                if (!File.Exists(path))
+                    throw new InvalidDataException("Invalid Data");
             }
 
             Utils.Log($"{DateTime.Now} - From Cached - {url}");

--- a/Wabbajack.Common/StatusFileStream.cs
+++ b/Wabbajack.Common/StatusFileStream.cs
@@ -5,9 +5,9 @@ namespace Wabbajack.Common
     public class StatusFileStream : Stream
     {
         private string _message;
-        private FileStream _inner;
+        private Stream _inner;
 
-        public StatusFileStream(FileStream fs, string message)
+        public StatusFileStream(Stream fs, string message)
         {
             _inner = fs;
             _message = message;

--- a/Wabbajack.Lib/CompilationSteps/IncludePatches.cs
+++ b/Wabbajack.Lib/CompilationSteps/IncludePatches.cs
@@ -38,6 +38,7 @@ namespace Wabbajack.Lib.CompilationSteps
             }
 
             var e = source.EvolveTo<PatchedFromArchive>();
+            e.FromHash = found.Hash;
             e.ArchiveHashPath = found.MakeRelativePaths();
             e.To = source.Path;
             e.Hash = source.File.Hash;

--- a/Wabbajack.Lib/Data.cs
+++ b/Wabbajack.Lib/Data.cs
@@ -207,6 +207,9 @@ namespace Wabbajack.Lib
         ///     The file to apply to the source file to patch it
         /// </summary>
         public string PatchID;
+
+        [Exclude]
+        public string FromHash;
     }
 
     public class SourcePatch

--- a/Wabbajack.Lib/Downloaders/NexusDownloader.cs
+++ b/Wabbajack.Lib/Downloaders/NexusDownloader.cs
@@ -102,13 +102,13 @@ namespace Wabbajack.Lib.Downloaders
                 {
                     var modfiles = new NexusApiClient().GetModFiles(GameRegistry.GetByMO2ArchiveName(GameName).Game, int.Parse(ModID));
                     var fileid = ulong.Parse(FileID);
-                    var found = modfiles
+                    var found = modfiles.files
                         .FirstOrDefault(file => file.file_id == fileid && file.category_name != null);
                     return found != null;
                 }
                 catch (Exception ex)
                 {
-                    Utils.Log($"{ModName} - {GameName} - {ModID} - {FileID} - Error Getting Nexus Download URL - {ex.Message}");
+                    Utils.Log($"{ModName} - {GameName} - {ModID} - {FileID} - Error Getting Nexus Download URL - {ex}");
                     return false;
                 }
 

--- a/Wabbajack.Lib/NexusApi/NexusApi.cs
+++ b/Wabbajack.Lib/NexusApi/NexusApi.cs
@@ -289,10 +289,10 @@ namespace Wabbajack.Lib.NexusApi
             public List<NexusFileInfo> files;
         }
 
-        public IList<NexusFileInfo> GetModFiles(Game game, int modid)
+        public GetModFilesResponse GetModFiles(Game game, int modid)
         {
             var url = $"https://api.nexusmods.com/v1/games/{GameRegistry.Games[game].NexusName}/mods/{modid}/files.json";
-            return GetCached<GetModFilesResponse>(url).files;
+            return GetCached<GetModFilesResponse>(url);
         }
 
         public List<MD5Response> GetModInfoFromMD5(Game game, string md5Hash)

--- a/Wabbajack.Lib/Validation/ValidateModlist.cs
+++ b/Wabbajack.Lib/Validation/ValidateModlist.cs
@@ -77,6 +77,11 @@ namespace Wabbajack.Lib.Validation
         /// <returns></returns>
         public Permissions FilePermissions(NexusDownloader.State mod)
         {
+            if (mod.Author == null || mod.GameName == null || mod.ModID == null || mod.FileID == null)
+            {
+                Utils.Error($"Error: Null data for {mod.Author} {mod.GameName} {mod.ModID} {mod.FileID}");
+            }
+
             var author_permissions = AuthorPermissions.GetOrDefault(mod.Author)?.Permissions;
             var game_permissions = AuthorPermissions.GetOrDefault(mod.Author)?.Games.GetOrDefault(mod.GameName)?.Permissions;
             var mod_permissions = AuthorPermissions.GetOrDefault(mod.Author)?.Games.GetOrDefault(mod.GameName)?.Mods.GetOrDefault(mod.ModID)

--- a/Wabbajack.Test/EndToEndTests.cs
+++ b/Wabbajack.Test/EndToEndTests.cs
@@ -103,7 +103,7 @@ namespace Wabbajack.Test
         {
             utils.AddMod(mod_name);
             var client = new NexusApiClient();
-            var file = client.GetModFiles(game, modid).First(f => f.is_primary);
+            var file = client.GetModFiles(game, modid).files.First(f => f.is_primary);
             var src = Path.Combine(DOWNLOAD_FOLDER, file.file_name);
 
             var ini = string.Join("\n",

--- a/Wabbajack.VirtualFileSystem/Context.cs
+++ b/Wabbajack.VirtualFileSystem/Context.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Text;
+using System.Threading.Tasks;
 using Alphaleonis.Win32.Filesystem;
 using Wabbajack.Common;
 using Wabbajack.Common.CSP;
@@ -70,6 +71,42 @@ namespace Wabbajack.VirtualFileSystem
 
                                 return VirtualFile.Analyze(this, null, f, f);
                             });
+
+            var newIndex = IndexRoot.Empty.Integrate(filtered.Concat(allFiles).ToList());
+
+            lock (this)
+            {
+                Index = newIndex;
+            }
+
+            return newIndex;
+        }
+
+        public IndexRoot AddRoots(List<string> roots)
+        {
+            if (!roots.All(p => Path.IsPathRooted(p)))
+                throw new InvalidDataException($"Paths are not absolute");
+
+            var filtered = Index.AllFiles.Where(file => File.Exists(file.Name)).ToList();
+
+            var byPath = filtered.ToImmutableDictionary(f => f.Name);
+
+            var filesToIndex = roots.SelectMany(root => Directory.EnumerateFiles(root, "*", DirectoryEnumerationOptions.Recursive)).ToList();
+
+            var results = Channel.Create(1024, ProgressUpdater<VirtualFile>($"Indexing roots", filesToIndex.Count));
+
+            var allFiles = filesToIndex
+                .PMap(Queue, f =>
+                {
+                    if (byPath.TryGetValue(f, out var found))
+                    {
+                        var fi = new FileInfo(f);
+                        if (found.LastModified == fi.LastWriteTimeUtc.Ticks && found.Size == fi.Length)
+                            return found;
+                    }
+
+                    return VirtualFile.Analyze(this, null, f, f);
+                });
 
             var newIndex = IndexRoot.Empty.Integrate(filtered.Concat(allFiles).ToList());
 
@@ -338,26 +375,26 @@ namespace Wabbajack.VirtualFileSystem
 
         public IndexRoot Integrate(List<VirtualFile> files)
         {
-            Utils.Log($"Integrating");
+            Utils.Log($"Integrating {files.Count} files");
             var allFiles = AllFiles.Concat(files).GroupBy(f => f.Name).Select(g => g.Last()).ToImmutableList();
 
-            var byFullPath = allFiles.SelectMany(f => f.ThisAndAllChildren)
-                                     .ToImmutableDictionary(f => f.FullPath);
+            var byFullPath = Task.Run(() => allFiles.SelectMany(f => f.ThisAndAllChildren)
+                                     .ToImmutableDictionary(f => f.FullPath));
 
-            var byHash = allFiles.SelectMany(f => f.ThisAndAllChildren)
+            var byHash = Task.Run(() => allFiles.SelectMany(f => f.ThisAndAllChildren)
                                  .Where(f => f.Hash != null)
-                                 .ToGroupedImmutableDictionary(f => f.Hash);
+                                 .ToGroupedImmutableDictionary(f => f.Hash));
 
-            var byName = allFiles.SelectMany(f => f.ThisAndAllChildren)
-                                 .ToGroupedImmutableDictionary(f => f.Name);
+            var byName = Task.Run(() => allFiles.SelectMany(f => f.ThisAndAllChildren)
+                                 .ToGroupedImmutableDictionary(f => f.Name));
 
-            var byRootPath = allFiles.ToImmutableDictionary(f => f.Name);
+            var byRootPath = Task.Run(() => allFiles.ToImmutableDictionary(f => f.Name));
 
             var result = new IndexRoot(allFiles,
-                byFullPath,
-                byHash,
-                byRootPath,
-                byName);
+                byFullPath.Result,
+                byHash.Result,
+                byRootPath.Result,
+                byName.Result);
             Utils.Log($"Done integrating");
             return result;
         }

--- a/Wabbajack.VirtualFileSystem/Context.cs
+++ b/Wabbajack.VirtualFileSystem/Context.cs
@@ -55,7 +55,7 @@ namespace Wabbajack.VirtualFileSystem
 
             var byPath = filtered.ToImmutableDictionary(f => f.Name);
 
-            var filesToIndex = Directory.EnumerateFiles(root, "*", DirectoryEnumerationOptions.Recursive).ToList();
+            var filesToIndex = Directory.EnumerateFiles(root, "*", DirectoryEnumerationOptions.Recursive).Distinct().ToList();
             
             var results = Channel.Create(1024, ProgressUpdater<VirtualFile>($"Indexing {root}", filesToIndex.Count));
 


### PR DESCRIPTION
Several fixes that came out of my testing of a custom mod list:

1) Fix concurrent patchers stepping on eachother
2) Check the patch cache before extracting BSAs/zips
3) Fix the nexus cache so that we don't get garbage back the first time a mod is seen.
4) Improve compilation times by adding all roots at once, and indexing files via multiple threads
