### PR TITLE
Fix error on HTTPDownloader trying to download to non-existing destinations

### DIFF
--- a/Wabbajack.Lib/Downloaders/HTTPDownloader.cs
+++ b/Wabbajack.Lib/Downloaders/HTTPDownloader.cs
@@ -75,6 +75,9 @@ namespace Wabbajack.Lib.Downloaders
 
             public async Task<bool> DoDownload(Archive a, string destination, bool download)
             {
+                if (download && !Directory.Exists(Directory.GetParent(destination).FullName))
+                    Directory.CreateDirectory(Directory.GetParent(destination).FullName);
+
                 using (var fs = download ? File.OpenWrite(destination) : null)
                 {
                     var client = Client ?? new HttpClient();


### PR DESCRIPTION
A bunch of users had errors when downloading modlists, Wabbajack tried to download them but the destination didn't exist. Destination directory is now automatically created if it doesn't exist yet.