### PR TITLE
Pulling game path from StoreHandler instead of MO2 ini

### DIFF
--- a/Wabbajack.Lib/MO2Compiler.cs
+++ b/Wabbajack.Lib/MO2Compiler.cs
@@ -47,10 +47,8 @@ namespace Wabbajack.Lib
             MO2Ini = Path.Combine(MO2Folder, "ModOrganizer.ini").LoadIniFile();
             var mo2game = (string)MO2Ini.General.gameName;
             CompilingGame = GameRegistry.Games.First(g => g.Value.MO2Name == mo2game).Value;
-            var path = ((string)MO2Ini.General.gamePath).Replace("\\\\", "\\");
-            if(path.StartsWith("@ByteArray"))
-                path = StoreHandler.Instance.GetGamePath(CompilingGame.Game);
-            GamePath = path;
+            GamePath = StoreHandler.Instance.GetGamePath(CompilingGame.Game);
+            // GamePath = ((string)MO2Ini.General.gamePath).Replace("\\\\", "\\");
             ModListOutputFile = outputFile;
         }
 

--- a/Wabbajack.Lib/MO2Compiler.cs
+++ b/Wabbajack.Lib/MO2Compiler.cs
@@ -47,8 +47,10 @@ namespace Wabbajack.Lib
             MO2Ini = Path.Combine(MO2Folder, "ModOrganizer.ini").LoadIniFile();
             var mo2game = (string)MO2Ini.General.gameName;
             CompilingGame = GameRegistry.Games.First(g => g.Value.MO2Name == mo2game).Value;
-            GamePath = StoreHandler.Instance.GetGamePath(CompilingGame.Game);
-            // GamePath = ((string)MO2Ini.General.gamePath).Replace("\\\\", "\\");
+            var path = ((string)MO2Ini.General.gamePath).Replace("\\\\", "\\");
+            if(path.StartsWith("@ByteArray"))
+                path = StoreHandler.Instance.GetGamePath(CompilingGame.Game);
+            GamePath = path;
             ModListOutputFile = outputFile;
         }
 

--- a/Wabbajack.Lib/MO2Compiler.cs
+++ b/Wabbajack.Lib/MO2Compiler.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Alphaleonis.Win32.Filesystem;
 using Wabbajack.Common;
+using Wabbajack.Common.StoreHandlers;
 using Wabbajack.Lib.CompilationSteps;
 using Wabbajack.Lib.NexusApi;
 using Wabbajack.Lib.Validation;
@@ -46,7 +47,8 @@ namespace Wabbajack.Lib
             MO2Ini = Path.Combine(MO2Folder, "ModOrganizer.ini").LoadIniFile();
             var mo2game = (string)MO2Ini.General.gameName;
             CompilingGame = GameRegistry.Games.First(g => g.Value.MO2Name == mo2game).Value;
-            GamePath = ((string)MO2Ini.General.gamePath).Replace("\\\\", "\\");
+            GamePath = StoreHandler.Instance.GetGamePath(CompilingGame.Game);
+            // GamePath = ((string)MO2Ini.General.gamePath).Replace("\\\\", "\\");
             ModListOutputFile = outputFile;
         }
 


### PR DESCRIPTION
Old `ModOrganizer.ini` (2.2.1):
`gamePath=S:\\SteamLibrary\\steamapps\\common\\Skyrim Special Edition`
new (2.2.2 rc7):
`gamePath=@ByteArray(S:\\SteamLibrary\\steamapps\\common\\Skyrim Special Edition)`

they use a [QByteArray](https://doc.qt.io/qt-5/qbytearray.html) for storing this path. We have no way of parsing Qt stuff so instead we just pull the game path from the `StoreHandler.GetGamePath()` method