### PR TITLE
Return a 404 (instead of an exception) when an archive isn't indexed

### DIFF
--- a/Wabbajack.BuildServer/Controllers/IndexedFiles.cs
+++ b/Wabbajack.BuildServer/Controllers/IndexedFiles.cs
@@ -92,6 +92,8 @@ namespace Wabbajack.BuildServer.Controllers
         public async Task<IActionResult> GetFile(string xxHashAsBase64)
         {
             var result = await _sql.AllArchiveContents(BitConverter.ToInt64(xxHashAsBase64.FromHex()));
+            if (result == null)
+                return NotFound();
             return Ok(result);
         }
 

--- a/Wabbajack.BuildServer/Models/Sql/SqlService.cs
+++ b/Wabbajack.BuildServer/Models/Sql/SqlService.cs
@@ -130,7 +130,7 @@ namespace Wabbajack.BuildServer.Model.Models
                 }
                 return new List<IndexedVirtualFile>();
             }
-            return Build(0).First();
+            return Build(0).FirstOrDefault();
         }
 
         public async Task IngestAllMetrics(IEnumerable<Metric> allMetrics)


### PR DESCRIPTION
Keeps the error log from getting cluttered