### PR TITLE
ValidateFreeSpace uses AlphaFile to handle longer names better

### DIFF
--- a/Wabbajack.Lib/AInstaller.cs
+++ b/Wabbajack.Lib/AInstaller.cs
@@ -11,6 +11,7 @@ using Directory = Alphaleonis.Win32.Filesystem.Directory;
 using File = System.IO.File;
 using FileInfo = System.IO.FileInfo;
 using Path = Alphaleonis.Win32.Filesystem.Path;
+using AlphaFile = Alphaleonis.Win32.Filesystem.File;
 
 namespace Wabbajack.Lib
 {
@@ -299,7 +300,7 @@ namespace Wabbajack.Lib
                     var required = g.Sum(i => i.Item2);
                     var contains = g.Sum(folder =>
                         Directory.EnumerateFiles(folder.Item1, "*", DirectoryEnumerationOptions.Recursive)
-                            .Sum(file => new FileInfo(file).Length));
+                            .Sum(file => AlphaFile.GetSize(file)));
                     var available = DriveInfo(g.Key).FreeBytesAvailable;
                     if (required - contains > available)
                         throw new NotEnoughDiskSpaceException(

--- a/Wabbajack.Lib/AInstaller.cs
+++ b/Wabbajack.Lib/AInstaller.cs
@@ -299,7 +299,7 @@ namespace Wabbajack.Lib
                     var required = g.Sum(i => i.Item2);
                     var contains = g.Sum(folder =>
                         Directory.EnumerateFiles(folder.Item1, "*", DirectoryEnumerationOptions.Recursive)
-                            .Sum(file => AlphaFile.GetSize(file)));
+                            .Sum(file => File.GetSize(file)));
                     var available = DriveInfo(g.Key).FreeBytesAvailable;
                     if (required - contains > available)
                         throw new NotEnoughDiskSpaceException(

--- a/Wabbajack.Lib/AInstaller.cs
+++ b/Wabbajack.Lib/AInstaller.cs
@@ -8,10 +8,9 @@ using Wabbajack.Common;
 using Wabbajack.Lib.Downloaders;
 using Wabbajack.VirtualFileSystem;
 using Directory = Alphaleonis.Win32.Filesystem.Directory;
-using File = System.IO.File;
-using FileInfo = System.IO.FileInfo;
+using File = Alphaleonis.Win32.Filesystem.File;
+using FileInfo = Alphaleonis.Win32.Filesystem.File;
 using Path = Alphaleonis.Win32.Filesystem.Path;
-using AlphaFile = Alphaleonis.Win32.Filesystem.File;
 
 namespace Wabbajack.Lib
 {


### PR DESCRIPTION
I was having problems testing installs inside Visual Studio,  ValidateFreeSpace() was failing due to "FileNotFound" errors.  Felt like a path being too long error.

I moved a compiled exe elsewhere to a shorter path and things worked again.

I then tried to swapping out the file size to AlphaFile, since I remember hearing you guys saying it was meant to handle longer file paths better.  VS then seemed to work without error.

I will say it took a very long time to do it inside VS (10-15 seconds?).  However, compiling an exe and running from the desktop was super speedy again, so might just be a slowdown interaction while debugging.

Not sure if this solution is actually ideal, so look it over and see if it's what we want.