### PR TITLE
Cli

### DIFF
--- a/Wabbajack.Common/CLI.cs
+++ b/Wabbajack.Common/CLI.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+
+namespace Wabbajack.Common
+{
+    public static class CLIArguments
+    {
+        [CLIOptions("nosettings")]
+        public static bool NoSettings { get; set; }
+
+        [CLIOptions("apikey")]
+        public static string ApiKey { get; set; }
+    }
+
+    public static class CLI
+    {
+        /// <summary>
+        /// Parses the argument and sets the properties of <see cref="CLIArguments"/>
+        /// </summary>
+        /// <param name="args"><see cref="Environment.GetCommandLineArgs"/></param>
+        public static void ParseOptions(string[] args)
+        {
+            if (args.Length == 0) return;
+            // get all properties of the class Options
+            typeof(CLIArguments).GetProperties().Do(p =>
+            {
+                var optionAttr = (CLIOptions[])p.GetCustomAttributes(typeof(CLIOptions));
+                if (optionAttr.Length != 1)
+                    return;
+
+                var cur = optionAttr[0];
+                if (cur == null) return;
+                
+                if (cur.Option != null && args.Any(a => a.Contains($"--{cur.Option}")))
+                {
+                    if (p.PropertyType == typeof(bool))
+                    {
+                        p.SetValue(p, true);
+                        return;
+                    }
+
+                    // filter to get the actual argument
+                    var filtered = args.Where(a => a.Contains($"--{cur.Option}")).ToList();
+                    if (filtered.Count != 1) return;
+
+                    // eg: --apikey="something"
+                    var arg = filtered[0];
+                    arg = arg.Replace($"--{cur.Option}=", "");
+
+                    // prev: --apikey="something", result: something
+                    if (p.PropertyType == typeof(string))
+                        p.SetValue(p, arg);
+                }
+
+                if (cur.ShortOption == 0) return;
+            });
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Property)]
+    public class CLIOptions : Attribute
+    {
+        // --option, long name of the option. Eg: --output
+        public string Option;
+        // -shortOption, short name of the option. Eg: -o
+        public char ShortOption;
+
+        public CLIOptions(string option)
+        {
+            Option = option;
+        }
+    }
+}

--- a/Wabbajack.Common/ExtensionManager.cs
+++ b/Wabbajack.Common/ExtensionManager.cs
@@ -19,7 +19,7 @@ namespace Wabbajack.Common
         {
             {"", "Wabbajack"},
             {"FriendlyTypeName", "Wabbajack"},
-            {"shell\\open\\command",  "\"{appPath}\" -i \"%1\""},
+            {"shell\\open\\command",  "\"{appPath}\" -i=\"%1\""},
         };
 
         private static readonly Dictionary<string, string> ExtList = new Dictionary<string, string>
@@ -34,7 +34,7 @@ namespace Wabbajack.Common
             var tempKey = progIDKey?.OpenSubKey("shell\\open\\command");
             if (progIDKey == null || tempKey == null) return true;
             var value = tempKey.GetValue("");
-            return value == null || value.ToString().Equals($"\"{appPath}\" -i \"%1\"");
+            return value == null || value.ToString().Equals($"\"{appPath}\" -i=\"%1\"");
         }
 
         public static bool IsAssociated()

--- a/Wabbajack.Lib/Downloaders/NexusDownloader.cs
+++ b/Wabbajack.Lib/Downloaders/NexusDownloader.cs
@@ -35,6 +35,11 @@ namespace Wabbajack.Lib.Downloaders
 
         public NexusDownloader()
         {
+            if (CLIArguments.ApiKey != null)
+            {
+                CLIArguments.ApiKey.ToEcryptedJson("nexusapikey");
+            }
+
             TriggerLogin = ReactiveCommand.CreateFromTask(
                 execute: () => Utils.CatchAndLog(NexusApiClient.RequestAndCacheAPIKey), 
                 canExecute: IsLoggedIn.Select(b => !b).ObserveOn(RxApp.MainThreadScheduler));

--- a/Wabbajack/App.xaml.cs
+++ b/Wabbajack/App.xaml.cs
@@ -14,7 +14,7 @@ namespace Wabbajack
     {
         public App()
         {
-            // Do initialization in MainWindow ctor
+            CLI.ParseOptions(Environment.GetCommandLineArgs());
         }
     }
 }

--- a/Wabbajack/View Models/MainWindowVM.cs
+++ b/Wabbajack/View Models/MainWindowVM.cs
@@ -129,16 +129,16 @@ namespace Wabbajack
                     .Select(active => !SettingsPane.IsValueCreated || !object.ReferenceEquals(active, SettingsPane.Value)),
                 execute: () => NavigateTo(SettingsPane.Value));
         }
+
         private static bool IsStartingFromModlist(out string modlistPath)
         {
-            string[] args = Environment.GetCommandLineArgs();
-            if (args.Length != 3 || !args[1].Contains("-i"))
+            if (CLIArguments.InstallPath == null)
             {
                 modlistPath = default;
                 return false;
             }
 
-            modlistPath = args[2];
+            modlistPath = CLIArguments.InstallPath;
             return true;
         }
 

--- a/Wabbajack/Views/MainWindow.xaml.cs
+++ b/Wabbajack/Views/MainWindow.xaml.cs
@@ -48,9 +48,7 @@ namespace Wabbajack
             }).FireAndForget();
 
             // Load settings
-            string[] args = Environment.GetCommandLineArgs();
-            if ((args.Length > 1 && args[1] == "nosettings")
-                || !MainSettings.TryLoadTypicalSettings(out var settings))
+            if (CLIArguments.NoSettings || !MainSettings.TryLoadTypicalSettings(out var settings))
             {
                 _settings = new MainSettings();
                 RunWhenLoaded(DefaultSettings);


### PR DESCRIPTION
Created a foundation for future CLI usages. The `CLIArguments` class gets populated on startup using the `CLI.ParseOptions` function.

Current CLI options:
`--nosettings`, loads standard settings on startup
`-i="path"`, when opening a `.wabbajack` file, installs the modlist at `path`
`--apikey="key"`, manually entering the apikey so you dont have to login. If this value is set than it gets encrypted to json in the `NexusDownloader`

We can expand on this and I will look into creating a `help` argument next.