### PR TITLE
Removed .Top() call in log display systems

### DIFF
--- a/Wabbajack/View Models/MainWindowVM.cs
+++ b/Wabbajack/View Models/MainWindowVM.cs
@@ -46,7 +46,6 @@ namespace Wabbajack
                 .Where(l => l.Count > 0)
                 .ObserveOn(RxApp.MainThreadScheduler)
                 .FlattenBufferResult()
-                .Top(5000)
                 .Bind(Log)
                 .Subscribe()
                 .DisposeWith(CompositeDisposable);


### PR DESCRIPTION
The virtualization systems invoked by the Top() call seem to have a bug in them when handling duplicate entries (at least on the list-side).  Removing it until it can be investigated further and fixed.