### PR TITLE
Reverted HTTPDownloader to be sync, until side effects can be researched

### DIFF
--- a/Wabbajack.Lib/Downloaders/HTTPDownloader.cs
+++ b/Wabbajack.Lib/Downloaders/HTTPDownloader.cs
@@ -87,7 +87,9 @@ namespace Wabbajack.Lib.Downloaders
                 var bufferSize = 1024 * 32;
 
                 Utils.Status($"Starting Download {a?.Name ?? Url}", 0);
-                var response = await client.GetAsync(Url, HttpCompletionOption.ResponseHeadersRead);
+                var responseTask = client.GetAsync(Url, HttpCompletionOption.ResponseHeadersRead);
+                responseTask.Wait();
+                var response = await responseTask;
 
                 Stream stream;
                 try


### PR DESCRIPTION
Was causing download failures, for some unknown reasons

Might be some other errors to fix, still, but anecdotally seems better