### PR TITLE
Failed compilation display bug

### DIFF
--- a/Wabbajack/View Models/Compilers/CompilerVM.cs
+++ b/Wabbajack/View Models/Compilers/CompilerVM.cs
@@ -184,8 +184,8 @@ namespace Wabbajack
                 {
                     try
                     {
-                        await this.Compiler.Compile();
-                        Completed = ErrorResponse.Success;
+                        var successful = await this.Compiler.Compile();
+                        Completed = ErrorResponse.Create(successful);
                     }
                     catch (Exception ex)
                     {

--- a/Wabbajack/View Models/Compilers/ISubCompilerVM.cs
+++ b/Wabbajack/View Models/Compilers/ISubCompilerVM.cs
@@ -12,6 +12,6 @@ namespace Wabbajack
         ModlistSettingsEditorVM ModlistSettings { get; }
         void Unload();
         IObservable<bool> CanCompile { get; }
-        Task Compile();
+        Task<bool> Compile();
     }
 }

--- a/Wabbajack/View Models/Compilers/MO2CompilerVM.cs
+++ b/Wabbajack/View Models/Compilers/MO2CompilerVM.cs
@@ -163,7 +163,7 @@ namespace Wabbajack
             ModlistSettings?.Save();
         }
 
-        public async Task Compile()
+        public async Task<bool> Compile()
         {
             string outputFile;
             if (string.IsNullOrWhiteSpace(Parent.OutputLocation.TargetPath))
@@ -193,7 +193,7 @@ namespace Wabbajack
                 {
                     Parent.MWVM.Settings.Performance.AttachToBatchProcessor(ActiveCompilation);
 
-                    await ActiveCompilation.Begin();
+                    return await ActiveCompilation.Begin();
                 }
             }
             finally

--- a/Wabbajack/View Models/Compilers/VortexCompilerVM.cs
+++ b/Wabbajack/View Models/Compilers/VortexCompilerVM.cs
@@ -177,7 +177,7 @@ namespace Wabbajack
             GameLocation.TargetPath = StoreHandler.Instance.GetGamePath(SelectedGame.Game, StoreType.GOG);
         }
 
-        public async Task Compile()
+        public async Task<bool> Compile()
         {
             string outputFile = $"{ModlistSettings.ModListName}{ExtensionManager.Extension}";
             if (!string.IsNullOrWhiteSpace(Parent.OutputLocation.TargetPath))
@@ -204,7 +204,7 @@ namespace Wabbajack
                 })
                 {
                     Parent.MWVM.Settings.Performance.AttachToBatchProcessor(ActiveCompilation);
-                    await ActiveCompilation.Begin();
+                    return await ActiveCompilation.Begin();
                 }
             }
             finally

--- a/Wabbajack/View Models/Installers/ISubInstallerVM.cs
+++ b/Wabbajack/View Models/Installers/ISubInstallerVM.cs
@@ -18,6 +18,6 @@ namespace Wabbajack
         void AfterInstallNavigation();
         int ConfigVisualVerticalOffset { get; }
         IObservable<bool> CanInstall { get; }
-        Task Install();
+        Task<bool> Install();
     }
 }

--- a/Wabbajack/View Models/Installers/InstallerVM.cs
+++ b/Wabbajack/View Models/Installers/InstallerVM.cs
@@ -364,8 +364,8 @@ namespace Wabbajack
                 {
                     try
                     {
-                        await this.Installer.Install();
-                        Completed = ErrorResponse.Success;
+                        var success = await this.Installer.Install();
+                        Completed = ErrorResponse.Create(success);
                         try
                         {
                             this.ModList?.OpenReadmeWindow();

--- a/Wabbajack/View Models/Installers/MO2InstallerVM.cs
+++ b/Wabbajack/View Models/Installers/MO2InstallerVM.cs
@@ -143,7 +143,7 @@ namespace Wabbajack
             Process.Start("explorer.exe", Location.TargetPath);
         }
 
-        public async Task Install()
+        public async Task<bool> Install()
         {
             using (var installer = new MO2Installer(
                 archive: Parent.ModListLocation.TargetPath,
@@ -154,14 +154,13 @@ namespace Wabbajack
             {
                 Parent.MWVM.Settings.Performance.AttachToBatchProcessor(installer);
 
-                await Task.Run(async () =>
+                return await Task.Run(async () =>
                 {
                     try
                     {
                         var workTask = installer.Begin();
                         ActiveInstallation = installer;
-                        await workTask;
-                        return ErrorResponse.Success;
+                        return await workTask;
                     }
                     finally
                     {

--- a/Wabbajack/View Models/Installers/VortexInstallerVM.cs
+++ b/Wabbajack/View Models/Installers/VortexInstallerVM.cs
@@ -57,7 +57,7 @@ namespace Wabbajack
             throw new NotImplementedException();
         }
 
-        public async Task Install()
+        public async Task<bool> Install()
         {
             AInstaller installer;
 
@@ -72,13 +72,13 @@ namespace Wabbajack
             {
                 Parent.MWVM.Settings.Performance.AttachToBatchProcessor(installer);
 
-                await Task.Run(async () =>
+                return await Task.Run(async () =>
                 {
                     try
                     {
                         var workTask = installer.Begin();
                         ActiveInstallation = installer;
-                        await workTask;
+                        return await workTask;
                     }
                     finally
                     {


### PR DESCRIPTION
Fixed issue where compile/install would show success for failures, if the failure didn't happen to throw an exception.

Related issue: #338