### PR TITLE
Downloader adjustments

### DIFF
--- a/Wabbajack.Common/Utils.cs
+++ b/Wabbajack.Common/Utils.cs
@@ -129,6 +129,30 @@ namespace Wabbajack.Common
             }
         }
 
+        public static void CatchAndLog(Action a)
+        {
+            try
+            {
+                a();
+            }
+            catch (Exception ex)
+            {
+                Utils.Error(ex);
+            }
+        }
+
+        public static async Task CatchAndLog(Func<Task> f)
+        {
+            try
+            {
+                await f();
+            }
+            catch (Exception ex)
+            {
+                Utils.Error(ex);
+            }
+        }
+
         /// <summary>
         ///     MurMur3 hashes the file pointed to by this string
         /// </summary>

--- a/Wabbajack.Lib/Downloaders/INeedsLogin.cs
+++ b/Wabbajack.Lib/Downloaders/INeedsLogin.cs
@@ -8,7 +8,7 @@ using System.Windows.Input;
 
 namespace Wabbajack.Lib.Downloaders
 {
-    public interface INeedsLogin : INotifyPropertyChanged
+    public interface INeedsLogin
     {
         ICommand TriggerLogin { get; }
         ICommand ClearLogin { get; }
@@ -17,6 +17,5 @@ namespace Wabbajack.Lib.Downloaders
         string MetaInfo { get; }
         Uri SiteURL { get; }
         Uri IconUri { get; }
-
     }
 }

--- a/Wabbajack.Lib/Downloaders/LoversLabDownloader.cs
+++ b/Wabbajack.Lib/Downloaders/LoversLabDownloader.cs
@@ -20,7 +20,7 @@ using File = Alphaleonis.Win32.Filesystem.File;
 
 namespace Wabbajack.Lib.Downloaders
 {
-    public class LoversLabDownloader : ViewModel, IDownloader, INeedsLogin
+    public class LoversLabDownloader : IDownloader, INeedsLogin
     {
         internal HttpClient _authedClient;
 

--- a/Wabbajack.Lib/Downloaders/LoversLabDownloader.cs
+++ b/Wabbajack.Lib/Downloaders/LoversLabDownloader.cs
@@ -226,7 +226,7 @@ namespace Wabbajack.Lib.Downloaders
         public override void Cancel()
         {
             Handled = true;
-            _source.SetCanceled();
+            _source.TrySetCanceled();
         }
     }
 }

--- a/Wabbajack.Lib/Downloaders/LoversLabDownloader.cs
+++ b/Wabbajack.Lib/Downloaders/LoversLabDownloader.cs
@@ -40,8 +40,12 @@ namespace Wabbajack.Lib.Downloaders
 
         public LoversLabDownloader()
         {
-            TriggerLogin = ReactiveCommand.Create(async () => await Utils.Log(new RequestLoversLabLogin()).Task, IsLoggedIn.Select(b => !b).ObserveOn(RxApp.MainThreadScheduler));
-            ClearLogin = ReactiveCommand.Create(() => Utils.DeleteEncryptedJson("loverslabcookies"), IsLoggedIn.ObserveOn(RxApp.MainThreadScheduler));
+            TriggerLogin = ReactiveCommand.CreateFromTask(
+                execute: () => Utils.CatchAndLog(async () => await Utils.Log(new RequestLoversLabLogin()).Task),
+                canExecute: IsLoggedIn.Select(b => !b).ObserveOn(RxApp.MainThreadScheduler));
+            ClearLogin = ReactiveCommand.Create(
+                execute: () => Utils.CatchAndLog(() => Utils.DeleteEncryptedJson("loverslabcookies")),
+                canExecute: IsLoggedIn.ObserveOn(RxApp.MainThreadScheduler));
         }
 
 

--- a/Wabbajack.Lib/Downloaders/NexusDownloader.cs
+++ b/Wabbajack.Lib/Downloaders/NexusDownloader.cs
@@ -20,31 +20,28 @@ namespace Wabbajack.Lib.Downloaders
         private UserStatus _status;
         private NexusApiClient _client;
 
-        public NexusDownloader()
-        {
-            TriggerLogin = ReactiveCommand.Create(async () => await NexusApiClient.RequestAndCacheAPIKey(), IsLoggedIn.Select(b => !b).ObserveOn(RxApp.MainThreadScheduler));
-            ClearLogin = ReactiveCommand.Create(() => Utils.DeleteEncryptedJson("nexusapikey"), IsLoggedIn.ObserveOn(RxApp.MainThreadScheduler));
-        }
-
         public IObservable<bool> IsLoggedIn => Utils.HaveEncryptedJsonObservable("nexusapikey");
 
         public string SiteName => "Nexus Mods";
 
-        public string MetaInfo
-        {
-            get
-            {
-                return "";
-            }
-        } 
-
+        public string MetaInfo => "";
 
         public Uri SiteURL => new Uri("https://www.nexusmods.com");
 
         public Uri IconUri => new Uri("https://www.nexusmods.com/favicon.ico");
-        
+
         public ICommand TriggerLogin { get; }
         public ICommand ClearLogin { get; }
+
+        public NexusDownloader()
+        {
+            TriggerLogin = ReactiveCommand.CreateFromTask(
+                execute: () => Utils.CatchAndLog(NexusApiClient.RequestAndCacheAPIKey), 
+                canExecute: IsLoggedIn.Select(b => !b).ObserveOn(RxApp.MainThreadScheduler));
+            ClearLogin = ReactiveCommand.Create(
+                execute: () => Utils.CatchAndLog(() => Utils.DeleteEncryptedJson("nexusapikey")),
+                canExecute: IsLoggedIn.ObserveOn(RxApp.MainThreadScheduler));
+        }
 
         public async Task<AbstractDownloadState> GetDownloaderState(dynamic archiveINI)
         {

--- a/Wabbajack.Lib/Downloaders/NexusDownloader.cs
+++ b/Wabbajack.Lib/Downloaders/NexusDownloader.cs
@@ -13,7 +13,7 @@ using Wabbajack.Lib.Validation;
 
 namespace Wabbajack.Lib.Downloaders
 {
-    public class NexusDownloader : ViewModel, IDownloader, INeedsLogin
+    public class NexusDownloader : IDownloader, INeedsLogin
     {
         private bool _prepared;
         private SemaphoreSlim _lock = new SemaphoreSlim(1);

--- a/Wabbajack.Lib/NexusApi/RequestNexusAuthorization.cs
+++ b/Wabbajack.Lib/NexusApi/RequestNexusAuthorization.cs
@@ -24,7 +24,7 @@ namespace Wabbajack.Lib.NexusApi
         public override void Cancel()
         {
             Handled = true;
-            _source.SetCanceled();
+            _source.TrySetCanceled();
         }
     }
 }

--- a/Wabbajack.Lib/Wabbajack.Lib.csproj
+++ b/Wabbajack.Lib/Wabbajack.Lib.csproj
@@ -45,6 +45,9 @@
     <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <WarningsAsErrors>CS4014</WarningsAsErrors>
+    <NoWarn>CS1998</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>
@@ -55,6 +58,8 @@
     <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <WarningsAsErrors>CS4014</WarningsAsErrors>
+    <NoWarn>CS1998</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="MongoDB.Bson">

--- a/Wabbajack/View Models/Compilers/MO2CompilerVM.cs
+++ b/Wabbajack/View Models/Compilers/MO2CompilerVM.cs
@@ -28,8 +28,6 @@ namespace Wabbajack
 
         public FilePickerVM ModListLocation { get; }
 
-        public IReactiveCommand BeginCommand { get; }
-
         [Reactive]
         public ACompiler ActiveCompilation { get; private set; }
 

--- a/Wabbajack/View Models/Compilers/VortexCompilerVM.cs
+++ b/Wabbajack/View Models/Compilers/VortexCompilerVM.cs
@@ -20,8 +20,6 @@ namespace Wabbajack
 
         private readonly VortexCompilationSettings _settings;
 
-        public IReactiveCommand BeginCommand { get; }
-
         private readonly ObservableAsPropertyHelper<ModlistSettingsEditorVM> _modListSettings;
         public ModlistSettingsEditorVM ModlistSettings => _modListSettings.Value;
 


### PR DESCRIPTION
PR with some odd one-off downloader improvements/fixes.   These are cherrypicked from a larger PR, so they may seem random.

No need to merge this immediately. Wanted to just start a PR on these so that I could point out a few things before I forgot about them, rather than waiting for a larger PR later.

- Nexus/LL downloader commands now try/catch their executions.   ReactiveCommands get really unhappy if exceptions are thrown (and stop firing new executions).
- New Utils.CatchAndLog convenience call.
- ViewModel/INotifyPropertyChanged concepts removed from INeedsLogin related classes.
- Global user intervention handling now try/catches so it can not halt if an error occurs.
- Downloader user intervention cancellation calls now call `TaskCompletionSource.TrySetCancelled`.  The `.Cancel()` call throws if you do it twice in a row, which was a bit obnoxious.  Would prefer to be able to cancel twice without it throwing.  (It does so currently in the wrap web browser logic, for ex)
- Removed some vestigial members (unrelated)