### PR TITLE
Rewrite ModDB downloader to support mirrors.

### DIFF
--- a/Wabbajack.Lib/Downloaders/HTTPDownloader.cs
+++ b/Wabbajack.Lib/Downloaders/HTTPDownloader.cs
@@ -7,6 +7,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Reflection.Emit;
 using System.Threading.Tasks;
+using System.Web;
 using Windows.Networking.BackgroundTransfer;
 using Ceras;
 using SharpCompress.Common;
@@ -105,6 +106,9 @@ namespace Wabbajack.Lib.Downloaders
                     var response = await client.GetAsync(Url, HttpCompletionOption.ResponseHeadersRead);
                     TOP:
 
+                    if (!response.IsSuccessStatusCode)
+                        throw new HttpException((int)response.StatusCode, response.ReasonPhrase);
+                    
                     Stream stream;
                     try
                     {

--- a/Wabbajack.Lib/Wabbajack.Lib.csproj
+++ b/Wabbajack.Lib/Wabbajack.Lib.csproj
@@ -198,6 +198,9 @@
     <PackageReference Include="CommonMark.NET">
       <Version>0.15.1</Version>
     </PackageReference>
+    <PackageReference Include="HtmlAgilityPack">
+      <Version>1.11.17</Version>
+    </PackageReference>
     <PackageReference Include="MegaApiClient">
       <Version>1.7.1</Version>
     </PackageReference>


### PR DESCRIPTION
Rewrites the moddb downloader:
* HttpDownloader now throws an exception on a non-success response instead of just blindly writing the response body to disk
* ModDB downloader now looks up the list of mirrors for the file, sorts by least-loaded server. Then tries  the first. If that download fails, it tries the next mirror. Once all mirrors fail, the downloader fails. 