### PR TITLE
Filter gallery by valid lists pulled from the validation service.

### DIFF
--- a/Wabbajack.CacheServer/ListValidationService.cs
+++ b/Wabbajack.CacheServer/ListValidationService.cs
@@ -28,16 +28,6 @@ namespace Wabbajack.CacheServer
             public bool HasFailures { get; set; }
         }
 
-        public class ModlistSummary
-        {
-            public string Name;
-            public DateTime Checked;
-            public int Failed;
-            public int Passed;
-            public string Link => $"/lists/status/{Name}.json";
-            public string Report => $"/lists/status/{Name}.html";
-        }
-
         public static Dictionary<string, ModListStatus> ModLists { get; set; }
 
         public ListValidationService() : base("/lists")

--- a/Wabbajack.Common/Consts.cs
+++ b/Wabbajack.Common/Consts.cs
@@ -73,7 +73,7 @@ namespace Wabbajack.Common
         public static string ModPermissionsURL = "https://raw.githubusercontent.com/wabbajack-tools/opt-out-lists/master/NexusModPermissions.yml";
         public static string ServerWhitelistURL = "https://raw.githubusercontent.com/wabbajack-tools/opt-out-lists/master/ServerWhitelist.yml";
         public static string ModlistMetadataURL = "https://raw.githubusercontent.com/wabbajack-tools/mod-lists/master/modlists.json";
-
+        public static string ModlistSummaryURL = "http://build.wabbajack.org/lists/status.json";
         public static string UserAgent
         {
             get

--- a/Wabbajack/View Models/ModListGalleryVM.cs
+++ b/Wabbajack/View Models/ModListGalleryVM.cs
@@ -39,6 +39,7 @@ namespace Wabbajack
                 .SelectTask(async _ =>
                 {
                     return (await ModlistMetadata.LoadFromGithub())
+                        .Where(m => !m.ValidationSummary.HasFailures)
                         .AsObservableChangeSet(x => x.DownloadMetadata?.Hash ?? $"Fallback{missingHashFallbackCounter++}");
                 })
                 .Switch()


### PR DESCRIPTION
Filters out any items from the install list that the build server considers broken. if the latest status can't be read from the build server, all entries are shown (defaults to no filtering)