### PR TITLE
Output Locations Implemented - Modlist name bugfix

### DIFF
--- a/Wabbajack.Lib/ACompiler.cs
+++ b/Wabbajack.Lib/ACompiler.cs
@@ -30,12 +30,12 @@ namespace Wabbajack.Lib
         public IObservable<(string, float)> ProgressUpdates => _progressUpdates;
         protected readonly Subject<(string, float)> _progressUpdates = new Subject<(string, float)>();
 
-        public ModManager ModManager;
+        public abstract ModManager ModManager { get; }
 
-        public string GamePath;
+        public abstract string GamePath { get; }
 
-        public string ModListOutputFolder;
-        public string ModListOutputFile;
+        public abstract string ModListOutputFolder { get; }
+        public abstract string ModListOutputFile { get; }
 
         public bool ShowReportWhenFinished { get; set; } = true;
 

--- a/Wabbajack.Lib/MO2Compiler.cs
+++ b/Wabbajack.Lib/MO2Compiler.cs
@@ -22,19 +22,24 @@ namespace Wabbajack.Lib
         
         public string MO2Folder;
 
-        public string MO2Profile;
+        public string MO2Profile { get; }
         public Dictionary<string, dynamic> ModMetas { get; set; }
 
-        public MO2Compiler(string mo2Folder)
-        {
-            ModManager = ModManager.MO2;
+        public override ModManager ModManager => ModManager.MO2;
 
+        public override string GamePath { get; }
+
+        public override string ModListOutputFolder => "output_folder";
+
+        public override string ModListOutputFile { get; }
+
+        public MO2Compiler(string mo2Folder, string mo2Profile, string outputFile)
+        {
             MO2Folder = mo2Folder;
+            MO2Profile = mo2Profile;
             MO2Ini = Path.Combine(MO2Folder, "ModOrganizer.ini").LoadIniFile();
             GamePath = ((string)MO2Ini.General.gamePath).Replace("\\\\", "\\");
-
-            ModListOutputFolder = "output_folder";
-            ModListOutputFile = MO2Profile + ExtensionManager.Extension;
+            ModListOutputFile = outputFile;
         }
 
         public dynamic MO2Ini { get; }

--- a/Wabbajack.Lib/MO2Compiler.cs
+++ b/Wabbajack.Lib/MO2Compiler.cs
@@ -55,10 +55,12 @@ namespace Wabbajack.Lib
                     if (MO2Ini.Settings != null)
                         if (MO2Ini.Settings.download_directory != null)
                             return MO2Ini.Settings.download_directory.Replace("/", "\\");
-                return Path.Combine(MO2Folder, "downloads");
+                return GetTypicalDownloadsFolder(MO2Folder);
             }
             set => _mo2DownloadsFolder = value;
         }
+
+        public static string GetTypicalDownloadsFolder(string mo2Folder) => Path.Combine(mo2Folder, "downloads");
 
         public string MO2ProfileDir => Path.Combine(MO2Folder, "profiles", MO2Profile);
 

--- a/Wabbajack.Lib/VortexCompiler.cs
+++ b/Wabbajack.Lib/VortexCompiler.cs
@@ -32,12 +32,16 @@ namespace Wabbajack.Lib
 
         public bool IgnoreMissingFiles { get; set; }
 
+        public override ModManager ModManager => ModManager.Vortex;
+        public override string GamePath { get; }
+        public override string ModListOutputFolder { get; }
+        public override string ModListOutputFile { get; }
+
         public const string StagingMarkerName = "__vortex_staging_folder";
         public const string DownloadMarkerName = "__vortex_downloads_folder";
 
-        public VortexCompiler(Game game, string gamePath, string vortexFolder, string downloadsFolder, string stagingFolder)
+        public VortexCompiler(Game game, string gamePath, string vortexFolder, string downloadsFolder, string stagingFolder, string outputFile)
         {
-            ModManager = ModManager.Vortex;
             Game = game;
 
             GamePath = gamePath;
@@ -46,6 +50,7 @@ namespace Wabbajack.Lib
             DownloadsFolder = downloadsFolder;
             StagingFolder = stagingFolder;
             ModListOutputFolder = "output_folder";
+            ModListOutputFile = outputFile;
 
             ActiveArchives = new List<string>();
         }
@@ -55,7 +60,6 @@ namespace Wabbajack.Lib
             ConfigureProcessor(10);
             if (string.IsNullOrEmpty(ModListName))
                 ModListName = $"Vortex ModList for {Game.ToString()}";
-            ModListOutputFile = $"{ModListName}{ExtensionManager.Extension}";
 
             Info($"Starting Vortex compilation for {GameName} at {GamePath} with staging folder at {StagingFolder} and downloads folder at  {DownloadsFolder}.");
 

--- a/Wabbajack.Test/ACompilerTest.cs
+++ b/Wabbajack.Test/ACompilerTest.cs
@@ -30,18 +30,15 @@ namespace Wabbajack.Test
 
         protected MO2Compiler ConfigureAndRunCompiler(string profile)
         {
-            var compiler = MakeCompiler();
-            compiler.MO2Profile = profile;
+            var compiler = new MO2Compiler(
+                mo2Folder: utils.MO2Folder,
+                mo2Profile: profile,
+                outputFile: profile + ExtensionManager.Extension);
             compiler.ShowReportWhenFinished = false;
             Assert.IsTrue(compiler.Begin().Result);
             return compiler;
         }
 
-        protected MO2Compiler MakeCompiler()
-        {
-            var compiler = new MO2Compiler(utils.MO2Folder);
-            return compiler;
-        }
         protected ModList CompileAndInstall(string profile)
         {
             var compiler = ConfigureAndRunCompiler(profile);

--- a/Wabbajack.Test/AVortexCompilerTest.cs
+++ b/Wabbajack.Test/AVortexCompilerTest.cs
@@ -48,7 +48,8 @@ namespace Wabbajack.Test
                 gamePath: utils.GameFolder,
                 vortexFolder: VortexCompiler.TypicalVortexFolder(),
                 downloadsFolder: VortexCompiler.RetrieveDownloadLocation(utils.Game),
-                stagingFolder: VortexCompiler.RetrieveStagingLocation(utils.Game));
+                stagingFolder: VortexCompiler.RetrieveStagingLocation(utils.Game),
+                outputFile: $"test{ExtensionManager.Extension}");
         }
 
         protected ModList CompileAndInstall()

--- a/Wabbajack.Test/EndToEndTests.cs
+++ b/Wabbajack.Test/EndToEndTests.cs
@@ -71,9 +71,11 @@ namespace Wabbajack.Test
             if (Directory.Exists(loot_folder))
                 Utils.DeleteDirectory(loot_folder);
 
-            var compiler = new MO2Compiler(utils.InstallFolder);
+            var compiler = new MO2Compiler(
+                mo2Folder: utils.InstallFolder,
+                mo2Profile: profile,
+                outputFile: profile + ExtensionManager.Extension);
             compiler.MO2DownloadsFolder = Path.Combine(utils.DownloadsFolder);
-            compiler.MO2Profile = profile;
             compiler.ShowReportWhenFinished = false;
             Assert.IsTrue(compiler.Begin().Result);
 
@@ -153,8 +155,10 @@ namespace Wabbajack.Test
 
         private MO2Compiler ConfigureAndRunCompiler(string profile)
         {
-            var compiler = new MO2Compiler(utils.MO2Folder);
-            compiler.MO2Profile = profile;
+            var compiler = new MO2Compiler(
+                mo2Folder: utils.MO2Folder,
+                mo2Profile: profile,
+                outputFile: profile + ExtensionManager.Extension);
             compiler.ShowReportWhenFinished = false;
             Assert.IsTrue(compiler.Begin().Result);
             return compiler;

--- a/Wabbajack/Settings.cs
+++ b/Wabbajack/Settings.cs
@@ -59,6 +59,7 @@ namespace Wabbajack
     public class CompilerSettings
     {
         public ModManager LastCompiledModManager { get; set; }
+        public string OutputLocation { get; set; }
         public MO2CompilationSettings MO2Compilation { get; } = new MO2CompilationSettings();
         public VortexCompilationSettings VortexCompilation { get; } = new VortexCompilationSettings();
     }

--- a/Wabbajack/View Models/Compilers/MO2CompilerVM.cs
+++ b/Wabbajack/View Models/Compilers/MO2CompilerVM.cs
@@ -182,6 +182,8 @@ namespace Wabbajack
                 .FilterSwitch(
                     this.WhenAny(x => x.DownloadLocation.Exists)
                         .Invert())
+                // A skip is needed to ignore the initial signal when the FilterSwitch turns on
+                .Skip(1)
                 .Subscribe(_ =>
                 {
                     DownloadLocation.TargetPath = MO2Compiler.GetTypicalDownloadsFolder(Mo2Folder);

--- a/Wabbajack/View Models/Compilers/MO2CompilerVM.cs
+++ b/Wabbajack/View Models/Compilers/MO2CompilerVM.cs
@@ -98,9 +98,11 @@ namespace Wabbajack
                 {
                     try
                     {
-                        ActiveCompilation = new MO2Compiler(Mo2Folder)
+                        ActiveCompilation = new MO2Compiler(
+                            mo2Folder: Mo2Folder,
+                            mo2Profile: MOProfile,
+                            outputFile: MOProfile + ExtensionManager.Extension)
                         {
-                            MO2Profile = MOProfile,
                             ModListName = ModlistSettings.ModListName,
                             ModListAuthor = ModlistSettings.AuthorText,
                             ModListDescription = ModlistSettings.Description,
@@ -184,7 +186,10 @@ namespace Wabbajack
                 {
                     try
                     {
-                        var tmpCompiler = new MO2Compiler(Mo2Folder);
+                        var tmpCompiler = new MO2Compiler(
+                            mo2Folder: Mo2Folder,
+                            mo2Profile: null,
+                            outputFile: null);
                         DownloadLocation.TargetPath = tmpCompiler.MO2DownloadsFolder;
                     }
                     catch (Exception ex)

--- a/Wabbajack/View Models/Compilers/MO2CompilerVM.cs
+++ b/Wabbajack/View Models/Compilers/MO2CompilerVM.cs
@@ -182,20 +182,9 @@ namespace Wabbajack
                 .FilterSwitch(
                     this.WhenAny(x => x.DownloadLocation.Exists)
                         .Invert())
-                .Subscribe(x =>
+                .Subscribe(_ =>
                 {
-                    try
-                    {
-                        var tmpCompiler = new MO2Compiler(
-                            mo2Folder: Mo2Folder,
-                            mo2Profile: null,
-                            outputFile: null);
-                        DownloadLocation.TargetPath = tmpCompiler.MO2DownloadsFolder;
-                    }
-                    catch (Exception ex)
-                    {
-                        Utils.Log($"Error setting default download location {ex}");
-                    }
+                    DownloadLocation.TargetPath = MO2Compiler.GetTypicalDownloadsFolder(Mo2Folder);
                 })
                 .DisposeWith(CompositeDisposable);
         }

--- a/Wabbajack/View Models/Compilers/VortexCompilerVM.cs
+++ b/Wabbajack/View Models/Compilers/VortexCompilerVM.cs
@@ -85,18 +85,19 @@ namespace Wabbajack
                     try
                     {
                         ActiveCompilation = new VortexCompiler(
-                            SelectedGame.Game,
-                            GameLocation.TargetPath,
-                            VortexCompiler.TypicalVortexFolder(),
-                            DownloadsLocation.TargetPath,
-                            StagingLocation.TargetPath)
+                            game: SelectedGame.Game,
+                            gamePath: GameLocation.TargetPath,
+                            vortexFolder: VortexCompiler.TypicalVortexFolder(),
+                            downloadsFolder: DownloadsLocation.TargetPath,
+                            stagingFolder: StagingLocation.TargetPath,
+                            outputFile: $"{ModlistSettings.ModListName}{ExtensionManager.Extension}")
                         {
                             ModListName = ModlistSettings.ModListName,
                             ModListAuthor = ModlistSettings.AuthorText,
                             ModListDescription = ModlistSettings.Description,
                             ModListImage = ModlistSettings.ImagePath.TargetPath,
                             ModListWebsite = ModlistSettings.Website,
-                            ModListReadme = ModlistSettings.ReadMeText.TargetPath
+                            ModListReadme = ModlistSettings.ReadMeText.TargetPath,
                         };
                     }
                     catch (Exception ex)


### PR DESCRIPTION
- Made ACompiler more picky on its required members being set.  Fixed output naming bug implicitly
- Removed a compiler object instantiation when locating where downloads folder should be.
- Bugfix for downloads path being filled in too aggressively when user was trying to clear it
- Output location backend systems implemented to go with the frontend controls