### PR TITLE
Disabled IncludeTaggedMods in the VortexCompiler Stack

### DIFF
--- a/Wabbajack.Lib/VortexCompiler.cs
+++ b/Wabbajack.Lib/VortexCompiler.cs
@@ -469,7 +469,7 @@ namespace Wabbajack.Lib
                 new IgnoreGameFiles(this),
 
                 new DirectMatch(this),
-                new IncludeTaggedMods(this, Consts.WABBAJACK_INCLUDE),
+                // new IncludeTaggedMods(this, Consts.WABBAJACK_INCLUDE), disabled until further refactoring
 
                 new IgnoreGameFiles(this),
 


### PR DESCRIPTION
IncludeTaggedMods is currently only made for the MO2Compiler
and will try to cast ACompiler to MO2Compiler.