### PR TITLE
Progress Bar Systems Rewired

### DIFF
--- a/Wabbajack.Common/StatusUpdate.cs
+++ b/Wabbajack.Common/StatusUpdate.cs
@@ -38,9 +38,9 @@ namespace Wabbajack.Common
             _progress.OnNext(0.0f);
         }
 
-        public void MakeUpdate(double progress)
+        public void MakeUpdate(float progress)
         {
-            _progress.OnNext((float)0.0);
+            _progress.OnNext(progress);
         }
 
         public void MakeUpdate(int max, int curr)

--- a/Wabbajack/View Models/Compilers/CompilerVM.cs
+++ b/Wabbajack/View Models/Compilers/CompilerVM.cs
@@ -37,6 +37,9 @@ namespace Wabbajack
         private readonly ObservableAsPropertyHelper<float> _percentCompleted;
         public float PercentCompleted => _percentCompleted.Value;
 
+        public ObservableCollectionExtended<CPUStatus> StatusList { get; } = new ObservableCollectionExtended<CPUStatus>();
+        public ObservableCollectionExtended<string> Log => MWVM.Log;
+
         public CompilerVM(MainWindowVM mainWindowVM)
         {
             MWVM = mainWindowVM;
@@ -105,7 +108,7 @@ namespace Wabbajack
                 .ToProperty(this, nameof(Compiling));
 
             // Compile progress updates and populate ObservableCollection
-            var subscription = this.WhenAny(x => x.Compiler.ActiveCompilation)
+            this.WhenAny(x => x.Compiler.ActiveCompilation)
                 .SelectMany(c => c?.QueueStatus ?? Observable.Empty<CPUStatus>())
                 .ObserveOn(RxApp.TaskpoolScheduler)
                 .ToObservableChangeSet(x => x.ID)
@@ -113,7 +116,7 @@ namespace Wabbajack
                 .EnsureUniqueChanges()
                 .ObserveOn(RxApp.MainThreadScheduler)
                 .Sort(SortExpressionComparer<CPUStatus>.Ascending(s => s.ID), SortOptimisations.ComparesImmutableValuesOnly)
-                .Bind(MWVM.StatusList)
+                .Bind(StatusList)
                 .Subscribe()
                 .DisposeWith(CompositeDisposable);
 

--- a/Wabbajack/View Models/InstallerVM.cs
+++ b/Wabbajack/View Models/InstallerVM.cs
@@ -228,7 +228,7 @@ namespace Wabbajack
                 canExecute: this.WhenAny(x => x.ModList)
                     .Select(modList => !string.IsNullOrEmpty(modList?.Readme))
                     .ObserveOnGuiThread());
-            BeginCommand = ReactiveCommand.Create(
+            BeginCommand = ReactiveCommand.CreateFromTask(
                 execute: ExecuteBegin,
                 canExecute: Observable.CombineLatest(
                         this.WhenAny(x => x.Installing),
@@ -315,7 +315,7 @@ namespace Wabbajack
             }
         }
 
-        private void ExecuteBegin()
+        private async Task ExecuteBegin()
         {
             InstallingMode = true;
             AInstaller installer;
@@ -337,7 +337,7 @@ namespace Wabbajack
                 return;
             }
 
-            Task.Run(async () =>
+            await Task.Run(async () =>
             {
                 IDisposable subscription = null;
                 try

--- a/Wabbajack/View Models/MainWindowVM.cs
+++ b/Wabbajack/View Models/MainWindowVM.cs
@@ -1,4 +1,4 @@
-using DynamicData;
+﻿using DynamicData;
 using DynamicData.Binding;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
@@ -24,8 +24,6 @@ namespace Wabbajack
         private readonly ObservableAsPropertyHelper<ViewModel> _activePane;
         public ViewModel ActivePane => _activePane.Value;
 
-        public ObservableCollectionExtended<CPUStatus> StatusList { get; } = new ObservableCollectionExtended<CPUStatus>();
-
         public ObservableCollectionExtended<string> Log { get; } = new ObservableCollectionExtended<string>();
 
         [Reactive]
@@ -48,9 +46,9 @@ namespace Wabbajack
                 .ToObservableChangeSet()
                 .Buffer(TimeSpan.FromMilliseconds(250), RxApp.TaskpoolScheduler)
                 .Where(l => l.Count > 0)
+                .ObserveOn(RxApp.MainThreadScheduler)
                 .FlattenBufferResult()
                 .Top(5000)
-                .ObserveOn(RxApp.MainThreadScheduler)
                 .Bind(Log)
                 .Subscribe()
                 .DisposeWith(CompositeDisposable);
@@ -72,21 +70,6 @@ namespace Wabbajack
                     }
                 })
                 .ToProperty(this, nameof(ActivePane));
-
-
-            // Compile progress updates and populate ObservableCollection
-            /*
-            _Compiler.WhenAny(c => c.Value.Compiler.)
-                .ObserveOn(RxApp.TaskpoolScheduler)
-                .ToObservableChangeSet(x => x.)
-                /*
-                .Batch(TimeSpan.FromMilliseconds(250), RxApp.TaskpoolScheduler)
-                .EnsureUniqueChanges()
-                .ObserveOn(RxApp.MainThreadScheduler)
-                .Sort(SortExpressionComparer<CPUStatus>.Ascending(s => s.ID), SortOptimisations.ComparesImmutableValuesOnly)
-                .Bind(this.StatusList)
-                .Subscribe()
-                .DisposeWith(this.CompositeDisposable);*/
         }
     }
 }

--- a/Wabbajack/Views/Compilers/CompilerView.xaml
+++ b/Wabbajack/Views/Compilers/CompilerView.xaml
@@ -56,7 +56,7 @@
             Grid.Column="0"
             Grid.ColumnSpan="5"
             OverhangShadow="True"
-            ProgressPercent="{Binding ProgressPercent}"
+            ProgressPercent="{Binding PercentCompleted}"
             StatePrefixTitle="Compiling" />
         <ScrollViewer
             Grid.Row="1"

--- a/Wabbajack/Views/Compilers/CompilerView.xaml
+++ b/Wabbajack/Views/Compilers/CompilerView.xaml
@@ -219,7 +219,7 @@
             Grid.ColumnSpan="5"
             Margin="5"
             Visibility="{Binding Compiling, Converter={StaticResource bool2VisibilityConverter}, FallbackValue=Hidden}">
-            <local:LogCpuView DataContext="{Binding MWVM}" />
+            <local:LogCpuView />
         </Grid>
     </Grid>
 </UserControl>

--- a/Wabbajack/Views/InstallationView.xaml
+++ b/Wabbajack/Views/InstallationView.xaml
@@ -194,7 +194,7 @@
             Title="{Binding ModListName}"
             Grid.Row="0"
             Grid.RowSpan="2"
-            ProgressPercent="{Binding ProgressPercent}"
+            ProgressPercent="{Binding PercentCompleted}"
             StatePrefixTitle="{Binding ProgressTitle}">
             <!--  Readd when Pause/Stop implementations added  -->
             <!--<Button Grid.Column="2"
@@ -342,7 +342,7 @@
             Grid.Row="2"
             Margin="5,0,5,5"
             Visibility="{Binding InstallingMode, Converter={StaticResource bool2VisibilityConverter}, FallbackValue=Hidden}">
-            <local:LogCpuView DataContext="{Binding MWVM}" />
+            <local:LogCpuView />
         </Grid>
     </Grid>
 </UserControl>

--- a/Wabbajack/Wabbajack.csproj
+++ b/Wabbajack/Wabbajack.csproj
@@ -43,6 +43,8 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <NoWarn>CS1998</NoWarn>
+    <WarningsAsErrors>CS4014</WarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>x64</PlatformTarget>
@@ -53,6 +55,8 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <NoWarn>CS1998</NoWarn>
+    <WarningsAsErrors>CS4014</WarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>Resources\Icons\wabbajack.ico</ApplicationIcon>
@@ -66,6 +70,8 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>true</Prefer32Bit>
+    <NoWarn>CS1998</NoWarn>
+    <WarningsAsErrors>CS4014</WarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Both compiler/installer sides should display progress now.

They seem to just go from 0 to 100 with no progress, but assumedly that's just because the backend needs to add that reporting granularity.

I will mention that I noticed the progress systems seem to have several phases that reset progress to zero.  `StatusUpdateTracker.NextStep` specifically.

If we want to continuously reset progress to zero in this fashion, then I think we need to add another layer to the progress reporting.

- Current Step
- Amount of Steps Total
- Current Progress of Current Step (this is currently what's being communicated)

Otherwise the progress bar displayed to the user is just going to repeatedly hit 100% and then drop to 0%.  If we can know the current step and max steps, then we can do some logic to display it appropriately.