### PR TITLE
Install fixes

### DIFF
--- a/Wabbajack/View Models/Installers/MO2InstallerVM.cs
+++ b/Wabbajack/View Models/Installers/MO2InstallerVM.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
 using Wabbajack.Common;
+using Wabbajack.Common.StatusFeed;
 using Wabbajack.Lib;
 using Wabbajack.Util;
 
@@ -105,7 +106,8 @@ namespace Wabbajack
                 .DisposeWith(CompositeDisposable);
 
             // Hook onto user interventions, and intercept MO2 specific ones for customization
-            this.WhenAny(x => x.ActiveInstallation.LogMessages)
+            this.WhenAny(x => x.ActiveInstallation)
+                .Select(x => x?.LogMessages ?? Observable.Empty<IStatusMessage>())
                 .Switch()
                 .Subscribe(x =>
                 {


### PR DESCRIPTION
Two fixes for installation:
- During 2nd/3rd installs in the same WJ process, MO2Installation overwrite confirmations were being confirmed twice (throwing errors).  I narrowed it down to what I think was an improper Rx switch.  It short circuits to the new ActiveInstallation better now.
- Hopeful fix for #490 .  Fixed AInstaller's empty folders logic to construct the expected folders before trimming the modlist instructions.