### PR TITLE
Cpu display optimization

### DIFF
--- a/Wabbajack.Lib/Downloaders/AbstractNeedsLoginDownloader.cs
+++ b/Wabbajack.Lib/Downloaders/AbstractNeedsLoginDownloader.cs
@@ -42,10 +42,10 @@ namespace Wabbajack.Lib.Downloaders
             
             TriggerLogin = ReactiveCommand.CreateFromTask(
                 execute: () => Utils.CatchAndLog(async () => await Utils.Log(new RequestSiteLogin(this)).Task),
-                canExecute: IsLoggedIn.Select(b => !b).ObserveOn(RxApp.MainThreadScheduler));
+                canExecute: IsLoggedIn.Select(b => !b).ObserveOnGuiThread());
             ClearLogin = ReactiveCommand.Create(
                 execute: () => Utils.CatchAndLog(() => Utils.DeleteEncryptedJson(_encryptedKeyName)),
-                canExecute: IsLoggedIn.ObserveOn(RxApp.MainThreadScheduler));
+                canExecute: IsLoggedIn.ObserveOnGuiThread());
         }
         
         public ICommand TriggerLogin { get; }

--- a/Wabbajack.Lib/Downloaders/NexusDownloader.cs
+++ b/Wabbajack.Lib/Downloaders/NexusDownloader.cs
@@ -42,10 +42,10 @@ namespace Wabbajack.Lib.Downloaders
 
             TriggerLogin = ReactiveCommand.CreateFromTask(
                 execute: () => Utils.CatchAndLog(NexusApiClient.RequestAndCacheAPIKey), 
-                canExecute: IsLoggedIn.Select(b => !b).ObserveOn(RxApp.MainThreadScheduler));
+                canExecute: IsLoggedIn.Select(b => !b).ObserveOnGuiThread());
             ClearLogin = ReactiveCommand.Create(
                 execute: () => Utils.CatchAndLog(() => Utils.DeleteEncryptedJson("nexusapikey")),
-                canExecute: IsLoggedIn.ObserveOn(RxApp.MainThreadScheduler));
+                canExecute: IsLoggedIn.ObserveOnGuiThread());
         }
 
         public async Task<AbstractDownloadState> GetDownloaderState(dynamic archiveINI)

--- a/Wabbajack/Extensions/DynamicDataExt.cs
+++ b/Wabbajack/Extensions/DynamicDataExt.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DynamicData;
+
+namespace Wabbajack
+{
+    public static class DynamicDataExt
+    {
+        public static IObservable<IChangeSet<TCache, TKey>> TransformAndCache<TObject, TKey, TCache>(
+            this IObservable<IChangeSet<TObject, TKey>> obs,
+            Func<TKey, TObject, TCache> onAdded,
+            Action<Change<TObject, TKey>, TCache> onUpdated)
+        {
+            var cache = new ChangeAwareCache<TCache, TKey>();
+            return obs
+                .Select(changeSet =>
+                {
+                    foreach (var change in changeSet)
+                    {
+                        switch (change.Reason)
+                        {
+                            case ChangeReason.Add:
+                            case ChangeReason.Update:
+                            case ChangeReason.Refresh:
+                                var lookup = cache.Lookup(change.Key);
+                                TCache val;
+                                if (lookup.HasValue)
+                                {
+                                    val = lookup.Value;
+                                }
+                                else
+                                {
+                                    val = onAdded(change.Key, change.Current);
+                                    cache.Add(val, change.Key);
+                                }
+                                onUpdated(change, val);
+                                break;
+                            case ChangeReason.Remove:
+                                cache.Remove(change.Key);
+                                break;
+                            case ChangeReason.Moved:
+                                break;
+                            default:
+                                throw new NotImplementedException();
+                        }
+                    }
+                    return cache.CaptureChanges();
+                })
+                .Where(cs => cs.Count > 0);
+        }
+    }
+}

--- a/Wabbajack/View Models/CPUDisplayVM.cs
+++ b/Wabbajack/View Models/CPUDisplayVM.cs
@@ -3,23 +3,46 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using ReactiveUI.Fody.Helpers;
 using Wabbajack.Common;
+using Wabbajack.Lib;
 
 namespace Wabbajack
 {
-    public class CPUDisplayVM
+    public class CPUDisplayVM : ViewModel
     {
-        public CPUStatus Status { get; set; }
+        [Reactive]
+        public int ID { get; set; }
+        [Reactive]
         public DateTime StartTime { get; set; }
+        [Reactive]
+        public bool IsWorking { get; set; }
+        [Reactive]
+        public string Msg { get; set; }
+        [Reactive]
+        public float ProgressPercent { get; set; }
+
+        public CPUDisplayVM()
+        {
+        }
+
+        public CPUDisplayVM(CPUStatus cpu)
+        {
+            AbsorbStatus(cpu);
+        }
 
         public void AbsorbStatus(CPUStatus cpu)
         {
-            bool starting = cpu.IsWorking && ((!Status?.IsWorking) ?? true);
-            Status = cpu;
+            bool starting = cpu.IsWorking && !IsWorking;
             if (starting)
             {
                 StartTime = DateTime.Now;
             }
+
+            ID = cpu.ID;
+            Msg = cpu.Msg;
+            ProgressPercent = cpu.ProgressPercent;
+            IsWorking = cpu.IsWorking;
         }
     }
 }

--- a/Wabbajack/View Models/Compilers/CompilerVM.cs
+++ b/Wabbajack/View Models/Compilers/CompilerVM.cs
@@ -1,4 +1,4 @@
-﻿using DynamicData;
+using DynamicData;
 using DynamicData.Binding;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
@@ -123,7 +123,7 @@ namespace Wabbajack
                 // Throttle so that it only loads image after any sets of swaps have completed
                 .Throttle(TimeSpan.FromMilliseconds(50), RxApp.TaskpoolScheduler)
                 .DistinctUntilChanged()
-                .ObserveOn(RxApp.MainThreadScheduler)
+                .ObserveOnGuiThread()
                 .Select(path =>
                 {
                     if (string.IsNullOrWhiteSpace(path)) return UIUtils.BitmapImageFromResource("Resources/Wabba_Mouth_No_Text.png");
@@ -172,8 +172,8 @@ namespace Wabbajack
                 .Batch(TimeSpan.FromMilliseconds(50), RxApp.TaskpoolScheduler)
                 .EnsureUniqueChanges()
                 .Filter(i => i.Status.IsWorking && i.Status.ID != WorkQueue.UnassignedCpuId)
-                .ObserveOn(RxApp.MainThreadScheduler)
                 .Sort(SortExpressionComparer<CPUDisplayVM>.Ascending(s => s.StartTime))
+                .ObserveOnGuiThread()
                 .Bind(StatusList)
                 .Subscribe()
                 .DisposeWith(CompositeDisposable);

--- a/Wabbajack/View Models/Installers/InstallerVM.cs
+++ b/Wabbajack/View Models/Installers/InstallerVM.cs
@@ -317,7 +317,7 @@ namespace Wabbajack
                 .Batch(TimeSpan.FromMilliseconds(50), RxApp.TaskpoolScheduler)
                 .EnsureUniqueChanges()
                 .Filter(i => i.Status.IsWorking && i.Status.ID != WorkQueue.UnassignedCpuId)
-                .ObserveOn(RxApp.MainThreadScheduler)
+                .ObserveOnGuiThread()
                 .Sort(SortExpressionComparer<CPUDisplayVM>.Ascending(s => s.StartTime))
                 .Bind(StatusList)
                 .Subscribe()

--- a/Wabbajack/View Models/Installers/InstallerVM.cs
+++ b/Wabbajack/View Models/Installers/InstallerVM.cs
@@ -299,28 +299,10 @@ namespace Wabbajack
                     })
                 .ToProperty(this, nameof(ProgressTitle));
 
-            Dictionary<int, CPUDisplayVM> cpuDisplays = new Dictionary<int, CPUDisplayVM>();
-            // Compile progress updates and populate ObservableCollection
-            this.WhenAny(x => x.Installer.ActiveInstallation)
-                .SelectMany(c => c?.QueueStatus ?? Observable.Empty<CPUStatus>())
-                .ObserveOn(RxApp.TaskpoolScheduler)
-                // Attach start times to incoming CPU items
-                .Scan(
-                    new CPUDisplayVM(),
-                    (_, cpu) =>
-                    {
-                        var ret = cpuDisplays.TryCreate(cpu.ID);
-                        ret.AbsorbStatus(cpu);
-                        return ret;
-                    })
-                .ToObservableChangeSet(x => x.Status.ID)
-                .Batch(TimeSpan.FromMilliseconds(50), RxApp.TaskpoolScheduler)
-                .EnsureUniqueChanges()
-                .Filter(i => i.Status.IsWorking && i.Status.ID != WorkQueue.UnassignedCpuId)
-                .ObserveOnGuiThread()
-                .Sort(SortExpressionComparer<CPUDisplayVM>.Ascending(s => s.StartTime))
-                .Bind(StatusList)
-                .Subscribe()
+            UIUtils.BindCpuStatus(
+                this.WhenAny(x => x.Installer.ActiveInstallation)
+                    .SelectMany(c => c?.QueueStatus ?? Observable.Empty<CPUStatus>()),
+                StatusList)
                 .DisposeWith(CompositeDisposable);
 
             BeginCommand = ReactiveCommand.CreateFromTask(

--- a/Wabbajack/View Models/MainWindowVM.cs
+++ b/Wabbajack/View Models/MainWindowVM.cs
@@ -63,8 +63,8 @@ namespace Wabbajack
                 .ToObservableChangeSet()
                 .Buffer(TimeSpan.FromMilliseconds(250), RxApp.TaskpoolScheduler)
                 .Where(l => l.Count > 0)
-                .ObserveOn(RxApp.MainThreadScheduler)
                 .FlattenBufferResult()
+                .ObserveOnGuiThread()
                 .Bind(Log)
                 .Subscribe()
                 .DisposeWith(CompositeDisposable);

--- a/Wabbajack/View Models/ModListVM.cs
+++ b/Wabbajack/View Models/ModListVM.cs
@@ -67,7 +67,7 @@ namespace Wabbajack
                         return default(MemoryStream);
                     }
                 })
-                .ObserveOn(RxApp.MainThreadScheduler)
+                .ObserveOnGuiThread()
                 .Select(memStream =>
                 {
                     if (memStream == null) return default(BitmapImage);

--- a/Wabbajack/View Models/ModVM.cs
+++ b/Wabbajack/View Models/ModVM.cs
@@ -64,7 +64,7 @@ namespace Wabbajack
                         return default;
                     }
                 })
-                .ObserveOn(RxApp.MainThreadScheduler)
+                .ObserveOnGuiThread()
                 .Select(memStream =>
                 {
                     if (memStream == null) return default;

--- a/Wabbajack/View Models/ModeSelectionVM.cs
+++ b/Wabbajack/View Models/ModeSelectionVM.cs
@@ -1,6 +1,6 @@
-﻿using Alphaleonis.Win32.Filesystem;
-using ReactiveUI;
+﻿using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
+using System.IO;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Windows.Input;

--- a/Wabbajack/View Models/SlideShow.cs
+++ b/Wabbajack/View Models/SlideShow.cs
@@ -108,7 +108,7 @@ namespace Wabbajack
                         return query.Items.ElementAtOrDefault(index);
                     })
                 .StartWith(default(ModVM))
-                .ObserveOn(RxApp.MainThreadScheduler)
+                .ObserveOnGuiThread()
                 .ToProperty(this, nameof(TargetMod));
 
             // Mark interest and materialize image of target mod

--- a/Wabbajack/Views/Common/CpuView.xaml
+++ b/Wabbajack/Views/Common/CpuView.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl
+<UserControl
     x:Class="Wabbajack.CpuView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -25,22 +25,22 @@
                             BorderThickness="0"
                             Foreground="{StaticResource DarkPrimaryVariantBrush}"
                             Maximum="1"
-                            Opacity="{Binding Status.ProgressPercent, Mode=OneWay}"
-                            Value="{Binding Status.ProgressPercent, Mode=OneWay}" />
+                            Opacity="{Binding ProgressPercent, Mode=OneWay}"
+                            Value="{Binding ProgressPercent, Mode=OneWay}" />
                         <Grid Height="1" VerticalAlignment="Bottom">
                             <mahapps:MetroProgressBar
                                 Background="Transparent"
                                 BorderThickness="0"
                                 Foreground="{StaticResource DarkSecondaryBrush}"
                                 Maximum="1"
-                                Value="{Binding Status.ProgressPercent, Mode=OneWay}" />
+                                Value="{Binding ProgressPercent, Mode=OneWay}" />
                         </Grid>
                         <TextBlock
                             Margin="0,0,0,2"
-                            Text="{Binding Status.Msg}"
+                            Text="{Binding Msg, Mode=OneWay}"
                             TextTrimming="CharacterEllipsis"
                             TextWrapping="NoWrap"
-                            ToolTip="{Binding Status.Msg}" />
+                            ToolTip="{Binding Msg, Mode=OneWay}" />
                     </Grid>
                 </DataTemplate>
             </ListBox.ItemTemplate>

--- a/Wabbajack/Wabbajack.csproj
+++ b/Wabbajack/Wabbajack.csproj
@@ -172,6 +172,7 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Compile Include="Extensions\DynamicDataExt.cs" />
     <Compile Include="UI\FilePickerVM.cs" />
     <Compile Include="UI\UIUtils.cs" />
     <Compile Include="Util\SystemParametersConstructor.cs" />
@@ -584,8 +585,6 @@
   <ItemGroup>
     <SplashScreen Include="Resources\Wabba_Mouth_Small.png" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="UserInterventions\" />
-  </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
Optimizations to make updating the CPU display less heavy on the GUI thread.

Problem was that for every CPU update that came down the line, it trigged an update on the ObservableCollection (Update, or Remove/Add).  This makes the ListBox/ItemsControl/ScrollViewer have to re-evaluate their sizes and virtualization, etc, which is relatively heavy for how often it was happening.

Added a DynamicData extension method to instead only create/remove a VM when an item is added, otherwise, call an "absorb" function to just update the fields on the `CpuDisplayVM` itself.  This way, the ObservableCollection is left alone most of the time, saving lots of strain.