### PR TITLE
VFS QoL Changes by an angry boi

### DIFF
--- a/Wabbajack.BuildServer/Models/Jobs/IndexJob.cs
+++ b/Wabbajack.BuildServer/Models/Jobs/IndexJob.cs
@@ -41,7 +41,7 @@ namespace Wabbajack.BuildServer.Models.Jobs
 
             using (var queue = new WorkQueue())
             {
-                var vfs = new Context(queue, true);
+                var vfs = new Context(queue, "vfs_cache.bin", true);
                 await vfs.AddRoot(Path.Combine(settings.DownloadDir, folder));
                 var archive = vfs.Index.ByRootPath.First().Value;
 

--- a/Wabbajack.BuildServer/Models/Jobs/ReindexArchives.cs
+++ b/Wabbajack.BuildServer/Models/Jobs/ReindexArchives.cs
@@ -45,7 +45,7 @@ namespace Wabbajack.BuildServer.Models.Jobs
                             File.Copy(file, Path.Combine(folder, Path.GetFileName(file)));
 
                             Utils.Log($"({completed}/{total_count}) Analyzing {file}");
-                            var vfs = new Context(queue, true);
+                            var vfs = new Context(queue, "vfs_cache.bin", true);
                             await vfs.AddRoot(folder);
 
                             var root = vfs.Index.ByRootPath.First().Value;

--- a/Wabbajack.Lib/ABatchProcessor.cs
+++ b/Wabbajack.Lib/ABatchProcessor.cs
@@ -67,7 +67,7 @@ namespace Wabbajack.Lib
                 .DisposeWith(_subs);
             UpdateTracker.Progress.Subscribe(_percentCompleted);
             UpdateTracker.StepName.Subscribe(_textStatus);
-            VFS = new Context(Queue) { UpdateTracker = UpdateTracker };
+            VFS = new Context(Queue, "vfs_compile_cache.bin") { UpdateTracker = UpdateTracker };
         }
 
         /// <summary>

--- a/Wabbajack.Lib/MO2Compiler.cs
+++ b/Wabbajack.Lib/MO2Compiler.cs
@@ -113,8 +113,8 @@ namespace Wabbajack.Lib
             UpdateTracker.NextStep("Indexing folders");
 
             if (cancel.IsCancellationRequested) return false;
-            await VFS.AddRoots(roots, _vfsCacheName);
-            await VFS.WriteToFile(_vfsCacheName);
+            await VFS.AddRoots(roots);
+            //await VFS.WriteToFile(_vfsCacheName);
             
             if (Directory.Exists(lootPath))
             {
@@ -134,8 +134,8 @@ namespace Wabbajack.Lib
 
             if (cancel.IsCancellationRequested) return false;
             UpdateTracker.NextStep("Reindexing downloads after meta inferring");
-            await VFS.AddRoot(MO2DownloadsFolder, _vfsCacheName);
-            await VFS.WriteToFile(_vfsCacheName);
+            await VFS.AddRoots(new List<string>{MO2DownloadsFolder});
+            //await VFS.WriteToFile(_vfsCacheName);
 
             if (cancel.IsCancellationRequested) return false;
             UpdateTracker.NextStep("Pre-validating Archives");

--- a/Wabbajack.Lib/MO2Compiler.cs
+++ b/Wabbajack.Lib/MO2Compiler.cs
@@ -113,7 +113,7 @@ namespace Wabbajack.Lib
             UpdateTracker.NextStep("Indexing folders");
 
             if (cancel.IsCancellationRequested) return false;
-            await VFS.AddRoots(roots);
+            await VFS.AddRoots(roots, _vfsCacheName);
             await VFS.WriteToFile(_vfsCacheName);
             
             if (Directory.Exists(lootPath))
@@ -134,7 +134,7 @@ namespace Wabbajack.Lib
 
             if (cancel.IsCancellationRequested) return false;
             UpdateTracker.NextStep("Reindexing downloads after meta inferring");
-            await VFS.AddRoot(MO2DownloadsFolder);
+            await VFS.AddRoot(MO2DownloadsFolder, _vfsCacheName);
             await VFS.WriteToFile(_vfsCacheName);
 
             if (cancel.IsCancellationRequested) return false;

--- a/Wabbajack.Lib/MO2Compiler.cs
+++ b/Wabbajack.Lib/MO2Compiler.cs
@@ -114,7 +114,7 @@ namespace Wabbajack.Lib
 
             if (cancel.IsCancellationRequested) return false;
             await VFS.AddRoots(roots);
-            //await VFS.WriteToFile(_vfsCacheName);
+            VFS.WriteToFile();
             
             if (Directory.Exists(lootPath))
             {
@@ -135,7 +135,7 @@ namespace Wabbajack.Lib
             if (cancel.IsCancellationRequested) return false;
             UpdateTracker.NextStep("Reindexing downloads after meta inferring");
             await VFS.AddRoot(MO2DownloadsFolder);
-            //await VFS.WriteToFile(_vfsCacheName);
+            VFS.WriteToFile();
 
             if (cancel.IsCancellationRequested) return false;
             UpdateTracker.NextStep("Pre-validating Archives");

--- a/Wabbajack.Lib/MO2Compiler.cs
+++ b/Wabbajack.Lib/MO2Compiler.cs
@@ -134,7 +134,7 @@ namespace Wabbajack.Lib
 
             if (cancel.IsCancellationRequested) return false;
             UpdateTracker.NextStep("Reindexing downloads after meta inferring");
-            await VFS.AddRoots(new List<string>{MO2DownloadsFolder});
+            await VFS.AddRoot(MO2DownloadsFolder);
             //await VFS.WriteToFile(_vfsCacheName);
 
             if (cancel.IsCancellationRequested) return false;

--- a/Wabbajack.Lib/VortexCompiler.cs
+++ b/Wabbajack.Lib/VortexCompiler.cs
@@ -103,7 +103,7 @@ namespace Wabbajack.Lib
             if (cancel.IsCancellationRequested) return false;
             UpdateTracker.NextStep("Indexing folders");
             await VFS.AddRoots(roots);
-            //await VFS.WriteToFile(_vfsCacheName);
+            VFS.WriteToFile();
 
             if (cancel.IsCancellationRequested) return false;
             UpdateTracker.NextStep("Cleaning output folder");

--- a/Wabbajack.Lib/VortexCompiler.cs
+++ b/Wabbajack.Lib/VortexCompiler.cs
@@ -102,7 +102,7 @@ namespace Wabbajack.Lib
 
             if (cancel.IsCancellationRequested) return false;
             UpdateTracker.NextStep("Indexing folders");
-            await VFS.AddRoots(roots);
+            await VFS.AddRoots(roots, _vfsCacheName);
             await VFS.WriteToFile(_vfsCacheName);
 
             if (cancel.IsCancellationRequested) return false;

--- a/Wabbajack.Lib/VortexCompiler.cs
+++ b/Wabbajack.Lib/VortexCompiler.cs
@@ -102,8 +102,8 @@ namespace Wabbajack.Lib
 
             if (cancel.IsCancellationRequested) return false;
             UpdateTracker.NextStep("Indexing folders");
-            await VFS.AddRoots(roots, _vfsCacheName);
-            await VFS.WriteToFile(_vfsCacheName);
+            await VFS.AddRoots(roots);
+            //await VFS.WriteToFile(_vfsCacheName);
 
             if (cancel.IsCancellationRequested) return false;
             UpdateTracker.NextStep("Cleaning output folder");

--- a/Wabbajack.VirtualFileSystem.Test/VirtualFileSystemTests.cs
+++ b/Wabbajack.VirtualFileSystem.Test/VirtualFileSystemTests.cs
@@ -27,7 +27,7 @@ namespace Wabbajack.VirtualFileSystem.Test
                 Utils.DeleteDirectory(VFS_TEST_DIR);
             Directory.CreateDirectory(VFS_TEST_DIR);
             Queue = new WorkQueue();
-            context = new Context(Queue);
+            context = new Context(Queue, Path.Combine(VFS_TEST_DIR_FULL, "vfs_cache.bin"));
         }
 
         [TestMethod]
@@ -46,7 +46,7 @@ namespace Wabbajack.VirtualFileSystem.Test
         private async Task AddTestRoot()
         {
             await context.AddRoot(VFS_TEST_DIR_FULL);
-            await context.WriteToFile(Path.Combine(VFS_TEST_DIR_FULL, "vfs_cache.bin"));
+            context.WriteToFile();
             await context.IntegrateFromFile(Path.Combine(VFS_TEST_DIR_FULL, "vfs_cache.bin"));
         }
 
@@ -178,7 +178,7 @@ namespace Wabbajack.VirtualFileSystem.Test
 
             var state = context.GetPortableState(files);
 
-            var new_context = new Context(Queue);
+            var new_context = new Context(Queue, Path.Combine(VFS_TEST_DIR_FULL, "vfs_cache.bin"));
 
             await new_context.IntegrateFromPortable(state,
                 new Dictionary<string, string> {{archive.Hash, archive.FullPath}});

--- a/Wabbajack.VirtualFileSystem/Context.cs
+++ b/Wabbajack.VirtualFileSystem/Context.cs
@@ -160,34 +160,12 @@ namespace Wabbajack.VirtualFileSystem
             });
         }
 
-        /*public async Task WriteToFile()
+        public void WriteToFile()
         {
-            using (var fs = File.Open(VFSFile, FileMode.Create))
-            using (var bw = new BinaryWriter(fs, Encoding.UTF8, true))
-            {
-                fs.SetLength(0);
-
-                bw.Write(Encoding.ASCII.GetBytes(Magic));
-                bw.Write(FileVersion);
-                bw.Write((ulong) Index.AllFiles.Count);
-
-                (await Index.AllFiles
-                    .PMap(Queue, f =>
-                    {
-                        var ms = new MemoryStream();
-                        f.Write(ms);
-                        return ms;
-                    }))
-                    .Do(ms =>
-                    {
-                        var size = ms.Position;
-                        ms.Position = 0;
-                        bw.Write((ulong) size);
-                        ms.CopyTo(fs);
-                    });
-                Utils.Log($"Wrote {fs.Position.ToFileSizeString()} file as vfs cache file {VFSFile}");
-            }
-        }*/
+            CompositeDisposable.Dispose();
+            _vfsBinaryWriter.Close();
+            _vfsFileStream.Close();
+        }
 
         public async Task IntegrateFromFile(string filename)
         {

--- a/Wabbajack.VirtualFileSystem/Context.cs
+++ b/Wabbajack.VirtualFileSystem/Context.cs
@@ -55,7 +55,7 @@ namespace Wabbajack.VirtualFileSystem
             return new TemporaryDirectory(Path.Combine(StagingFolder, Guid.NewGuid().ToString()));
         }
 
-        public async Task<IndexRoot> AddRoot(string root, string filename)
+        public async Task<IndexRoot> AddRoot(string root, string filename = null)
         {
             if (!Path.IsPathRooted(root))
                 throw new InvalidDataException($"Path is not absolute: {root}");
@@ -80,7 +80,7 @@ namespace Wabbajack.VirtualFileSystem
                         count++;
 
                     //TODO: possible that this never happens because another thread is incrementing count
-                    if (count != 0 && count % AutoSave == 1)
+                    if (count != 0 && count % AutoSave == 1 && !string.IsNullOrWhiteSpace(filename))
                         await WriteToFile(filename);
 
                     if (!byPath.TryGetValue(f, out var found))
@@ -103,7 +103,7 @@ namespace Wabbajack.VirtualFileSystem
             return newIndex;
         }
 
-        public async Task<IndexRoot> AddRoots(List<string> roots, string filename)
+        public async Task<IndexRoot> AddRoots(List<string> roots, string filename = null)
         {
             if (!roots.All(Path.IsPathRooted))
                 throw new InvalidDataException($"Paths are not absolute");
@@ -128,7 +128,7 @@ namespace Wabbajack.VirtualFileSystem
                         count++;
 
                     //TODO: possible that this never happens because another thread is incrementing count
-                    if (count != 0 && count % AutoSave == 1)
+                    if (count != 0 && count % AutoSave == 1 && !string.IsNullOrWhiteSpace(filename))
                             await WriteToFile(filename);
 
                     Utils.Status($"Indexing {Path.GetFileName(f)}");

--- a/Wabbajack.VirtualFileSystem/Context.cs
+++ b/Wabbajack.VirtualFileSystem/Context.cs
@@ -26,7 +26,7 @@ namespace Wabbajack.VirtualFileSystem
         }
         public const ulong FileVersion = 0x02;
         public const string Magic = "WABBAJACK VFS FILE";
-        public const int AutoSave = 500;
+        public const int AutoSave = 10000;
 
         private const string StagingFolder = "vfs_staging";
         public IndexRoot Index { get; private set; } = IndexRoot.Empty;

--- a/Wabbajack.VirtualFileSystem/Context.cs
+++ b/Wabbajack.VirtualFileSystem/Context.cs
@@ -84,6 +84,12 @@ namespace Wabbajack.VirtualFileSystem
             ms.CopyTo(_vfsFileStream);
         }
 
+        public async Task<IndexRoot> AddRoot(string root)
+        {
+            // I am lazy
+            return await AddRoots(new List<string> {root});
+        }
+
         public async Task<IndexRoot> AddRoots(List<string> roots)
         {
             if (!roots.All(Path.IsPathRooted))


### PR DESCRIPTION
This is me not wanting to have WJ fail after more than 7h of indexing without writing to VFS once in a while.

Changes:

1) formatting and some syntax changes
2) WJ will not index a non-existing file
3) WriteToFile periodically

2nd Point:
Even tho we already filter non existing files out:
`var filtered = Index.AllFiles.Where(file => File.Exists(file.Name)).ToList();`
It is possible that a file in the 
`var filesToIndex = Directory.EnumerateFiles(root, "*", DirectoryEnumerationOptions.Recursive).Distinct().ToList();` List get's deleted before being enumerated upon. Adding a simple check, returning null and than filtering out the null values prevents this.

3rd Point:
Every 10000th file, we write the VFS to file. This worked during my testing of ~30k files but I see a problem with multiple threads trying to change the same variable and than checking it afterwards:

```csharp
var count = 0;
var allFiles = await filesToIndex.PMap(Queue, async f => {
//...
count++;
//...
if (count != 0 && count % AutoSave == 1)
  await WriteToFile
//...
```

I only have a max of 8 threads but someone with 16+ will maybe run into an issue where multiple threads increment `count` and `count % AutoSave == 1` is always false because we count "too fast". Maybe instead of simply calling `count++` we call `var localCount = count++` and use that local variable to compare against.
