### PR TITLE
Mo2 validity bugfixes

### DIFF
--- a/Wabbajack.Lib/MO2Installer.cs
+++ b/Wabbajack.Lib/MO2Installer.cs
@@ -327,7 +327,7 @@ namespace Wabbajack.Lib
             if (!Directory.Exists(path)) return ErrorResponse.Success;
 
             // Check folder does not have a wabbajack modlist
-            foreach (var file in Directory.EnumerateFiles(path, DirectoryEnumerationOptions.Recursive))
+            foreach (var file in Directory.EnumerateFiles(path))
             {
                 if (!File.Exists(file)) continue;
                 if (System.IO.Path.GetExtension(file).Equals(ExtensionManager.Extension))

--- a/Wabbajack/View Models/Installers/MO2InstallerVM.cs
+++ b/Wabbajack/View Models/Installers/MO2InstallerVM.cs
@@ -58,10 +58,10 @@ namespace Wabbajack
             Location.AdditionalError = Observable.CombineLatest(
                     this.WhenAny(x => x.Location.TargetPath),
                     this.WhenAny(x => x.DownloadLocation.TargetPath),
-                    resultSelector: (target, download) =>
-                    {
-                        return MO2Installer.CheckValidInstallPath(target, download);
-                    });
+                    resultSelector: (target, download) => (target, download))
+                .ObserveOn(RxApp.MainThreadScheduler)
+                .Select(i => MO2Installer.CheckValidInstallPath(i.target, i.download))
+                .ObserveOnGuiThread();
 
             CanInstall = Observable.CombineLatest(
                 this.WhenAny(x => x.Location.InError),


### PR DESCRIPTION
"Freezes" when going to the installer page, which was just a bad recursiveness call looking for MO2 install location validity.  Should be fine with top level, even though an ideal would would be recursive