### PR TITLE
Exceptions as data thoughts

### DIFF
--- a/Wabbajack.Common/FileExtractor.cs
+++ b/Wabbajack.Common/FileExtractor.cs
@@ -48,12 +48,11 @@ namespace Wabbajack.Common
                 else if (source.EndsWith(".exe"))
                     ExtractAllWithInno(source, dest);
                 else
-                    ExtractAllWith7Zip(queue, source, dest);
+                    ExtractAllWith7Zip(source, dest);
             }
             catch (Exception ex)
             {
-                queue.Log($"Error while extracting {source}");
-                throw ex;
+                Utils.ErrorThrow(ex, $"Error while extracting {source}");
             }
         }
 
@@ -154,14 +153,13 @@ namespace Wabbajack.Common
             }
             catch (Exception ex)
             {
-                queue.Log($"While Extracting {source}");
-                throw ex;
+                Utils.ErrorThrow(ex, $"While Extracting {source}");
             }
         }
 
-        private static void ExtractAllWith7Zip(WorkQueue queue, string source, string dest)
+        private static void ExtractAllWith7Zip(string source, string dest)
         {
-            queue.Log(new GenericInfo($"Extracting {Path.GetFileName(source)}", $"The contents of {source} are being extracted to {dest} using 7zip.exe"));
+            Utils.Log(new GenericInfo($"Extracting {Path.GetFileName(source)}", $"The contents of {source} are being extracted to {dest} using 7zip.exe"));
 
             var info = new ProcessStartInfo
             {
@@ -210,7 +208,7 @@ namespace Wabbajack.Common
             {
                 return;
             }
-            queue.Log(new _7zipReturnError(p.ExitCode, source, dest, p.StandardOutput.ReadToEnd()));
+            Utils.Log(new _7zipReturnError(p.ExitCode, source, dest, p.StandardOutput.ReadToEnd()));
         }
 
         /// <summary>

--- a/Wabbajack.Common/FileExtractor.cs
+++ b/Wabbajack.Common/FileExtractor.cs
@@ -83,7 +83,7 @@ namespace Wabbajack.Common
             }
             catch (Exception e)
             {
-                Utils.LogToFile($"Error while setting process priority level for innounp.exe\n{e}");
+                Utils.Error(e, "Error while setting process priority level for innounp.exe");
             }
 
             var name = Path.GetFileName(source);
@@ -104,7 +104,7 @@ namespace Wabbajack.Common
             }
             catch (Exception e)
             {
-                Utils.LogToFile($"Error while reading StandardOutput for innounp.exe\n{e}");
+                Utils.Error(e, "Error while reading StandardOutput for innounp.exe");
             }
 
             p.WaitForExit();

--- a/Wabbajack.Common/StatusFeed/AErrorMessage.cs
+++ b/Wabbajack.Common/StatusFeed/AErrorMessage.cs
@@ -6,10 +6,11 @@ using System.Threading.Tasks;
 
 namespace Wabbajack.Common.StatusFeed
 {
-    public abstract class AErrorMessage : Exception, IError
+    public abstract class AErrorMessage : Exception, IException
     {
         public DateTime Timestamp { get; } = DateTime.Now;
         public abstract string ShortDescription { get; }
         public abstract string ExtendedDescription { get; }
+        Exception IException.Exception => this;
     }
 }

--- a/Wabbajack.Common/StatusFeed/Errors/7zipReturnError.cs
+++ b/Wabbajack.Common/StatusFeed/Errors/7zipReturnError.cs
@@ -8,25 +8,25 @@ namespace Wabbajack.Common.StatusFeed.Errors
 {
     public class _7zipReturnError : AStatusMessage, IError
     {
-        private string _destination;
-        private string _filename;
-        private int _code;
-        private string _7zip_output;
+        public string Destination { get; }
+        public string Filename;
+        public int Code;
+        public string _7zip_output;
         public override string ShortDescription => $"7Zip returned an error while executing";
 
         public override string ExtendedDescription =>
-            $@"7Zip.exe should always return 0 when it finishes executing. While extracting {_filename} 7Zip encountered some error and
-instead returned {_code} which indicates there was an error. The archive might be corrupt or in a format that 7Zip cannot handle. Please verify the file is valid and that you
-haven't run out of disk space in the {_destination} folder.
+            $@"7Zip.exe should always return 0 when it finishes executing. While extracting {Filename} 7Zip encountered some error and
+instead returned {Code} which indicates there was an error. The archive might be corrupt or in a format that 7Zip cannot handle. Please verify the file is valid and that you
+haven't run out of disk space in the {Destination} folder.
 
 7Zip Output:
 {_7zip_output}";
 
         public _7zipReturnError(int code, string filename, string destination, string output)
         {
-            _code = code;
-            _filename = filename;
-            _destination = destination;
+            Code = code;
+            Filename = filename;
+            Destination = destination;
             _7zip_output = output;
         }
     }

--- a/Wabbajack.Common/StatusFeed/Errors/GenericException.cs
+++ b/Wabbajack.Common/StatusFeed/Errors/GenericException.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Wabbajack.Common.StatusFeed.Errors
+{
+    public class GenericException : IException
+    {
+        public string ExtraMessage { get; }
+
+        public DateTime Timestamp { get; } = DateTime.Now;
+
+        public string ShortDescription => ExtraMessage ?? Exception?.Message;
+
+        public string ExtendedDescription => $"{ExtraMessage}: {Exception?.ToString()}";
+
+        public Exception Exception { get; }
+
+        public GenericException(Exception exception, string extraMessage = null)
+        {
+            ExtraMessage = extraMessage;
+            Exception = exception;
+        }
+    }
+}

--- a/Wabbajack.Common/StatusFeed/Errors/UnconvertedError.cs
+++ b/Wabbajack.Common/StatusFeed/Errors/UnconvertedError.cs
@@ -15,7 +15,7 @@ namespace Wabbajack.Common.StatusFeed.Errors
             _msg = msg;
         }
 
-        public override string ShortDescription { get => _msg; }
-        public override string ExtendedDescription { get; } = "";
+        public override string ShortDescription => _msg;
+        public override string ExtendedDescription => _msg;
     }
 }

--- a/Wabbajack.Common/StatusFeed/IException.cs
+++ b/Wabbajack.Common/StatusFeed/IException.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Wabbajack.Common.StatusFeed
+{
+    public interface IException : IError
+    {
+        Exception Exception { get; }
+    }
+}

--- a/Wabbajack.Common/StatusFeed/IUserIntervention.cs
+++ b/Wabbajack.Common/StatusFeed/IUserIntervention.cs
@@ -10,34 +10,11 @@ namespace Wabbajack.Common.StatusFeed
     /// Defines a message that requires user interaction. The user must perform some action
     /// or make a choice. 
     /// </summary>
-    public interface IUserIntervention<T> : IStatusMessage
-    {
-        /// <summary>
-        /// The user didn't make a choice, so this action should be aborted
-        /// </summary>
-        void Cancel();
-
-        /// <summary>
-        /// The user has provided the required information.
-        /// </summary>
-        /// <param name="result"></param>
-        void Resume(T result);
-    }
-
-    /// <summary>
-    /// Defines a message that requires user interaction. The user must perform some action
-    /// or make a choice. 
-    /// </summary>
     public interface IUserIntervention : IStatusMessage
     {
         /// <summary>
         /// The user didn't make a choice, so this action should be aborted
         /// </summary>
         void Cancel();
-
-        /// <summary>
-        /// Resume without any further information
-        /// </summary>
-        void Resume();
     }
 }

--- a/Wabbajack.Common/Utils.cs
+++ b/Wabbajack.Common/Utils.cs
@@ -18,6 +18,7 @@ using IniParser;
 using Newtonsoft.Json;
 using ReactiveUI;
 using Wabbajack.Common.StatusFeed;
+using Wabbajack.Common.StatusFeed.Errors;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 using Directory = System.IO.Directory;
@@ -68,9 +69,20 @@ namespace Wabbajack.Common
             return msg;
         }
 
+        public static void Error(Exception ex, string extraMessage = null)
+        {
+            Log(new GenericException(ex, extraMessage));
+        }
+
+        public static void ErrorThrow(Exception ex, string extraMessage = null)
+        {
+            Error(ex, extraMessage);
+            throw ex;
+        }
+
         public static void Error(IException err)
         {
-            LogToFile(err.ShortDescription);
+            LogToFile($"{err.ShortDescription}\n{err.Exception.StackTrace}");
             LoggerSubj.OnNext(err);
         }
 
@@ -80,7 +92,7 @@ namespace Wabbajack.Common
             throw err.Exception;
         }
 
-        public static void LogToFile(string msg)
+        private static void LogToFile(string msg)
         {
             lock (_lock)
             {
@@ -588,11 +600,6 @@ namespace Wabbajack.Common
             var stream = result.Result.Content.ReadAsStreamAsync();
             stream.Wait();
             return stream.Result;
-        }
-
-        public static string ExceptionToString(this Exception ex)
-        {
-            return ex.ToString();
         }
 
         public static IEnumerable<T> DistinctBy<T, V>(this IEnumerable<T> vs, Func<T, V> select)

--- a/Wabbajack.Common/Utils.cs
+++ b/Wabbajack.Common/Utils.cs
@@ -72,6 +72,11 @@ namespace Wabbajack.Common
         {
             LogToFile(err.ShortDescription);
             LoggerSubj.OnNext(err);
+        }
+
+        public static void ErrorThrow(IException err)
+        {
+            Error(err);
             throw err.Exception;
         }
 

--- a/Wabbajack.Common/Utils.cs
+++ b/Wabbajack.Common/Utils.cs
@@ -63,31 +63,23 @@ namespace Wabbajack.Common
 
         public static T Log<T>(T msg) where T : IStatusMessage
         {
-            lock (_lock)
-            {
-                File.AppendAllText(LogFile, msg + "\r\n");
-            }
+            LogToFile(msg.ShortDescription);
             LoggerSubj.OnNext(msg);
             return msg;
         }
 
-        public static void Error(AErrorMessage err)
+        public static void Error(IException err)
         {
-            lock (_lock)
-            {
-                File.AppendAllText(LogFile, err.ShortDescription + "\r\n");
-            }
+            LogToFile(err.ShortDescription);
             LoggerSubj.OnNext(err);
-            throw err;
+            throw err.Exception;
         }
 
         public static void LogToFile(string msg)
         {
             lock (_lock)
             {
-                msg = $"{(DateTime.Now - _startTime).TotalSeconds:0.##} - {msg}";
-
-                File.AppendAllText(LogFile, msg + "\r\n");
+                File.AppendAllText(LogFile, $"{(DateTime.Now - _startTime).TotalSeconds:0.##} - {msg}\r\n");
             }
         }
 

--- a/Wabbajack.Common/Wabbajack.Common.csproj
+++ b/Wabbajack.Common/Wabbajack.Common.csproj
@@ -112,9 +112,11 @@
     <Compile Include="StatusFeed\AStatusMessage.cs" />
     <Compile Include="StatusFeed\Errors\7zipReturnError.cs" />
     <Compile Include="StatusFeed\Errors\FileExtractionError.cs" />
+    <Compile Include="StatusFeed\Errors\GenericException.cs" />
     <Compile Include="StatusFeed\Errors\UnconvertedError.cs" />
     <Compile Include="StatusFeed\GenericInfo.cs" />
     <Compile Include="StatusFeed\IError.cs" />
+    <Compile Include="StatusFeed\IException.cs" />
     <Compile Include="StatusFeed\IInfo.cs" />
     <Compile Include="StatusFeed\IStatusMessage.cs" />
     <Compile Include="StatusFeed\IUserIntervention.cs" />

--- a/Wabbajack.Common/WorkQueue.cs
+++ b/Wabbajack.Common/WorkQueue.cs
@@ -22,24 +22,11 @@ namespace Wabbajack.Common
         private readonly Subject<CPUStatus> _Status = new Subject<CPUStatus>();
         public IObservable<CPUStatus> Status => _Status;
 
-        private static readonly Subject<IStatusMessage> _messages = new Subject<IStatusMessage>();
-        public IObservable<IStatusMessage> Messages => _messages;
-
         public static List<Thread> Threads { get; private set; }
 
         public WorkQueue(int threadCount = 0)
         {
             StartThreads(threadCount == 0 ? Environment.ProcessorCount : threadCount);
-        }
-
-        public void Log(IStatusMessage msg)
-        {
-            _messages.OnNext(msg);
-        }
-
-        public void Log(string msg)
-        {
-            _messages.OnNext(new GenericInfo(msg));
         }
 
         private void StartThreads(int threadCount)

--- a/Wabbajack.Lib/CompilationSteps/CompilationErrors/InvalidGameESMError.cs
+++ b/Wabbajack.Lib/CompilationSteps/CompilationErrors/InvalidGameESMError.cs
@@ -10,29 +10,29 @@ namespace Wabbajack.Lib.CompilationSteps.CompilationErrors
 {
     public class InvalidGameESMError : AErrorMessage
     {
-        private readonly string _hash;
-        private readonly string _path;
+        public string Hash { get; }
+        public string PathToFile { get; }
         private readonly CleanedESM _esm;
-        private string _gameFileName => Path.GetFileName(_esm.To);
+        public string GameFileName => Path.GetFileName(_esm.To);
         public override string ShortDescription
         {
             get =>
-                $"Game file {_gameFileName} has a hash of {_hash} which does not match the expected value of {_esm.SourceESMHash}";
+                $"Game file {GameFileName} has a hash of {Hash} which does not match the expected value of {_esm.SourceESMHash}";
         }
 
         public override string ExtendedDescription
         {
             get =>
-                $@"This modlist is setup to perform automatic cleaning of the stock game file {_gameFileName} in order to perform this cleaning Wabbajack must first verify that the 
-source file is in the correct state. It seems that the file in your game directory has a hash of {_hash} instead of the expect hash of {_esm.SourceESMHash}. This could be caused by
+                $@"This modlist is setup to perform automatic cleaning of the stock game file {GameFileName} in order to perform this cleaning Wabbajack must first verify that the 
+source file is in the correct state. It seems that the file in your game directory has a hash of {Hash} instead of the expect hash of {_esm.SourceESMHash}. This could be caused by
 the modlist expecting a different of the game than you currently have installed, or perhaps you have already cleaned the file. You could attempt to fix this error by re-installing
 the game, and then attempting to re-install this modlist. Also verify that the version of the game you have installed matches the version expected by this modlist.";
         }
 
         public InvalidGameESMError(CleanedESM esm, string hash, string path)
         {
-            _hash = hash;
-            _path = path;
+            Hash = hash;
+            PathToFile = path;
             _esm = esm;
         }
     }

--- a/Wabbajack.Lib/CompilationSteps/DeconstructBSAs.cs
+++ b/Wabbajack.Lib/CompilationSteps/DeconstructBSAs.cs
@@ -73,7 +73,7 @@ namespace Wabbajack.Lib.CompilationSteps
             foreach (var match in matches)
             {
                 if (match is IgnoredDirectly)
-                    Utils.Error(new UnconvertedError($"File required for BSA {source.Path} creation doesn't exist: {match.To}"));
+                    Utils.ErrorThrow(new UnconvertedError($"File required for BSA {source.Path} creation doesn't exist: {match.To}"));
                 _mo2Compiler.ExtraFiles.Add(match);
             }
 

--- a/Wabbajack.Lib/CompilationSteps/IncludeSteamWorkshopItems.cs
+++ b/Wabbajack.Lib/CompilationSteps/IncludeSteamWorkshopItems.cs
@@ -42,7 +42,7 @@ namespace Wabbajack.Lib.CompilationSteps
             }
             catch (Exception e)
             {
-                Utils.LogToFile($"Exception while trying to evolve source to FromSteam\n{e}");
+                Utils.Error(e, $"Exception while trying to evolve source to FromSteam");
                 return null;
             }
         }

--- a/Wabbajack.Lib/Downloaders/HTTPDownloader.cs
+++ b/Wabbajack.Lib/Downloaders/HTTPDownloader.cs
@@ -98,7 +98,7 @@ namespace Wabbajack.Lib.Downloaders
 
                 if (stream.IsFaulted || response.StatusCode != HttpStatusCode.OK)
                 {
-                    Utils.Log($"While downloading {Url} - {stream.Exception.ExceptionToString()}");
+                    Utils.Error(stream.Exception, $"While downloading {Url}");
                     return false;
                 }
 

--- a/Wabbajack.Lib/Downloaders/NexusDownloader.cs
+++ b/Wabbajack.Lib/Downloaders/NexusDownloader.cs
@@ -46,12 +46,12 @@ namespace Wabbajack.Lib.Downloaders
             var status = client.GetUserStatus();
             if (!client.IsAuthenticated)
             {
-                Utils.Error(new UnconvertedError($"Authenticating for the Nexus failed. A nexus account is required to automatically download mods."));
+                Utils.ErrorThrow(new UnconvertedError($"Authenticating for the Nexus failed. A nexus account is required to automatically download mods."));
                 return;
             }
 
             if (status.is_premium) return;
-            Utils.Error(new UnconvertedError($"Automated installs with Wabbajack requires a premium nexus account. {client.Username} is not a premium account."));
+            Utils.ErrorThrow(new UnconvertedError($"Automated installs with Wabbajack requires a premium nexus account. {client.Username} is not a premium account."));
         }
 
         public class State : AbstractDownloadState

--- a/Wabbajack.Lib/MO2Installer.cs
+++ b/Wabbajack.Lib/MO2Installer.cs
@@ -140,7 +140,7 @@ namespace Wabbajack.Lib
                 var hash = gameFile.FileHash();
                 if (hash != esm.SourceESMHash)
                 {
-                    Utils.Error(new InvalidGameESMError(esm, hash, gameFile));
+                    Utils.ErrorThrow(new InvalidGameESMError(esm, hash, gameFile));
                 }
             }
         }

--- a/Wabbajack.Lib/StatusMessages/ConfirmUpdateOfExistingInstall.cs
+++ b/Wabbajack.Lib/StatusMessages/ConfirmUpdateOfExistingInstall.cs
@@ -35,7 +35,7 @@ will be reverted. Are you sure you wish to continue?";
             _source.SetResult(Choice.Abort);
         }
 
-        public void Resume()
+        public void Confirm()
         {
             _source.SetResult(Choice.Continue);
         }

--- a/Wabbajack.Lib/VortexCompiler.cs
+++ b/Wabbajack.Lib/VortexCompiler.cs
@@ -238,9 +238,7 @@ namespace Wabbajack.Lib
             }
             catch (JsonSerializationException e)
             {
-                Info("Failed to parse vortex.deployment.json!");
-                Utils.LogToFile(e.Message);
-                Utils.LogToFile(e.StackTrace);
+                Utils.Error(e, "Failed to parse vortex.deployment.json!");
             }
 
             VortexDeployment.files.Do(f =>
@@ -352,7 +350,7 @@ namespace Wabbajack.Lib
                 }
                 catch (Exception e)
                 {
-                    Utils.LogToFile($"Exception while writing to disk at {filePath}\n{e}");
+                    Utils.Error(e, $"Exception while writing to disk at {filePath}");
                 }
             });
         }

--- a/Wabbajack/View Models/Compilers/MO2CompilerVM.cs
+++ b/Wabbajack/View Models/Compilers/MO2CompilerVM.cs
@@ -136,7 +136,7 @@ namespace Wabbajack
                     catch (Exception ex)
                     {
                         while (ex.InnerException != null) ex = ex.InnerException;
-                        Utils.Log($"Compiler error: {ex.ExceptionToString()}");
+                        Utils.Error(ex, $"Compiler error");
                         return;
                     }
 
@@ -147,7 +147,7 @@ namespace Wabbajack
                     catch (Exception ex)
                     {
                         while (ex.InnerException != null) ex = ex.InnerException;
-                        Utils.Log($"Compiler error: {ex.ExceptionToString()}");
+                        Utils.Error(ex, $"Compiler error");
                     }
                     finally
                     {

--- a/Wabbajack/View Models/Compilers/VortexCompilerVM.cs
+++ b/Wabbajack/View Models/Compilers/VortexCompilerVM.cs
@@ -103,7 +103,7 @@ namespace Wabbajack
                     catch (Exception ex)
                     {
                         while (ex.InnerException != null) ex = ex.InnerException;
-                        Utils.Log($"Compiler error: {ex.ExceptionToString()}");
+                        Utils.Error(ex, $"Compiler error");
                         return;
                     }
                     await Task.Run(async () =>
@@ -115,7 +115,7 @@ namespace Wabbajack
                         catch (Exception ex)
                         {
                             while (ex.InnerException != null) ex = ex.InnerException;
-                            Utils.Log($"Compiler error: {ex.ExceptionToString()}");
+                            Utils.Error(ex, $"Compiler error");
                         }
                         finally
                         {

--- a/Wabbajack/View Models/MainWindowVM.cs
+++ b/Wabbajack/View Models/MainWindowVM.cs
@@ -75,7 +75,7 @@ namespace Wabbajack
         {
             var result = MessageBox.Show(msg.ExtendedDescription, msg.ShortDescription, MessageBoxButton.OKCancel);
             if (result == MessageBoxResult.OK)
-                msg.Resume();
+                msg.Confirm();
             else
                 msg.Cancel();
         }

--- a/Wabbajack/View Models/ModListVM.cs
+++ b/Wabbajack/View Models/ModListVM.cs
@@ -61,7 +61,7 @@ namespace Wabbajack
                     }
                     catch (Exception ex)
                     {
-                        Utils.LogToFile($"Exception while caching Mod List image {Name}\n{ex.ExceptionToString()}");
+                        Utils.Error(ex, $"Exception while caching Mod List image {Name}");
                         return default(MemoryStream);
                     }
                 })
@@ -80,7 +80,7 @@ namespace Wabbajack
                     }
                     catch (Exception ex)
                     {
-                        Utils.LogToFile($"Exception while caching Mod List image {Name}\n{ex.ExceptionToString()}");
+                        Utils.Error(ex, $"Exception while caching Mod List image {Name}");
                         return default(BitmapImage);
                     }
                 })

--- a/Wabbajack/View Models/ModVM.cs
+++ b/Wabbajack/View Models/ModVM.cs
@@ -59,7 +59,7 @@ namespace Wabbajack
                     }
                     catch (Exception ex)
                     {
-                        Utils.LogToFile($"Exception while caching slide {ModName} ({ModID})\n{ex.ExceptionToString()}");
+                        Utils.Error(ex, $"Exception while caching slide {ModName} ({ModID})");
                         return default(MemoryStream);
                     }
                 })
@@ -79,7 +79,7 @@ namespace Wabbajack
                     }
                     catch (Exception ex)
                     {
-                        Utils.LogToFile($"Exception while caching slide {ModName} ({ModID})\n{ex.ExceptionToString()}");
+                        Utils.Error(ex, $"Exception while caching slide {ModName} ({ModID})");
                         return default(BitmapImage);
                     }
                     finally

--- a/Wabbajack/Views/MainWindow.xaml.cs
+++ b/Wabbajack/Views/MainWindow.xaml.cs
@@ -23,8 +23,7 @@ namespace Wabbajack
             AppDomain.CurrentDomain.UnhandledException += (sender, e) =>
             {
                 // Don't do any special logging side effects
-                Wabbajack.Common.Utils.Log("Uncaught error:");
-                Wabbajack.Common.Utils.Log(((Exception)e.ExceptionObject).ExceptionToString());
+                Wabbajack.Common.Utils.Error(((Exception)e.ExceptionObject), "Uncaught error");
             };
 
             var appPath = System.Reflection.Assembly.GetExecutingAssembly().Location;


### PR DESCRIPTION
Decided to do my thoughts as a PR, just because it'll be easier to communicate the ideas with granular commits, I think.  Don't feel like you gotta merge all of them. Feel free to just take any keeper thoughts and cherry pick or reimplement.

Overall definitely what I was thinking of for the system we should use.  I think we'll be able to do some neat stuff with this.

You asked specifically about my thoughts on ShortDescription / ExtendedDescription.  I do like the concept a lot.  Short can be used for display in the log to keep things neat, and Extended can be exposed via tooltip, or a click-to-expand setup.  Awesome

Other Thoughts Expressed via Commit:
### IException, GenericException
When funneling every log message through an Rx pipe, there wasn't an easy way to take an Exception in a catch block, and put it into the logging system.  You'd have to convert it to a string right then, which means our logging system loses access to the Exception object if it would find it useful.  This interface should allow us to quickly put any exception down the pipe, not just our custom error classes.

### Made Utils.LogToFile private.  Removed ExceptionToString
LogToFile was exposing a route to the user that would log a message to the file without going to the Rx pipe.  Closed that off.

Added `Utils.Error(Exception ex, string extraMessage = null)`

Removed ExceptionToString, as users should just use the above method, which will let us change how we print exceptions, or do extra things with them easily in the future if we want to.  I think it's good practice to not lose the Exception object by converting it to a string early before it hits the centralized logging systems.

Went around and cleaned up all the old exception printing messages that broke.

### Utils.ErrorThrow added for when wanting to throw the exception
`Util` now offers two functions for errors: `Error` and `ErrorThrow`.

This is mainly to provide symmetry in API when considering the `Util.Error(Exception ex)` call.

For example, consider a user doing this:
```
catch (Exception ex)
{
    Util.Error(ex);
}
```

Does this throw the exception?  It shouldn't because the user needs the option to report an error but not throw.  So `Error` should be just reporting the error, and the user can throw themselves afterwards (or call `ErrorThrow`).

But now `Util.Error(Exception ex)` doesn't throw, but `Util.Error(AErrorMessage err)` does, which will definitely lead to confusion and bugs having that asymmetry.   Solution seemed to make the throwing version obvious in the name `ErrorThrow` and have a `Util.Error(AErrorMessage err)` to be symmetrical even if it's mostly unused.

Edit:
On thinking about this more, I think it would also be fine to just rename `Util.Error(Exception ex)` to just `Util.Log(Exception ex)`.  That way you can leave `Util.Error(AErrorMessage)` as the throwing call if that's a more preferable name.  I still lean the `ErrorThrow` way, though, as I could see myself accidentally calling `Error` without realizing it would also throw internally.

### Made lots of error classes members public gets
I think one of the real selling points of making messages/errors into classes is that now the GUI (or whoever) can look for specific message types, and offer customized behavior for each when it wants to.  A big enabler of that is having access to gritty members, so it can place member A here as red, and B there as green, and show C on hovering, etc.  If everything is coalesced to a single string for it to use, it makes that way more difficult.

So, the members have been made public getters, so the GUI can access them later on, rather than solely relying on Short/Long message, they can go more granular if it's helpful.

Short/Long message would be the fallback for when the GUI doesn't have customized behavior for that class, and also will be used as it falls through to the Util.LogToFile methods for printing to disk, so they'll still be important.

### Removed IUserIntervention.Resume
One thing to consider, is that every user intervention fired down the pipe will probably be explicitly recognized, cast to its type, and handled individually based on what Type it is.  I don't foresee getting a `IUserIntervention<string>` and just handling it in its interface form.  If I get a `IUserIntervention<string>`, I have no clue if I'm opening a file picker, or just offering a textbox, or maybe getting the string some other way?   The GUI's clue for what the engine wants is the Type of class that it is (MissingFileIntervention, open FilePicker), so it must recognize and cast the intervention class to proceed.

Well now that we've cast it, and my code is dealing with the literal "MissingFileIntervention" class, we don't have to limit ourselves in the Resume definitions.  It could be `Resume(string path, string nickname)` or `Resume(int maxCpuCores, int maxMemoryUsageMB)` or whatever that individual intervention needs.  I think the `IUserIntervention<T>.Resume(T item)` holds the system back from having more expressive communication.  We have lots of communication going from the engine to the GUI in the form of members exposed, and this would allow just as vibrant communication the other direction.

I think `IUserIntervention.Cancel()` is still important.  Obviously it'll be called if the user clicks "cancel" or can't find the missing file, or whatever... but it's also the fallback for us.  If the GUI looked through all its known interventions and couldn't cast the object, well then it can't handle it.  It then calls `Cancel()` to signify it's got no clue what to do.  This would only ever happen if we messed up, as every intervention should be known by the GUI-side, too.  So we'd probably see this in user reports and fix the mismatch up.

I do think an argument could be made for `IUserIntervention<T>.Resume(T item)` as a way to implement a generic handler system if we felt like we couldn't/wouldn't implement every intervention explicitly on the GUI side.  The GUI could use reflection, find the type of T, and if `string`, make a very standard display with the ExtendedDescription + a TextBox, or an IntSpinner if it was an `int`.   However, even then, I'd say my preferred setup for handling this requirement would just be to add a `GenericStringIntervention` class.

### WorkQueue.Messages removed (for now)
I did this mainly in the short term until we sort the plan out.  It was a bit confusing to have message subjects on each WorkQueue instance, while also having a static one in Utils.  If I'm the InstallerVM, and I've just kicked up a new install which has its own WorkQueue, do I hook onto the WorkQueue's subject or onto Utils?  It wasn't exactly clear in its current state.

I think if we opt to have separate message subjects in each WorkQueue and one in Util, we'll want to do the following first:
1)  Always funnel WorkQueue's messages into Util, as it does the file logging.  We want everything logged (I assume) so it'll have to get there.
2)  So now Util has all the messages of everything, while WorkQueue's should have all the messages related to its run?  But that might not be true, because subfunctions a WorkQueue is running might go call the static Util's logging methods, meaning they wouldn't fire on the WorkQueue's subject they were working under.  To really be reliable we would want to change all calls to fire through their active WorkQueue's subject, and only calls truly unrelated to any WorkQueue call Util.

But that seems like a bunch of work that probably doesn't matter, and right now having two subjects wasn't reliable of which logs went where.. so I just simplified it to the singular Utils for now.  I do think it would be more ideal to have a message stream for each WorkQueue (in case we have two running at once?), but I think we'd have to do a lot more work to prep that.