### PR TITLE
Fixed Infinite Layout Recalc Bug

### DIFF
--- a/Wabbajack/Views/Common/LogCpuView.xaml
+++ b/Wabbajack/Views/Common/LogCpuView.xaml
@@ -18,7 +18,14 @@
             Grid.Column="0"
             Margin="0,0,2,0"
             local:AutoScrollBehavior.ScrollOnNewItem="True"
-            ItemsSource="{Binding Log}" />
+            ItemsSource="{Binding Log}"
+            ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+            <ListBox.ItemTemplate>
+                <DataTemplate>
+                    <TextBlock Text="{Binding}" TextWrapping="WrapWithOverflow" />
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
         <ListBox
             Grid.Column="2"
             HorizontalAlignment="Stretch"


### PR DESCRIPTION
Randomly stumbled on this as I was testing other stuff, and happened to have a long log message print to the WJ console.

It seems that long messages would interact somehow with the virtualization systems + scroll viewer systems and get themselves into an infinite loop of layout recalculations.  My best guess is that the virtualization display systems would kick in, hiding some list items, which would recalc the scroll viewer to rethink things, which would recalc its position of its contents, which would trigger the virtualization systems to reconsider their setup again, in a loop.  Something like that

I do think this is just an WPF/ListBox issue at its core, and this patch is just a bandaid to make the situation not occur.  But it looks nicer this way anyway, I think.

![devenv_2t0Myod9DG](https://user-images.githubusercontent.com/24981326/69490539-3e617100-0e4f-11ea-89c0-24f41fe9d4f0.png)
