### PR TITLE
Reimplement readme small improvements

### DIFF
--- a/Wabbajack.Lib/ACompiler.cs
+++ b/Wabbajack.Lib/ACompiler.cs
@@ -95,10 +95,8 @@ namespace Wabbajack.Lib
                 ModList.Readme = $"readme{readme.Extension}";
             }
 
-            // DISABLED FOR THIS RELEASE
-            //ModList.ReadmeIsWebsite = ReadmeIsWebsite;
+            ModList.ReadmeIsWebsite = ReadmeIsWebsite;
 
-            //ModList.ToJSON(Path.Combine(ModListOutputFolder, "modlist.json"));
             ModList.ToCERAS(Path.Combine(ModListOutputFolder, "modlist"), CerasConfig.Config);
 
             if (File.Exists(ModListOutputFile))

--- a/Wabbajack.Lib/CerasConfig.cs
+++ b/Wabbajack.Lib/CerasConfig.cs
@@ -32,8 +32,7 @@ namespace Wabbajack.Lib
 
                 },
             };
-            // DISABLED FOR THIS RELEASE
-            //Config.VersionTolerance.Mode = VersionToleranceMode.Standard;
+            Config.VersionTolerance.Mode = VersionToleranceMode.Standard;
         }
     }
 }

--- a/Wabbajack.Lib/Data.cs
+++ b/Wabbajack.Lib/Data.cs
@@ -119,8 +119,7 @@ namespace Wabbajack.Lib
         /// <summary>
         ///     Whether readme is a website
         /// </summary>
-        /// DISABLED FOR THIS RELEASE
-        //public bool ReadmeIsWebsite;
+        public bool ReadmeIsWebsite;
     }
 
     public class Directive

--- a/Wabbajack/View Models/Compilers/CompilerVM.cs
+++ b/Wabbajack/View Models/Compilers/CompilerVM.cs
@@ -158,7 +158,7 @@ namespace Wabbajack
                         return ret;
                     })
                 .ToObservableChangeSet(x => x.Status.ID)
-                .Batch(TimeSpan.FromMilliseconds(250), RxApp.TaskpoolScheduler)
+                .Batch(TimeSpan.FromMilliseconds(50), RxApp.TaskpoolScheduler)
                 .EnsureUniqueChanges()
                 .Filter(i => i.Status.IsWorking && i.Status.ID != WorkQueue.UnassignedCpuId)
                 .ObserveOn(RxApp.MainThreadScheduler)

--- a/Wabbajack/View Models/Compilers/CompilerVM.cs
+++ b/Wabbajack/View Models/Compilers/CompilerVM.cs
@@ -60,6 +60,9 @@ namespace Wabbajack
         [Reactive]
         public ErrorResponse? Completed { get; set; }
 
+        private readonly ObservableAsPropertyHelper<string> _progressTitle;
+        public string ProgressTitle => _progressTitle.Value;
+
         public CompilerVM(MainWindowVM mainWindowVM)
         {
             MWVM = mainWindowVM;
@@ -247,6 +250,22 @@ namespace Wabbajack
                         Process.Start("explorer.exe", OutputLocation.TargetPath);
                     }
                 });
+
+            _progressTitle = Observable.CombineLatest(
+                    this.WhenAny(x => x.Compiling),
+                    this.WhenAny(x => x.StartedCompilation),
+                    resultSelector: (compiling, started) =>
+                    {
+                        if (compiling)
+                        {
+                            return "Compiling";
+                        }
+                        else
+                        {
+                            return started ? "Compiled" : "Configuring";
+                        }
+                    })
+                .ToProperty(this, nameof(ProgressTitle));
         }
     }
 }

--- a/Wabbajack/View Models/Compilers/CompilerVM.cs
+++ b/Wabbajack/View Models/Compilers/CompilerVM.cs
@@ -114,8 +114,9 @@ namespace Wabbajack
 
             _image = this.WhenAny(x => x.CurrentModlistSettings.ImagePath.TargetPath)
                 // Throttle so that it only loads image after any sets of swaps have completed
-                .Throttle(TimeSpan.FromMilliseconds(50), RxApp.MainThreadScheduler)
+                .Throttle(TimeSpan.FromMilliseconds(50), RxApp.TaskpoolScheduler)
                 .DistinctUntilChanged()
+                .ObserveOn(RxApp.MainThreadScheduler)
                 .Select(path =>
                 {
                     if (string.IsNullOrWhiteSpace(path)) return UIUtils.BitmapImageFromResource("Resources/Wabba_Mouth_No_Text.png");

--- a/Wabbajack/View Models/Installers/InstallerVM.cs
+++ b/Wabbajack/View Models/Installers/InstallerVM.cs
@@ -301,7 +301,7 @@ namespace Wabbajack
                         return ret;
                     })
                 .ToObservableChangeSet(x => x.Status.ID)
-                .Batch(TimeSpan.FromMilliseconds(250), RxApp.TaskpoolScheduler)
+                .Batch(TimeSpan.FromMilliseconds(50), RxApp.TaskpoolScheduler)
                 .EnsureUniqueChanges()
                 .Filter(i => i.Status.IsWorking && i.Status.ID != WorkQueue.UnassignedCpuId)
                 .ObserveOn(RxApp.MainThreadScheduler)

--- a/Wabbajack/View Models/Installers/InstallerVM.cs
+++ b/Wabbajack/View Models/Installers/InstallerVM.cs
@@ -281,8 +281,14 @@ namespace Wabbajack
                     this.WhenAny(x => x.StartedInstallation),
                     resultSelector: (installing, started) =>
                     {
-                        if (!installing) return "Configuring";
-                        return started ? "Installing" : "Installed";
+                        if (installing)
+                        {
+                            return "Installing";
+                        }
+                        else
+                        {
+                            return started ? "Installed" : "Configuring";
+                        }
                     })
                 .ToProperty(this, nameof(ProgressTitle));
 

--- a/Wabbajack/View Models/Installers/InstallerVM.cs
+++ b/Wabbajack/View Models/Installers/InstallerVM.cs
@@ -210,7 +210,7 @@ namespace Wabbajack
             _image = Observable.CombineLatest(
                     this.WhenAny(x => x.ModList.Error),
                     this.WhenAny(x => x.ModList)
-                        .Select(x => x?.ImageObservable ?? Observable.Empty<BitmapImage>())
+                        .Select(x => x?.ImageObservable ?? Observable.Return(WabbajackLogo))
                         .Switch()
                         .StartWith(WabbajackLogo),
                     this.WhenAny(x => x.Slideshow.Image)
@@ -228,21 +228,24 @@ namespace Wabbajack
                 .Select<BitmapImage, ImageSource>(x => x)
                 .ToProperty(this, nameof(Image));
             _titleText = Observable.CombineLatest(
-                    this.WhenAny(x => x.ModList.Name),
+                    this.WhenAny(x => x.ModList)
+                        .Select(modList => modList?.Name ?? string.Empty),
                     this.WhenAny(x => x.Slideshow.TargetMod.ModName)
                         .StartWith(default(string)),
                     this.WhenAny(x => x.Installing),
                     resultSelector: (modList, mod, installing) => installing ? mod : modList)
                 .ToProperty(this, nameof(TitleText));
             _authorText = Observable.CombineLatest(
-                    this.WhenAny(x => x.ModList.Author),
+                    this.WhenAny(x => x.ModList)
+                        .Select(modList => modList?.Author ?? string.Empty),
                     this.WhenAny(x => x.Slideshow.TargetMod.ModAuthor)
                         .StartWith(default(string)),
                     this.WhenAny(x => x.Installing),
                     resultSelector: (modList, mod, installing) => installing ? mod : modList)
                 .ToProperty(this, nameof(AuthorText));
             _description = Observable.CombineLatest(
-                    this.WhenAny(x => x.ModList.Description),
+                    this.WhenAny(x => x.ModList)
+                        .Select(modList => modList?.Description ?? string.Empty),
                     this.WhenAny(x => x.Slideshow.TargetMod.ModDescription)
                         .StartWith(default(string)),
                     this.WhenAny(x => x.Installing),

--- a/Wabbajack/View Models/Installers/MO2InstallerVM.cs
+++ b/Wabbajack/View Models/Installers/MO2InstallerVM.cs
@@ -59,7 +59,7 @@ namespace Wabbajack
                     this.WhenAny(x => x.Location.TargetPath),
                     this.WhenAny(x => x.DownloadLocation.TargetPath),
                     resultSelector: (target, download) => (target, download))
-                .ObserveOn(RxApp.MainThreadScheduler)
+                .ObserveOn(RxApp.TaskpoolScheduler)
                 .Select(i => MO2Installer.CheckValidInstallPath(i.target, i.download))
                 .ObserveOnGuiThread();
 

--- a/Wabbajack/View Models/MainWindowVM.cs
+++ b/Wabbajack/View Models/MainWindowVM.cs
@@ -40,10 +40,7 @@ namespace Wabbajack
         public readonly UserInterventionHandlers UserInterventionHandlers;
         public readonly LoginManagerVM LoginManagerVM;
 
-
         public readonly List<ViewModel> NavigationTrail = new List<ViewModel>();
-
-        public Dispatcher ViewDispatcher { get; set; }
 
         public ICommand CopyVersionCommand { get; }
 
@@ -54,7 +51,6 @@ namespace Wabbajack
         public MainWindowVM(MainWindow mainWindow, MainSettings settings)
         {
             MainWindow = mainWindow;
-            ViewDispatcher = MainWindow.Dispatcher;
             Settings = settings;
             Installer = new Lazy<InstallerVM>(() => new InstallerVM(this));
             Compiler = new Lazy<CompilerVM>(() => new CompilerVM(this));

--- a/Wabbajack/View Models/ModListVM.cs
+++ b/Wabbajack/View Models/ModListVM.cs
@@ -87,8 +87,7 @@ namespace Wabbajack
         public void OpenReadmeWindow()
         {
             if (string.IsNullOrEmpty(Readme)) return;
-            // DISABLED FOR THIS RELEASE
-            if (false) // SourceModList.ReadmeIsWebsite)
+            if (SourceModList.ReadmeIsWebsite)
             {
                 Process.Start(Readme);
             }

--- a/Wabbajack/Views/Compilers/CompilerView.xaml
+++ b/Wabbajack/Views/Compilers/CompilerView.xaml
@@ -77,7 +77,7 @@
             Grid.ColumnSpan="5"
             OverhangShadow="True"
             ProgressPercent="{Binding PercentCompleted}"
-            StatePrefixTitle="Compiling" />
+            StatePrefixTitle="{Binding ProgressTitle}" />
         <Button
             x:Name="BackButton"
             Grid.Row="0"

--- a/Wabbajack/Views/Installers/InstallationView.xaml
+++ b/Wabbajack/Views/Installers/InstallationView.xaml
@@ -381,6 +381,21 @@
                                 <local:VortexInstallerConfigView />
                             </DataTemplate>
                         </ContentPresenter.Resources>
+                        <ContentPresenter.Style>
+                            <Style TargetType="ContentPresenter">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding RelativeSource={x:Static RelativeSource.Self}, Path=Content}" Value="{x:Null}">
+                                        <Setter Property="ContentPresenter.ContentTemplate">
+                                            <Setter.Value>
+                                                <DataTemplate>
+                                                    <Rectangle Height="74" />
+                                                </DataTemplate>
+                                            </Setter.Value>
+                                        </Setter>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </ContentPresenter.Style>
                     </ContentPresenter>
                 </Grid>
                 <local:BeginButton


### PR DESCRIPTION
- Reimplemented the Ceras VersionTolerance, and website readme features
- Bugfixes for installer VM not clearing title/image display when switching to a target that did not have them.
- Improvements to make modlist target file picker to not move visually
- Lowered throttle for CPU display updates to 50ms
- Improved top bar configuration text. (Configuring/Installing/Installed)
- Improved some minor threading calls that were not offloading properly