### PR TITLE
Steam handler hotfix

### DIFF
--- a/Wabbajack.Common/StoreHandlers/SteamHandler.cs
+++ b/Wabbajack.Common/StoreHandlers/SteamHandler.cs
@@ -159,11 +159,11 @@ namespace Wabbajack.Common.StoreHandlers
 
                     if (!valid) return;
 
-                    var gameMeta = GameRegistry.Games.Values.FirstOrDefault(g => 
-                        g.SteamIDs.Contains(game.ID)
-                        && 
-                        g.RequiredFiles.TrueForAll(file => 
-                            File.Exists(Path.Combine(game.Path, file))));
+                    var gameMeta = GameRegistry.Games.Values.FirstOrDefault(g =>
+                    {
+                        return g.SteamIDs.Contains(game.ID)
+                            && (g.RequiredFiles?.TrueForAll(file => File.Exists(Path.Combine(game.Path, file))) ?? true);
+                    });
 
                     if (gameMeta == null)
                         return;

--- a/Wabbajack.Common/StoreHandlers/SteamHandler.cs
+++ b/Wabbajack.Common/StoreHandlers/SteamHandler.cs
@@ -131,7 +131,7 @@ namespace Wabbajack.Common.StoreHandlers
                 Directory.EnumerateFiles(u, "*.acf", SearchOption.TopDirectoryOnly).Where(File.Exists).Do(f =>
                 {
                     var game = new SteamGame();
-                    var valid = false;
+                    var gotID = false;
 
                     File.ReadAllLines(f).Do(l =>
                     {
@@ -140,6 +140,7 @@ namespace Wabbajack.Common.StoreHandlers
                             if (!int.TryParse(GetVdfValue(l), out var id))
                                 return;
                             game.ID = id;
+                            gotID = true;
                         }
 
                         if (l.Contains("\"name\""))
@@ -149,19 +150,17 @@ namespace Wabbajack.Common.StoreHandlers
                         {
                             var path = Path.Combine(u, "common", GetVdfValue(l));
                             if (Directory.Exists(path))
+                            {
                                 game.Path = path;
-                            else
-                                return;
+                            }
                         }
-
-                        valid = true;
                     });
 
-                    if (!valid) return;
+                    if (!gotID || !Directory.Exists(game.Path)) return;
 
                     var gameMeta = GameRegistry.Games.Values.FirstOrDefault(g =>
                     {
-                        return g.SteamIDs.Contains(game.ID)
+                        return (g.SteamIDs?.Contains(game.ID) ?? false)
                             && (g.RequiredFiles?.TrueForAll(file => File.Exists(Path.Combine(game.Path, file))) ?? true);
                     });
 

--- a/Wabbajack/View Models/Installers/InstallerVM.cs
+++ b/Wabbajack/View Models/Installers/InstallerVM.cs
@@ -335,11 +335,9 @@ namespace Wabbajack
                         }
                     }
                     catch (Exception ex)
-                    {
+                    { 
+                        Utils.Error(ex, $"Encountered error, can't continue");
                         while (ex.InnerException != null) ex = ex.InnerException;
-                        Utils.Log(ex.StackTrace);
-                        Utils.Log(ex.ToString());
-                        Utils.Log($"{ex.Message} - Can't continue");
                         Completed = ErrorResponse.Fail(ex);
                     }
                 });


### PR DESCRIPTION
- Adjusted error printing for installer to just use Utils.Error
- Logic fixes in SteamHandler to deal with some null refs