### PR TITLE
Image Loading Display and GUI GC correctness pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ### Changelog
 
+* Progress ring displays when downloading modlist images
+* GUI releases memory of download modlists better when navigating around
+* Fixed phrasing after failed installations to say "failed".
+
 #### Version - 1.0 beta 15 - 1/6/2020
 * Don't delete the download folder when deleting empty folders during an update
 * If `Game Folder Files` exists in the MO2 folder during compilation the Game folder will be ignored as a file source

--- a/Wabbajack.Common/Extensions/RxExt.cs
+++ b/Wabbajack.Common/Extensions/RxExt.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Reactive;
 using System.Reactive.Concurrency;
@@ -67,7 +67,7 @@ namespace Wabbajack
         /// <param name="filterSwitch">On/Off signal of whether to subscribe to source observable</param>
         /// <param name="valueOnOff">Value to fire when switching off</param>
         /// <returns>Observable that publishes data from source, if the switch is on.</returns>
-        public static IObservable<T> FilterSwitch<T>(this IObservable<T> source, IObservable<bool> filterSwitch, T valueWhenOff)
+        public static IObservable<T> FlowSwitch<T>(this IObservable<T> source, IObservable<bool> filterSwitch, T valueWhenOff)
         {
             return filterSwitch
                 .DistinctUntilChanged()
@@ -225,6 +225,22 @@ namespace Wabbajack
                     .Delay(delay, scheduler)
                     .Select(_ => true)
                     .StartWith(false));
+        }
+
+        public static IObservable<T> DisposeOld<T>(this IObservable<T> source)
+            where T : IDisposable
+        {
+            return source
+                .StartWith(default(T))
+                .Pairwise()
+                .Do(x =>
+                {
+                    if (x.Previous != null)
+                    {
+                        x.Previous.Dispose();
+                    }
+                })
+                .Select(x => x.Current);
         }
     }
 }

--- a/Wabbajack.Common/Extensions/RxExt.cs
+++ b/Wabbajack.Common/Extensions/RxExt.cs
@@ -88,7 +88,7 @@ namespace Wabbajack
         /// Inspiration:
         /// http://reactivex.io/documentation/operators/debounce.html
         /// https://stackoverflow.com/questions/20034476/how-can-i-use-reactive-extensions-to-throttle-events-using-a-max-window-size
-        public static IObservable<T> Debounce<T>(this IObservable<T> source, TimeSpan interval, IScheduler scheduler = null)
+        public static IObservable<T> Debounce<T>(this IObservable<T> source, TimeSpan interval, IScheduler scheduler)
         {
             scheduler = scheduler ?? Scheduler.Default;
             return Observable.Create<T>(o =>
@@ -207,15 +207,6 @@ namespace Wabbajack
                 prevStorage = i;
                 return (prev, i);
             });
-        }
-
-        public static IObservable<T> DelayInitial<T>(this IObservable<T> source, TimeSpan delay)
-        {
-            return source.FlowSwitch(
-                Observable.Return(System.Reactive.Unit.Default)
-                    .Delay(delay)
-                    .Select(_ => true)
-                    .StartWith(false));
         }
 
         public static IObservable<T> DelayInitial<T>(this IObservable<T> source, TimeSpan delay, IScheduler scheduler)

--- a/Wabbajack.Common/Utils.cs
+++ b/Wabbajack.Common/Utils.cs
@@ -1131,9 +1131,7 @@ namespace Wabbajack.Common
 
         public static HashSet<T> ToHashSet<T>(this IEnumerable<T> coll)
         {
-            var hs = new HashSet<T>();
-            coll.Do(v => hs.Add(v));
-            return hs;
+            return new HashSet<T>(coll);
         }
         
         public static HashSet<T> ToHashSet<T>(this T[] coll)

--- a/Wabbajack.Lib/Extensions/ReactiveUIExt.cs
+++ b/Wabbajack.Lib/Extensions/ReactiveUIExt.cs
@@ -2,10 +2,12 @@
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reactive;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using DynamicData;
 using DynamicData.Kernel;
 using ReactiveUI;
+using Wabbajack.Lib;
 
 namespace Wabbajack
 {
@@ -78,6 +80,29 @@ namespace Wabbajack
             return new ChangeSet<TObject, TKey>(changes);
         }
 
+        public static ObservableAsPropertyHelper<TRet> ToGuiProperty<TRet>(
+            this IObservable<TRet> source,
+            ViewModel vm,
+            string property,
+            TRet initialValue = default,
+            bool deferSubscription = false)
+        {
+            return source
+                .ToProperty(vm, property, initialValue, deferSubscription, RxApp.MainThreadScheduler)
+                .DisposeWith(vm.CompositeDisposable);
+        }
+
+        public static void ToGuiProperty<TRet>(
+            this IObservable<TRet> source,
+            ViewModel vm,
+            string property,
+            out ObservableAsPropertyHelper<TRet> result,
+            TRet initialValue = default,
+            bool deferSubscription = false)
+        {
+            source.ToProperty(vm, property, out result, initialValue, deferSubscription, RxApp.MainThreadScheduler)
+                .DisposeWith(vm.CompositeDisposable);
+        }
 
         internal static Optional<Change<TObject, TKey>> Reduce<TObject, TKey>(Optional<Change<TObject, TKey>> previous, Change<TObject, TKey> next)
         {

--- a/Wabbajack/UI/FilePickerVM.cs
+++ b/Wabbajack/UI/FilePickerVM.cs
@@ -147,9 +147,8 @@ namespace Wabbajack
                     }
                 })
                 .DistinctUntilChanged()
-                .ObserveOnGuiThread()
                 .StartWith(false)
-                .ToProperty(this, nameof(Exists));
+                .ToGuiProperty(this, nameof(Exists));
 
             var passesFilters = Observable.CombineLatest(
                     this.WhenAny(x => x.TargetPath),
@@ -218,12 +217,11 @@ namespace Wabbajack
                         if (filter.Failed) return filter;
                         return ErrorResponse.Convert(err);
                     })
-                .ObserveOnGuiThread()
-                .ToProperty(this, nameof(ErrorState));
+                .ToGuiProperty(this, nameof(ErrorState));
 
             _inError = this.WhenAny(x => x.ErrorState)
                 .Select(x => !x.Succeeded)
-                .ToProperty(this, nameof(InError));
+                .ToGuiProperty(this, nameof(InError));
 
             // Doesn't derive from ErrorState, as we want to bubble non-empty tooltips,
             // which is slightly different logic
@@ -244,8 +242,7 @@ namespace Wabbajack
                         if (!string.IsNullOrWhiteSpace(filters)) return filters;
                         return err?.Reason;
                     })
-                .ObserveOnGuiThread()
-                .ToProperty(this, nameof(ErrorTooltip));
+                .ToGuiProperty(this, nameof(ErrorTooltip));
         }
 
         public ICommand ConstructTypicalPickerCommand()

--- a/Wabbajack/UI/FilePickerVM.cs
+++ b/Wabbajack/UI/FilePickerVM.cs
@@ -80,7 +80,7 @@ namespace Wabbajack
                     this.WhenAny(x => x.TargetPath)
                         // Dont want to debounce the initial value, because we know it's null
                         .Skip(1)
-                        .Debounce(TimeSpan.FromMilliseconds(200), RxApp.TaskpoolScheduler)
+                        .Debounce(TimeSpan.FromMilliseconds(200), RxApp.MainThreadScheduler)
                         .StartWith(default(string)),
                     resultSelector: (existsOption, type, path) => (ExistsOption: existsOption, Type: type, Path: path))
                 .StartWith((ExistsOption: ExistCheckOption, Type: PathType, Path: TargetPath))

--- a/Wabbajack/View Models/BackNavigatingVM.cs
+++ b/Wabbajack/View Models/BackNavigatingVM.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reactive;
@@ -36,7 +36,7 @@ namespace Wabbajack
                     .ObserveOnGuiThread());
 
             _IsActive = this.ConstructIsActive(mainWindowVM)
-                .ToProperty(this, nameof(IsActive));
+                .ToGuiProperty(this, nameof(IsActive));
         }
     }
 

--- a/Wabbajack/View Models/BackNavigatingVM.cs
+++ b/Wabbajack/View Models/BackNavigatingVM.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reactive;
@@ -35,8 +35,7 @@ namespace Wabbajack
                 canExecute: this.ConstructCanNavigateBack()
                     .ObserveOnGuiThread());
 
-            _IsActive = mainWindowVM.WhenAny(x => x.ActivePane)
-                .Select(x => object.ReferenceEquals(this, x))
+            _IsActive = this.ConstructIsActive(mainWindowVM)
                 .ToProperty(this, nameof(IsActive));
         }
     }
@@ -47,6 +46,12 @@ namespace Wabbajack
         {
             return vm.WhenAny(x => x.NavigateBackTarget)
                 .Select(x => x != null);
+        }
+
+        public static IObservable<bool> ConstructIsActive(this IBackNavigatingVM vm, MainWindowVM mwvm)
+        {
+            return mwvm.WhenAny(x => x.ActivePane)
+                .Select(x => object.ReferenceEquals(vm, x));
         }
     }
 }

--- a/Wabbajack/View Models/Compilers/CompilerVM.cs
+++ b/Wabbajack/View Models/Compilers/CompilerVM.cs
@@ -123,7 +123,7 @@ namespace Wabbajack
 
             _image = this.WhenAny(x => x.CurrentModlistSettings.ImagePath.TargetPath)
                 // Throttle so that it only loads image after any sets of swaps have completed
-                .Throttle(TimeSpan.FromMilliseconds(50), RxApp.TaskpoolScheduler)
+                .Throttle(TimeSpan.FromMilliseconds(50), RxApp.MainThreadScheduler)
                 .DistinctUntilChanged()
                 .ObserveOnGuiThread()
                 .Select(path =>
@@ -174,7 +174,7 @@ namespace Wabbajack
                         return compiler.PercentCompleted.StartWith(0);
                     })
                 .Switch()
-                .Debounce(TimeSpan.FromMilliseconds(25))
+                .Debounce(TimeSpan.FromMilliseconds(25), RxApp.MainThreadScheduler)
                 .ToGuiProperty(this, nameof(PercentCompleted));
 
             BeginCommand = ReactiveCommand.CreateFromTask(

--- a/Wabbajack/View Models/Compilers/CompilerVM.cs
+++ b/Wabbajack/View Models/Compilers/CompilerVM.cs
@@ -243,18 +243,24 @@ namespace Wabbajack
                     }
                 });
 
-            _progressTitle = Observable.CombineLatest(
-                    this.WhenAny(x => x.Compiling),
-                    this.WhenAny(x => x.StartedCompilation),
-                    resultSelector: (compiling, started) =>
+            _progressTitle = this.WhenAnyValue(
+                    x => x.Compiling,
+                    x => x.StartedCompilation,
+                    x => x.Completed,
+                    selector: (compiling, started, completed) =>
                     {
                         if (compiling)
                         {
                             return "Compiling";
                         }
+                        else if (started)
+                        {
+                            if (completed == null) return "Compiling";
+                            return completed.Value.Succeeded ? "Compiled" : "Failed";
+                        }
                         else
                         {
-                            return started ? "Compiled" : "Configuring";
+                            return "Configuring";
                         }
                     })
                 .ToProperty(this, nameof(ProgressTitle));

--- a/Wabbajack/View Models/Compilers/CompilerVM.cs
+++ b/Wabbajack/View Models/Compilers/CompilerVM.cs
@@ -115,11 +115,11 @@ namespace Wabbajack
                     pair.Previous?.Unload();
                 })
                 .Select(p => p.Current)
-                .ToProperty(this, nameof(Compiler));
+                .ToGuiProperty(this, nameof(Compiler));
 
             // Let sub VM determine what settings we're displaying and when
             _currentModlistSettings = this.WhenAny(x => x.Compiler.ModlistSettings)
-                .ToProperty(this, nameof(CurrentModlistSettings));
+                .ToGuiProperty(this, nameof(CurrentModlistSettings));
 
             _image = this.WhenAny(x => x.CurrentModlistSettings.ImagePath.TargetPath)
                 // Throttle so that it only loads image after any sets of swaps have completed
@@ -135,12 +135,11 @@ namespace Wabbajack
                     }
                     return null;
                 })
-                .ToProperty(this, nameof(Image));
+                .ToGuiProperty(this, nameof(Image));
 
             _compiling = this.WhenAny(x => x.Compiler.ActiveCompilation)
                 .Select(compilation => compilation != null)
-                .ObserveOnGuiThread()
-                .ToProperty(this, nameof(Compiling));
+                .ToGuiProperty(this, nameof(Compiling));
 
             BackCommand = ReactiveCommand.Create(
                 execute: () =>
@@ -176,7 +175,7 @@ namespace Wabbajack
                     })
                 .Switch()
                 .Debounce(TimeSpan.FromMilliseconds(25))
-                .ToProperty(this, nameof(PercentCompleted));
+                .ToGuiProperty(this, nameof(PercentCompleted));
 
             BeginCommand = ReactiveCommand.CreateFromTask(
                 canExecute: this.WhenAny(x => x.Compiler.CanCompile)
@@ -217,8 +216,7 @@ namespace Wabbajack
             _ActiveGlobalUserIntervention = activeInterventions.Connect()
                 .Filter(x => x.CpuID == WorkQueue.UnassignedCpuId)
                 .QueryWhenChanged(query => query.FirstOrDefault())
-                .ObserveOnGuiThread()
-                .ToProperty(this, nameof(ActiveGlobalUserIntervention));
+                .ToGuiProperty(this, nameof(ActiveGlobalUserIntervention));
 
             CloseWhenCompleteCommand = ReactiveCommand.Create(
                 canExecute: this.WhenAny(x => x.Completed)
@@ -263,12 +261,11 @@ namespace Wabbajack
                             return "Configuring";
                         }
                     })
-                .ToProperty(this, nameof(ProgressTitle));
+                .ToGuiProperty(this, nameof(ProgressTitle));
 
             _CurrentCpuCount = this.WhenAny(x => x.Compiler.ActiveCompilation.Queue.CurrentCpuCount)
                 .Switch()
-                .ObserveOnGuiThread()
-                .ToProperty(this, nameof(CurrentCpuCount));
+                .ToGuiProperty(this, nameof(CurrentCpuCount));
         }
     }
 }

--- a/Wabbajack/View Models/Compilers/MO2CompilerVM.cs
+++ b/Wabbajack/View Models/Compilers/MO2CompilerVM.cs
@@ -68,7 +68,7 @@ namespace Wabbajack
                         return null;
                     }
                 })
-                .ToProperty(this, nameof(Mo2Folder));
+                .ToGuiProperty(this, nameof(Mo2Folder));
             _moProfile = this.WhenAny(x => x.ModListLocation.TargetPath)
                 .Select(loc =>
                 {
@@ -82,7 +82,7 @@ namespace Wabbajack
                         return null;
                     }
                 })
-                .ToProperty(this, nameof(MOProfile));
+                .ToGuiProperty(this, nameof(MOProfile));
 
             // Wire missing Mo2Folder to signal error state for ModList Location
             ModListLocation.AdditionalError = this.WhenAny(x => x.Mo2Folder)
@@ -116,9 +116,7 @@ namespace Wabbajack
                     pair.Current?.Init();
                 })
                 .Select(x => x.Current)
-                // Save to property
-                .ObserveOnGuiThread()
-                .ToProperty(this, nameof(ModlistSettings));
+                .ToGuiProperty(this, nameof(ModlistSettings));
 
             CanCompile = Observable.CombineLatest(
                     this.WhenAny(x => x.ModListLocation.InError),

--- a/Wabbajack/View Models/Compilers/MO2CompilerVM.cs
+++ b/Wabbajack/View Models/Compilers/MO2CompilerVM.cs
@@ -98,7 +98,7 @@ namespace Wabbajack
                     (this).WhenAny(x => x.ModListLocation.TargetPath),
                     resultSelector: (state, path) => (State: state, Path: path))
                 // A short throttle is a quick hack to make the above changes "atomic"
-                .Throttle(TimeSpan.FromMilliseconds(25))
+                .Throttle(TimeSpan.FromMilliseconds(25), RxApp.MainThreadScheduler)
                 .Select(u =>
                 {
                     if (u.State.Failed) return null;
@@ -142,7 +142,7 @@ namespace Wabbajack
 
             // If Mo2 folder changes and download location is empty, set it for convenience
             this.WhenAny(x => x.Mo2Folder)
-                .DelayInitial(TimeSpan.FromMilliseconds(100))
+                .DelayInitial(TimeSpan.FromMilliseconds(100), RxApp.MainThreadScheduler)
                 .Where(x => Directory.Exists(x))
                 .FlowSwitch(
                     (this).WhenAny(x => x.DownloadLocation.Exists)

--- a/Wabbajack/View Models/Compilers/MO2CompilerVM.cs
+++ b/Wabbajack/View Models/Compilers/MO2CompilerVM.cs
@@ -143,7 +143,7 @@ namespace Wabbajack
                 .DisposeWith(CompositeDisposable);
 
             // If Mo2 folder changes and download location is empty, set it for convenience
-            (this).WhenAny(x => x.Mo2Folder)
+            this.WhenAny(x => x.Mo2Folder)
                 .DelayInitial(TimeSpan.FromMilliseconds(100))
                 .Where(x => Directory.Exists(x))
                 .FlowSwitch(

--- a/Wabbajack/View Models/Compilers/VortexCompilerVM.cs
+++ b/Wabbajack/View Models/Compilers/VortexCompilerVM.cs
@@ -94,9 +94,7 @@ namespace Wabbajack
                     current?.Init();
                 })
                 .Select(x => x.Current)
-                // Save to property
-                .ObserveOnGuiThread()
-                .ToProperty(this, nameof(ModlistSettings));
+                .ToGuiProperty(this, nameof(ModlistSettings));
 
             CanCompile = Observable.CombineLatest(
                     this.WhenAny(x => x.GameLocation.InError),

--- a/Wabbajack/View Models/Installers/InstallerVM.cs
+++ b/Wabbajack/View Models/Installers/InstallerVM.cs
@@ -172,7 +172,7 @@ namespace Wabbajack
                     return x.path;
                 })
                 // Throttle slightly so changes happen more atomically
-                .Throttle(TimeSpan.FromMilliseconds(50))
+                .Throttle(TimeSpan.FromMilliseconds(50), RxApp.MainThreadScheduler)
                 .Replay(1)
                 .RefCount();
 
@@ -192,7 +192,7 @@ namespace Wabbajack
 
             // Force GC collect when modlist changes, just to make sure we clean up any loose large items immediately
             this.WhenAny(x => x.ModList)
-                .Delay(TimeSpan.FromMilliseconds(50))
+                .Delay(TimeSpan.FromMilliseconds(50), RxApp.MainThreadScheduler)
                 .Subscribe(x =>
                 {
                     GC.Collect();
@@ -252,7 +252,7 @@ namespace Wabbajack
                         return installer.PercentCompleted.StartWith(0f);
                     })
                 .Switch()
-                .Debounce(TimeSpan.FromMilliseconds(25))
+                .Debounce(TimeSpan.FromMilliseconds(25), RxApp.MainThreadScheduler)
                 .ToGuiProperty(this, nameof(PercentCompleted));
 
             Slideshow = new SlideShow(this);

--- a/Wabbajack/View Models/Installers/InstallerVM.cs
+++ b/Wabbajack/View Models/Installers/InstallerVM.cs
@@ -1,4 +1,4 @@
-using Syroot.Windows.IO;
+﻿using Syroot.Windows.IO;
 using System;
 using ReactiveUI;
 using System.Diagnostics;
@@ -147,7 +147,7 @@ namespace Wabbajack
                     pair.Previous?.Unload();
                 })
                 .Select(p => p.Current)
-                .ToProperty(this, nameof(Installer));
+                .ToGuiProperty(this, nameof(Installer));
 
             // Load settings
             MWVM.Settings.SaveSignal
@@ -158,7 +158,7 @@ namespace Wabbajack
                 .DisposeWith(CompositeDisposable);
 
             _IsActive = this.ConstructIsActive(MWVM)
-                .ToProperty(this, nameof(IsActive));
+                .ToGuiProperty(this, nameof(IsActive));
 
             // Active path represents the path to currently have loaded
             // If we're not actively showing, then "unload" the active path
@@ -188,7 +188,7 @@ namespace Wabbajack
                 .DisposeOld()
                 .ObserveOnGuiThread()
                 .StartWith(default(ModListVM))
-                .ToProperty(this, nameof(ModList));
+                .ToGuiProperty(this, nameof(ModList));
 
             // Force GC collect when modlist changes, just to make sure we clean up any loose large items immediately
             this.WhenAny(x => x.ModList)
@@ -205,17 +205,16 @@ namespace Wabbajack
                     // When the resulting modlist comes in, mark it as done
                     this.WhenAny(x => x.ModList)
                         .Select(_ => false))
-                .ToProperty(this, nameof(LoadingModlist));
+                .ToGuiProperty(this, nameof(LoadingModlist));
             _htmlReport = this.WhenAny(x => x.ModList)
                 .Select(modList => modList?.ReportHTML)
-                .ToProperty(this, nameof(HTMLReport));
+                .ToGuiProperty(this, nameof(HTMLReport));
             _installing = this.WhenAny(x => x.Installer.ActiveInstallation)
                 .Select(i => i != null)
-                .ObserveOnGuiThread()
-                .ToProperty(this, nameof(Installing));
+                .ToGuiProperty(this, nameof(Installing));
             _TargetManager = this.WhenAny(x => x.ModList)
                 .Select(modList => modList?.ModManager)
-                .ToProperty(this, nameof(TargetManager));
+                .ToGuiProperty(this, nameof(TargetManager));
 
             // Add additional error check on ModList
             ModListLocation.AdditionalError = this.WhenAny(x => x.ModList)
@@ -254,7 +253,7 @@ namespace Wabbajack
                     })
                 .Switch()
                 .Debounce(TimeSpan.FromMilliseconds(25))
-                .ToProperty(this, nameof(PercentCompleted));
+                .ToGuiProperty(this, nameof(PercentCompleted));
 
             Slideshow = new SlideShow(this);
 
@@ -280,7 +279,7 @@ namespace Wabbajack
                         return installing ? slideshow : modList;
                     })
                 .Select<BitmapImage, ImageSource>(x => x)
-                .ToProperty(this, nameof(Image));
+                .ToGuiProperty(this, nameof(Image));
             _titleText = Observable.CombineLatest(
                     this.WhenAny(x => x.ModList)
                         .Select(modList => modList?.Name ?? string.Empty),
@@ -288,7 +287,7 @@ namespace Wabbajack
                         .StartWith(default(string)),
                     this.WhenAny(x => x.Installing),
                     resultSelector: (modList, mod, installing) => installing ? mod : modList)
-                .ToProperty(this, nameof(TitleText));
+                .ToGuiProperty(this, nameof(TitleText));
             _authorText = Observable.CombineLatest(
                     this.WhenAny(x => x.ModList)
                         .Select(modList => modList?.Author ?? string.Empty),
@@ -296,7 +295,7 @@ namespace Wabbajack
                         .StartWith(default(string)),
                     this.WhenAny(x => x.Installing),
                     resultSelector: (modList, mod, installing) => installing ? mod : modList)
-                .ToProperty(this, nameof(AuthorText));
+                .ToGuiProperty(this, nameof(AuthorText));
             _description = Observable.CombineLatest(
                     this.WhenAny(x => x.ModList)
                         .Select(modList => modList?.Description ?? string.Empty),
@@ -304,7 +303,7 @@ namespace Wabbajack
                         .StartWith(default(string)),
                     this.WhenAny(x => x.Installing),
                     resultSelector: (modList, mod, installing) => installing ? mod : modList)
-                .ToProperty(this, nameof(Description));
+                .ToGuiProperty(this, nameof(Description));
             _modListName = Observable.CombineLatest(
                         this.WhenAny(x => x.ModList.Error)
                             .Select(x => x != null),
@@ -315,7 +314,7 @@ namespace Wabbajack
                         if (err) return "Corrupted Modlist";
                         return name;
                     })
-                .ToProperty(this, nameof(ModListName));
+                .ToGuiProperty(this, nameof(ModListName));
 
             // Define commands
             ShowReportCommand = ReactiveCommand.Create(ShowReport);
@@ -350,7 +349,7 @@ namespace Wabbajack
                             return "Configuring";
                         }
                     })
-                .ToProperty(this, nameof(ProgressTitle));
+                .ToGuiProperty(this, nameof(ProgressTitle));
 
             UIUtils.BindCpuStatus(
                 this.WhenAny(x => x.Installer.ActiveInstallation)
@@ -405,8 +404,7 @@ namespace Wabbajack
             _ActiveGlobalUserIntervention = activeInterventions.Connect()
                 .Filter(x => x.CpuID == WorkQueue.UnassignedCpuId)
                 .QueryWhenChanged(query => query.FirstOrDefault())
-                .ObserveOnGuiThread()
-                .ToProperty(this, nameof(ActiveGlobalUserIntervention));
+                .ToGuiProperty(this, nameof(ActiveGlobalUserIntervention));
 
             CloseWhenCompleteCommand = ReactiveCommand.Create(
                 canExecute: this.WhenAny(x => x.Completed)
@@ -429,8 +427,7 @@ namespace Wabbajack
 
             _CurrentCpuCount = this.WhenAny(x => x.Installer.ActiveInstallation.Queue.CurrentCpuCount)
                 .Switch()
-                .ObserveOnGuiThread()
-                .ToProperty(this, nameof(CurrentCpuCount));
+                .ToGuiProperty(this, nameof(CurrentCpuCount));
         }
 
         private void ShowReport()

--- a/Wabbajack/View Models/Installers/InstallerVM.cs
+++ b/Wabbajack/View Models/Installers/InstallerVM.cs
@@ -89,6 +89,9 @@ namespace Wabbajack
         private readonly ObservableAsPropertyHelper<(int CurrentCPUs, int DesiredCPUs)> _CurrentCpuCount;
         public (int CurrentCPUs, int DesiredCPUs) CurrentCpuCount => _CurrentCpuCount.Value;
 
+        private readonly ObservableAsPropertyHelper<bool> _LoadingModlist;
+        public bool LoadingModlist => _LoadingModlist.Value;
+
         // Command properties
         public IReactiveCommand ShowReportCommand { get; }
         public IReactiveCommand OpenReadmeCommand { get; }
@@ -162,6 +165,14 @@ namespace Wabbajack
                 .ObserveOnGuiThread()
                 .StartWith(default(ModListVM))
                 .ToProperty(this, nameof(ModList));
+            _LoadingModlist = Observable.Merge(
+                    // When target location changes, mark as loading
+                    this.WhenAny(x => x.ModListLocation.TargetPath)
+                        .Select(_ => true),
+                    // When the resulting modlist comes in, mark it as done
+                    this.WhenAny(x => x.ModList)
+                        .Select(_ => false))
+                .ToProperty(this, nameof(LoadingModlist));
             _htmlReport = this.WhenAny(x => x.ModList)
                 .Select(modList => modList?.ReportHTML)
                 .ToProperty(this, nameof(HTMLReport));

--- a/Wabbajack/View Models/Installers/InstallerVM.cs
+++ b/Wabbajack/View Models/Installers/InstallerVM.cs
@@ -285,18 +285,24 @@ namespace Wabbajack
                     .Select(x => x?.StartsWith("https://") ?? false)
                     .ObserveOnGuiThread());
 
-            _progressTitle = Observable.CombineLatest(
-                    this.WhenAny(x => x.Installing),
-                    this.WhenAny(x => x.StartedInstallation),
-                    resultSelector: (installing, started) =>
+            _progressTitle = this.WhenAnyValue(
+                    x => x.Installing,
+                    x => x.StartedInstallation,
+                    x => x.Completed,
+                    selector: (installing, started, completed) =>
                     {
                         if (installing)
                         {
                             return "Installing";
                         }
+                        else if (started)
+                        {
+                            if (completed == null) return "Installing";
+                            return completed.Value.Succeeded ? "Installed" : "Failed";
+                        }
                         else
                         {
-                            return started ? "Installed" : "Configuring";
+                            return "Configuring";
                         }
                     })
                 .ToProperty(this, nameof(ProgressTitle));

--- a/Wabbajack/View Models/Installers/InstallerVM.cs
+++ b/Wabbajack/View Models/Installers/InstallerVM.cs
@@ -185,9 +185,19 @@ namespace Wabbajack
                     if (!File.Exists(modListPath)) return default(ModListVM);
                     return new ModListVM(modListPath);
                 })
+                .DisposeOld()
                 .ObserveOnGuiThread()
                 .StartWith(default(ModListVM))
                 .ToProperty(this, nameof(ModList));
+
+            // Force GC collect when modlist changes, just to make sure we clean up any loose large items immediately
+            this.WhenAny(x => x.ModList)
+                .Delay(TimeSpan.FromMilliseconds(50))
+                .Subscribe(x =>
+                {
+                    GC.Collect();
+                });
+
             _LoadingModlist = Observable.Merge(
                     // When active path changes, mark as loading
                     activePath

--- a/Wabbajack/View Models/Installers/MO2InstallerVM.cs
+++ b/Wabbajack/View Models/Installers/MO2InstallerVM.cs
@@ -88,7 +88,7 @@ namespace Wabbajack
             // Load settings
             _CurrentSettings = installerVM.WhenAny(x => x.ModListLocation.TargetPath)
                 .Select(path => path == null ? null : installerVM.MWVM.Settings.Installer.Mo2ModlistSettings.TryCreate(path))
-                .ToProperty(this, nameof(CurrentSettings));
+                .ToGuiProperty(this, nameof(CurrentSettings));
             this.WhenAny(x => x.CurrentSettings)
                 .Pairwise()
                 .Subscribe(settingsPair =>

--- a/Wabbajack/View Models/Installers/VortexInstallerVM.cs
+++ b/Wabbajack/View Models/Installers/VortexInstallerVM.cs
@@ -39,7 +39,7 @@ namespace Wabbajack
             Parent = installerVM;
 
             _TargetGame = installerVM.WhenAny(x => x.ModList.SourceModList.GameType)
-                .ToProperty(this, nameof(TargetGame));
+                .ToGuiProperty(this, nameof(TargetGame));
 
             CanInstall = Observable.CombineLatest(
                 this.WhenAny(x => x.TargetGame)

--- a/Wabbajack/View Models/ModListGalleryVM.cs
+++ b/Wabbajack/View Models/ModListGalleryVM.cs
@@ -52,7 +52,7 @@ namespace Wabbajack
             this.WhenAny(x => x.IsActive)
                 .Where(x => !x)
                 .Skip(1)
-                .Delay(TimeSpan.FromMilliseconds(50))
+                .Delay(TimeSpan.FromMilliseconds(50), RxApp.MainThreadScheduler)
                 .Subscribe(_ =>
                 {
                     GC.Collect();

--- a/Wabbajack/View Models/ModListGalleryVM.cs
+++ b/Wabbajack/View Models/ModListGalleryVM.cs
@@ -21,29 +21,42 @@ namespace Wabbajack
 
         public ObservableCollectionExtended<ModListMetadataVM> ModLists { get; } = new ObservableCollectionExtended<ModListMetadataVM>();
 
-        public IReactiveCommand RefreshCommand { get; }
-
         private int missingHashFallbackCounter;
 
         public ModListGalleryVM(MainWindowVM mainWindowVM)
             : base(mainWindowVM)
         {
             MWVM = mainWindowVM;
-            RefreshCommand = ReactiveCommand.Create(() => { });
 
-            RefreshCommand.StartingExecution()
-                .StartWith(Unit.Default)
+            Observable.Return(Unit.Default)
                 .ObserveOn(RxApp.TaskpoolScheduler)
                 .SelectTask(async _ =>
                 {
                     return (await ModlistMetadata.LoadFromGithub())
                         .AsObservableChangeSet(x => x.DownloadMetadata?.Hash ?? $"Fallback{missingHashFallbackCounter++}");
                 })
+                // Unsubscribe and release when not active
+                .FlowSwitch(
+                    this.WhenAny(x => x.IsActive), 
+                    valueWhenOff: Observable.Return(ChangeSet<ModlistMetadata, string>.Empty))
+                // Convert to VM and bind to resulting list
                 .Switch()
                 .ObserveOnGuiThread()
                 .Transform(m => new ModListMetadataVM(this, m))
+                .DisposeMany()
                 .Bind(ModLists)
                 .Subscribe()
+                .DisposeWith(CompositeDisposable);
+
+            // Extra GC when navigating away, just to immediately clean up modlist metadata
+            this.WhenAny(x => x.IsActive)
+                .Where(x => !x)
+                .Skip(1)
+                .Delay(TimeSpan.FromMilliseconds(50))
+                .Subscribe(_ =>
+                {
+                    GC.Collect();
+                })
                 .DisposeWith(CompositeDisposable);
         }
     }

--- a/Wabbajack/View Models/ModListMetadataVM.cs
+++ b/Wabbajack/View Models/ModListMetadataVM.cs
@@ -45,6 +45,9 @@ namespace Wabbajack
         private readonly ObservableAsPropertyHelper<BitmapImage> _Image;
         public BitmapImage Image => _Image.Value;
 
+        private readonly ObservableAsPropertyHelper<bool> _LoadingImage;
+        public bool LoadingImage => _LoadingImage.Value;
+
         public ModListMetadataVM(ModListGalleryVM parent, ModlistMetadata metadata)
         {
             _parent = parent;
@@ -121,9 +124,16 @@ namespace Wabbajack
                 })
                 .ToGuiProperty(this, nameof(Exists));
 
-            _Image = Observable.Return(Metadata.Links.ImageUri)
-                .DownloadBitmapImage((ex) => Utils.Log($"Error downloading modlist image {Metadata.Title}"))
+            var imageObs = Observable.Return(Metadata.Links.ImageUri)
+                .DownloadBitmapImage((ex) => Utils.Log($"Error downloading modlist image {Metadata.Title}"));
+
+            _Image = imageObs
                 .ToGuiProperty(this, nameof(Image));
+
+            _LoadingImage = imageObs
+                .Select(x => false)
+                .StartWith(true)
+                .ToGuiProperty(this, nameof(LoadingImage));
         }
 
         private Task Download()

--- a/Wabbajack/View Models/ModListMetadataVM.cs
+++ b/Wabbajack/View Models/ModListMetadataVM.cs
@@ -119,11 +119,11 @@ namespace Wabbajack
                         return true;
                     }
                 })
-                .ToProperty(this, nameof(Exists));
+                .ToGuiProperty(this, nameof(Exists));
 
             _Image = Observable.Return(Metadata.Links.ImageUri)
                 .DownloadBitmapImage((ex) => Utils.Log($"Error downloading modlist image {Metadata.Title}"))
-                .ToProperty(this, nameof(Image));
+                .ToGuiProperty(this, nameof(Image));
         }
 
         private Task Download()

--- a/Wabbajack/View Models/ModListVM.cs
+++ b/Wabbajack/View Models/ModListVM.cs
@@ -13,7 +13,7 @@ namespace Wabbajack
 {
     public class ModListVM : ViewModel
     {
-        public ModList SourceModList { get; }
+        public ModList SourceModList { get; private set; }
         public Exception Error { get; }
         public string ModListPath { get; }
         public string Name => SourceModList?.Name;
@@ -122,6 +122,14 @@ namespace Wabbajack
                     }
                 }
             }
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
+            // Just drop reference explicitly, as it's large, so it can be GCed
+            // Even if someone is holding a stale reference to the VM
+            this.SourceModList = null;
         }
     }
 }

--- a/Wabbajack/View Models/ModListVM.cs
+++ b/Wabbajack/View Models/ModListVM.cs
@@ -42,6 +42,7 @@ namespace Wabbajack
             }
 
             ImageObservable = Observable.Return(Unit.Default)
+                // Download and retrieve bytes on background thread
                 .ObserveOn(RxApp.TaskpoolScheduler)
                 .Select(filePath =>
                 {
@@ -66,6 +67,7 @@ namespace Wabbajack
                         return default(MemoryStream);
                     }
                 })
+                // Create Bitmap image on GUI thread
                 .ObserveOnGuiThread()
                 .Select(memStream =>
                 {
@@ -79,6 +81,11 @@ namespace Wabbajack
                         Utils.Error(ex, $"Exception while caching Mod List image {Name}");
                         return default(BitmapImage);
                     }
+                })
+                // If ever would return null, show WJ logo instead
+                .Select(x =>
+                {
+                    return x ?? InstallerVM.WabbajackLogo;
                 })
                 .Replay(1)
                 .RefCount();

--- a/Wabbajack/View Models/Settings/LoginManagerVM.cs
+++ b/Wabbajack/View Models/Settings/LoginManagerVM.cs
@@ -36,8 +36,7 @@ namespace Wabbajack
         {
             Login = login;
             _MetaInfo = (login.MetaInfo ?? Observable.Return(""))
-                .ObserveOnGuiThread()
-                .ToProperty(this, nameof(MetaInfo));
+                .ToGuiProperty(this, nameof(MetaInfo));
         }
     }
 }

--- a/Wabbajack/View Models/SlideShow.cs
+++ b/Wabbajack/View Models/SlideShow.cs
@@ -109,15 +109,14 @@ namespace Wabbajack
                         return query.Items.ElementAtOrDefault(index);
                     })
                 .StartWith(default(ModVM))
-                .ObserveOnGuiThread()
-                .ToProperty(this, nameof(TargetMod));
+                .ToGuiProperty(this, nameof(TargetMod));
 
             // Mark interest and materialize image of target mod
             _image = this.WhenAny(x => x.TargetMod)
                 // We want to Switch here, not SelectMany, as we want to hotswap to newest target without waiting on old ones
                 .Select(x => x?.ImageObservable ?? Observable.Return(default(BitmapImage)))
                 .Switch()
-                .ToProperty(this, nameof(Image));
+                .ToGuiProperty(this, nameof(Image));
 
             VisitNexusSiteCommand = ReactiveCommand.Create(
                 execute: () => Process.Start(TargetMod.ModURL),

--- a/Wabbajack/View Models/SlideShow.cs
+++ b/Wabbajack/View Models/SlideShow.cs
@@ -66,7 +66,7 @@ namespace Wabbajack
                         this.WhenAny(x => x.Installer.Installing),
                         resultSelector: (enabled, installing) => enabled && installing))
                 // Block spam
-                .Debounce(TimeSpan.FromMilliseconds(250))
+                .Debounce(TimeSpan.FromMilliseconds(250), RxApp.MainThreadScheduler)
                 .Scan(
                     seed: 0,
                     accumulator: (i, _) => i + 1)

--- a/Wabbajack/View Models/SlideShow.cs
+++ b/Wabbajack/View Models/SlideShow.cs
@@ -80,19 +80,20 @@ namespace Wabbajack
                 {
                     if (modList?.SourceModList?.Archives == null)
                     {
-                        return Observable.Empty<ModVM>()
+                        return Observable.Empty<NexusDownloader.State>()
                             .ToObservableChangeSet(x => x.ModID);
                     }
                     return modList.SourceModList.Archives
                         .Select(m => m.State)
                         .OfType<NexusDownloader.State>()
-                        .Select(nexus => new ModVM(nexus))
                         // Shuffle it
                         .Shuffle(_random)
                         .AsObservableChangeSet(x => x.ModID);
                 })
                 // Switch to the new list after every ModList change
                 .Switch()
+                .Transform(nexus => new ModVM(nexus))
+                .DisposeMany()
                 // Filter out any NSFW slides if we don't want them
                 .AutoRefreshOnObservable(slide => this.WhenAny(x => x.ShowNSFW))
                 .Filter(slide => !slide.IsNSFW || ShowNSFW)

--- a/Wabbajack/Views/Common/DetailImageView.xaml
+++ b/Wabbajack/Views/Common/DetailImageView.xaml
@@ -4,10 +4,12 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:icon="http://metro.mahapps.com/winfx/xaml/iconpacks"
+    xmlns:lib="clr-namespace:Wabbajack.Lib;assembly=Wabbajack.Lib"
     xmlns:local="clr-namespace:Wabbajack"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     d:DesignHeight="450"
     d:DesignWidth="800"
+    x:TypeArguments="lib:ViewModel"
     ClipToBounds="True"
     mc:Ignorable="d">
     <UserControl.Resources>

--- a/Wabbajack/Views/Common/DetailImageView.xaml.cs
+++ b/Wabbajack/Views/Common/DetailImageView.xaml.cs
@@ -1,15 +1,20 @@
 ﻿using ReactiveUI;
+using ReactiveUI.Fody.Helpers;
+using System;
 using System.Linq;
+using System.Reactive;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Windows;
 using System.Windows.Media;
+using Wabbajack.Lib;
 
 namespace Wabbajack
 {
     /// <summary>
     /// Interaction logic for DetailImageView.xaml
     /// </summary>
-    public partial class DetailImageView : UserControlRx
+    public partial class DetailImageView : UserControlRx<ViewModel>
     {
         public ImageSource Image
         {
@@ -51,30 +56,36 @@ namespace Wabbajack
         public static readonly DependencyProperty DescriptionProperty = DependencyProperty.Register(nameof(Description), typeof(string), typeof(DetailImageView),
              new FrameworkPropertyMetadata(default(string), FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, WireNotifyPropertyChanged));
 
-        private readonly ObservableAsPropertyHelper<bool> _showAuthor;
-        public bool ShowAuthor => _showAuthor.Value;
+        [Reactive]
+        public bool ShowAuthor { get; private set; }
 
-        private readonly ObservableAsPropertyHelper<bool> _showDescription;
-        public bool ShowDescription => _showDescription.Value;
+        [Reactive]
+        public bool ShowDescription { get; private set; }
 
-        private readonly ObservableAsPropertyHelper<bool> _showTitle;
-        public bool ShowTitle => _showTitle.Value;
+        [Reactive]
+        public bool ShowTitle { get; private set; }
 
         public DetailImageView()
         {
             InitializeComponent();
 
-            _showAuthor = this.WhenAny(x => x.Author)
-                .Select(x => !string.IsNullOrWhiteSpace(x))
-                .ToProperty(this, nameof(ShowAuthor));
+            this.WhenActivated(dispose =>
+            {
+                this.WhenAny(x => x.Author)
+                    .Select(x => !string.IsNullOrWhiteSpace(x))
+                    .Subscribe(x => ShowAuthor = x)
+                    .DisposeWith(dispose);
 
-            _showDescription = this.WhenAny(x => x.Description)
-                .Select(x => !string.IsNullOrWhiteSpace(x))
-                .ToProperty(this, nameof(ShowDescription));
+                this.WhenAny(x => x.Description)
+                    .Select(x => !string.IsNullOrWhiteSpace(x))
+                    .Subscribe(x => ShowDescription = x)
+                    .DisposeWith(dispose);
 
-            _showTitle = this.WhenAny(x => x.Title)
-                .Select(x => !string.IsNullOrWhiteSpace(x))
-                .ToProperty(this, nameof(ShowTitle));
+                this.WhenAny(x => x.Title)
+                    .Select(x => !string.IsNullOrWhiteSpace(x))
+                    .Subscribe(x => ShowTitle = x)
+                    .DisposeWith(dispose);
+            });
         }
     }
 }

--- a/Wabbajack/Views/Common/TopProgressView.xaml
+++ b/Wabbajack/Views/Common/TopProgressView.xaml
@@ -3,11 +3,13 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:lib="clr-namespace:Wabbajack.Lib;assembly=Wabbajack.Lib"
     xmlns:local="clr-namespace:Wabbajack"
     xmlns:mahapps="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     d:DesignHeight="450"
     d:DesignWidth="800"
+    x:TypeArguments="lib:ViewModel"
     BorderThickness="0"
     mc:Ignorable="d">
     <Grid>

--- a/Wabbajack/Views/Common/TopProgressView.xaml.cs
+++ b/Wabbajack/Views/Common/TopProgressView.xaml.cs
@@ -2,13 +2,17 @@
 using System.Windows;
 using System.Windows.Controls;
 using ReactiveUI;
+using System;
+using ReactiveUI.Fody.Helpers;
+using Wabbajack.Lib;
+using System.Reactive.Disposables;
 
 namespace Wabbajack
 {
     /// <summary>
     /// Interaction logic for TopProgressView.xaml
     /// </summary>
-    public partial class TopProgressView : UserControlRx
+    public partial class TopProgressView : UserControlRx<ViewModel>
     {
         public double ProgressPercent
         {
@@ -50,18 +54,22 @@ namespace Wabbajack
         public static readonly DependencyProperty ShadowMarginProperty = DependencyProperty.Register(nameof(ShadowMargin), typeof(bool), typeof(TopProgressView),
              new FrameworkPropertyMetadata(true));
 
-        private readonly ObservableAsPropertyHelper<double> _ProgressOpacityPercent;
-        public double ProgressOpacityPercent => _ProgressOpacityPercent.Value;
+        [Reactive]
+        public double ProgressOpacityPercent { get; private set; }
 
         public TopProgressView()
         {
             InitializeComponent();
-            _ProgressOpacityPercent = this.WhenAny(x => x.ProgressPercent)
-                .Select(x =>
-                {
-                    return 0.3 + x * 0.7;
-                })
-                .ToProperty(this, nameof(ProgressOpacityPercent));
+            this.WhenActivated(dispose =>
+            {
+                this.WhenAny(x => x.ProgressPercent)
+                    .Select(x =>
+                    {
+                        return 0.3 + x * 0.7;
+                    })
+                    .Subscribe(x => ProgressOpacityPercent = x)
+                    .DisposeWith(dispose);
+            });
         }
     }
 }

--- a/Wabbajack/Views/Installers/InstallationView.xaml
+++ b/Wabbajack/Views/Installers/InstallationView.xaml
@@ -7,6 +7,7 @@
     xmlns:icon="http://metro.mahapps.com/winfx/xaml/iconpacks"
     xmlns:lib="clr-namespace:Wabbajack.Lib;assembly=Wabbajack.Lib"
     xmlns:local="clr-namespace:Wabbajack"
+    xmlns:mahapps="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     d:DataContext="{d:DesignInstance local:InstallerVM}"
     d:DesignHeight="500"
@@ -48,11 +49,14 @@
             Grid.Row="1"
             Margin="5,0,5,5">
             <Border BorderBrush="{StaticResource BorderInterestBrush}" BorderThickness="1,0,1,1">
-                <local:DetailImageView
-                    Title="{Binding TitleText, Mode=OneWay}"
-                    Author="{Binding AuthorText, Mode=OneWay}"
-                    Description="{Binding Description, Mode=OneWay}"
-                    Image="{Binding Image, Mode=OneWay}" />
+                <Grid>
+                    <local:DetailImageView
+                        Title="{Binding TitleText, Mode=OneWay}"
+                        Author="{Binding AuthorText, Mode=OneWay}"
+                        Description="{Binding Description, Mode=OneWay}"
+                        Image="{Binding Image, Mode=OneWay}" />
+                    <mahapps:ProgressRing Visibility="{Binding LoadingModlist, Mode=OneWay, Converter={StaticResource bool2VisibilityHiddenConverter}}" />
+                </Grid>
             </Border>
             <Grid
                 Margin="0,20,25,0"
@@ -422,8 +426,8 @@
             <local:CpuView
                 Grid.Column="2"
                 ProgressPercent="{Binding PercentCompleted, Mode=OneWay}"
-                ViewModel="{Binding}"
                 SettingsHook="{Binding MWVM.Settings}"
+                ViewModel="{Binding}"
                 Visibility="{Binding ActiveGlobalUserIntervention, Converter={StaticResource IsNotNullVisibilityConverter}, ConverterParameter=False}" />
             <local:AttentionBorder Grid.Column="2" Visibility="{Binding ActiveGlobalUserIntervention, Converter={StaticResource IsNotNullVisibilityConverter}}">
                 <local:AttentionBorder.DisplayContent>

--- a/Wabbajack/Views/ModListTileView.xaml
+++ b/Wabbajack/Views/ModListTileView.xaml
@@ -86,6 +86,7 @@
                 BorderBrush="{StaticResource ButtonNormalBorder}"
                 BorderThickness="0,0,0,1">
                 <Grid ClipToBounds="True">
+                    <mahapps:ProgressRing x:Name="LoadingProgress" />
                     <Viewbox
                         Height="340"
                         HorizontalAlignment="Center"
@@ -119,7 +120,7 @@
                         <Ellipse.Style>
                             <Style TargetType="Ellipse">
                                 <Style.Triggers>
-                                    <DataTrigger Binding="{Binding IsMouseOver, RelativeSource={RelativeSource AncestorType={x:Type Button}}}" Value="True">
+                                    <DataTrigger Binding="{Binding IsMouseOver, ElementName=ModListTile}" Value="True">
                                         <DataTrigger.EnterActions>
                                             <BeginStoryboard>
                                                 <Storyboard>

--- a/Wabbajack/Views/ModListTileView.xaml.cs
+++ b/Wabbajack/Views/ModListTileView.xaml.cs
@@ -54,6 +54,10 @@ namespace Wabbajack
                 this.WhenAny(x => x.ViewModel.Image)
                     .BindToStrict(this, x => x.ModListImage.Source)
                     .DisposeWith(dispose);
+                this.WhenAny(x => x.ViewModel.LoadingImage)
+                    .Select(x => x ? Visibility.Visible : Visibility.Collapsed)
+                    .BindToStrict(this, x => x.LoadingProgress.Visibility)
+                    .DisposeWith(dispose);
             });
         }
     }

--- a/Wabbajack/Views/UserControlRx.cs
+++ b/Wabbajack/Views/UserControlRx.cs
@@ -7,40 +7,6 @@ using System.Windows.Controls;
 
 namespace Wabbajack
 {
-    public class UserControlRx : UserControl, IDisposable, IReactiveObject
-    {
-        public event PropertyChangedEventHandler PropertyChanged;
-        public event PropertyChangingEventHandler PropertyChanging;
-
-        public void RaisePropertyChanging(PropertyChangingEventArgs args)
-        {
-            PropertyChanging?.Invoke(this, args);
-        }
-
-        public void RaisePropertyChanged(PropertyChangedEventArgs args)
-        {
-            PropertyChanged?.Invoke(this, args);
-        }
-
-        private readonly Lazy<CompositeDisposable> _compositeDisposable = new Lazy<CompositeDisposable>();
-        public CompositeDisposable CompositeDisposable => _compositeDisposable.Value;
-
-        public virtual void Dispose()
-        {
-            if (_compositeDisposable.IsValueCreated)
-            {
-                _compositeDisposable.Value.Dispose();
-            }
-        }
-
-        protected static void WireNotifyPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-        {
-            if (!(d is UserControlRx control)) return;
-            if (Equals(e.OldValue, e.NewValue)) return;
-            control.RaisePropertyChanged(e.Property.Name);
-        }
-    }
-
     public class UserControlRx<TViewModel> : ReactiveUserControl<TViewModel>, IReactiveObject
          where TViewModel : class
     {
@@ -59,7 +25,7 @@ namespace Wabbajack
 
         protected static void WireNotifyPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-            if (!(d is UserControlRx control)) return;
+            if (!(d is UserControlRx<TViewModel> control)) return;
             if (Equals(e.OldValue, e.NewValue)) return;
             control.RaisePropertyChanged(e.Property.Name);
         }

--- a/Wabbajack/Wabbajack.csproj
+++ b/Wabbajack/Wabbajack.csproj
@@ -614,6 +614,8 @@
   <ItemGroup>
     <SplashScreen Include="Resources\Wabba_Mouth_Small.png" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Folder Include="Interfaces\" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
Added some progress rings to image loading for modlist images.  Also did a pass to help release these images from the gallery and installation VM when navigating away from those pages.  That also revealed an improper Rx pattern I was following that was causing a memory leak.

- Fixed status term that displayed "installed" after a failed installation
- Added progress loading rings when downloading modlist images
- Adjusted InstallationVM to unload/release modlist when navigating away
- Other various adjustments to release assets when no longer needed
- OAPH properties improved to properly be disposed with their parent objects (this fixed a memory leak)

Some best practice notes from talking with some RxUI people:
- Always dispose OAPH properties
- Best practice to provide an explicit scheduler for Rx calls that can take them.  Was an API mistake to make them optional, in some people's opinions.
- Timers/Debounce/etc that aren't spamming like crazy are better off actually running on the GUI thread, rather than a background thread?