### PR TITLE
Bugfix for case sensitivity in downloads folder detection

### DIFF
--- a/Wabbajack.Lib/AInstaller.cs
+++ b/Wabbajack.Lib/AInstaller.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
@@ -348,7 +348,7 @@ namespace Wabbajack.Lib
                 {
                     var relative_to = f.RelativeTo(OutputFolder);
                     Utils.Status($"Checking if modlist file {relative_to}");
-                    if (indexed.ContainsKey(relative_to) || f.StartsWith(DownloadFolder + Path.DirectorySeparator))
+                    if (indexed.ContainsKey(relative_to) || f.StartsWith(DownloadFolder + Path.DirectorySeparator, StringComparison.OrdinalIgnoreCase))
                     {
                         return;
                     }


### PR DESCRIPTION
Small fix for cleanup logic being case sensitive when filtering for downloads.

Couldn't think of any quick good unit tests that wouldn't require refactoring the surrounding code a good bit.  Tested via breakpoints and tinkering /w path in WJ GUI.