### PR TITLE
Made HashSets case insensitive

### DIFF
--- a/Wabbajack.Common/Consts.cs
+++ b/Wabbajack.Common/Consts.cs
@@ -20,7 +20,7 @@ namespace Wabbajack.Common
 
         public static string MegaPrefix = "https://mega.nz/#!";
 
-        public static HashSet<string> SupportedArchives = new HashSet<string> {".zip", ".rar", ".7z", ".7zip", ".fomod", ".omod", ".exe", ".dat"};
+        public static HashSet<string> SupportedArchives = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {".zip", ".rar", ".7z", ".7zip", ".fomod", ".omod", ".exe", ".dat"};
 
         // HashSet with archive extensions that need to be tested before extraction
         public static HashSet<string> TestArchivesBeforeExtraction = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {".dat"};

--- a/Wabbajack.Common/Consts.cs
+++ b/Wabbajack.Common/Consts.cs
@@ -23,13 +23,13 @@ namespace Wabbajack.Common
         public static HashSet<string> SupportedArchives = new HashSet<string> {".zip", ".rar", ".7z", ".7zip", ".fomod", ".omod", ".exe", ".dat"};
 
         // HashSet with archive extensions that need to be tested before extraction
-        public static HashSet<string> TestArchivesBeforeExtraction = new HashSet<string> {".dat"};
+        public static HashSet<string> TestArchivesBeforeExtraction = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {".dat"};
 
-        public static HashSet<string> SupportedBSAs = new HashSet<string> {".bsa", ".ba2", ".BA2"};
+        public static HashSet<string> SupportedBSAs = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {".bsa", ".ba2"};
 
-        public static HashSet<string> ConfigFileExtensions = new HashSet<string> {".json", ".ini", ".yml"};
-        public static HashSet<string> ESPFileExtensions = new HashSet<string>() { ".esp", ".esm", ".esl"};
-        public static HashSet<string> AssetFileExtensions = new HashSet<string>() {".dds", ".tga", ".nif", ".psc", ".pex"};
+        public static HashSet<string> ConfigFileExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {".json", ".ini", ".yml"};
+        public static HashSet<string> ESPFileExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { ".esp", ".esm", ".esl"};
+        public static HashSet<string> AssetFileExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {".dds", ".tga", ".nif", ".psc", ".pex"};
 
         public static string NexusCacheDirectory = "nexus_link_cache";
 


### PR DESCRIPTION
I saw two ba2's floating around in the same HashSet. Made it case insensitive, aswell as the others at the same time.