### PR TITLE
Percent hotfix

### DIFF
--- a/Wabbajack.Common/StatusUpdate.cs
+++ b/Wabbajack.Common/StatusUpdate.cs
@@ -44,7 +44,7 @@ namespace Wabbajack.Common
         {
             var per_step = 1.0f / _internalMaxStep;
             var macro = _internalCurrentStep * per_step;
-            return Percent.FactoryPutInRange(macro + (per_step * sub_status));
+            return Percent.FactoryPutInRange(macro + (per_step * sub_status.Value));
         }
 
         public void MakeUpdate(Percent progress)

--- a/Wabbajack.Common/Util/Percent.cs
+++ b/Wabbajack.Common/Util/Percent.cs
@@ -70,7 +70,37 @@ namespace Wabbajack.Common
             return new Percent(c1.Value / c2.Value);
         }
 
-        public static implicit operator double(Percent c1)
+        public static bool operator ==(Percent c1, Percent c2)
+        {
+            return c1.Value == c2.Value;
+        }
+
+        public static bool operator !=(Percent c1, Percent c2)
+        {
+            return c1.Value != c2.Value;
+        }
+
+        public static bool operator >(Percent c1, Percent c2)
+        {
+            return c1.Value > c2.Value;
+        }
+
+        public static bool operator <(Percent c1, Percent c2)
+        {
+            return c1.Value < c2.Value;
+        }
+
+        public static bool operator >=(Percent c1, Percent c2)
+        {
+            return c1.Value >= c2.Value;
+        }
+
+        public static bool operator <=(Percent c1, Percent c2)
+        {
+            return c1.Value <= c2.Value;
+        }
+
+        public static explicit operator double(Percent c1)
         {
             return c1.Value;
         }

--- a/Wabbajack.Lib/ABatchProcessor.cs
+++ b/Wabbajack.Lib/ABatchProcessor.cs
@@ -128,7 +128,7 @@ namespace Wabbajack.Lib
                 ManualCoreLimit,
                 MaxCores,
                 TargetUsagePercent,
-                (manual, max, target) => CalculateThreadsToUse(recommendedCount, manual, max, target));
+                (manual, max, target) => CalculateThreadsToUse(recommendedCount, manual, max, target.Value));
         }
 
         /// <summary>

--- a/Wabbajack/Views/Compilers/CompilerView.xaml.cs
+++ b/Wabbajack/Views/Compilers/CompilerView.xaml.cs
@@ -122,7 +122,6 @@ namespace Wabbajack
                     .BindToStrict(this, x => x.LogView.ProgressPercent)
                     .DisposeWith(dispose);
                 this.WhenAny(x => x.ViewModel.PercentCompleted)
-                    .Select(f => (double)f)
                     .BindToStrict(this, x => x.CpuView.ProgressPercent)
                     .DisposeWith(dispose);
                 this.WhenAny(x => x.ViewModel.MWVM.Settings)

--- a/Wabbajack/Views/Installers/InstallationView.xaml.cs
+++ b/Wabbajack/Views/Installers/InstallationView.xaml.cs
@@ -134,7 +134,6 @@ namespace Wabbajack
                     .BindToStrict(this, x => x.LogView.ProgressPercent)
                     .DisposeWith(dispose);
                 this.WhenAny(x => x.ViewModel.PercentCompleted)
-                    .Select(f => (double)f)
                     .BindToStrict(this, x => x.CpuView.ProgressPercent)
                     .DisposeWith(dispose);
                 this.WhenAny(x => x.ViewModel.MWVM.Settings)

--- a/Wabbajack/Views/ModListTileView.xaml.cs
+++ b/Wabbajack/Views/ModListTileView.xaml.cs
@@ -15,6 +15,7 @@ using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
 using ReactiveUI;
+using Wabbajack.Common;
 
 namespace Wabbajack
 {
@@ -28,7 +29,7 @@ namespace Wabbajack
             InitializeComponent();
             this.WhenActivated(dispose =>
             {
-                this.MarkAsNeeded<ModListTileView, ModListMetadataVM, double>(this.ViewModel, x => x.ProgressPercent);
+                this.MarkAsNeeded<ModListTileView, ModListMetadataVM, Percent>(this.ViewModel, x => x.ProgressPercent);
                 this.MarkAsNeeded<ModListTileView, ModListMetadataVM, bool>(this.ViewModel, x => x.IsBroken);
                 this.MarkAsNeeded<ModListTileView, ModListMetadataVM, bool>(this.ViewModel, x => x.Exists);
                 this.MarkAsNeeded<ModListTileView, ModListMetadataVM, string>(this.ViewModel, x => x.Metadata.Links.ImageUri);

--- a/Wabbajack/Views/Settings/PerformanceSettingsView.xaml.cs
+++ b/Wabbajack/Views/Settings/PerformanceSettingsView.xaml.cs
@@ -64,7 +64,7 @@ namespace Wabbajack
                         vmToViewConverter: x => x,
                         viewToVmConverter: x => (byte)(x ?? 0))
                     .DisposeWith(disposable);
-                this.BindStrict(this.ViewModel, x => x.TargetUsage, x => x.TargetUsageSpinner.Value)
+                this.Bind(this.ViewModel, x => x.TargetUsage, x => x.TargetUsageSpinner.Value)
                     .DisposeWith(disposable);
                 this.Bind(this.ViewModel, x => x.TargetUsage, x => x.TargetUsageSlider.Value)
                     .DisposeWith(disposable);


### PR DESCRIPTION
Crash hotfix for Percent systems and binding
- Removed implicit double conversion operator
- Adjusted remaining compile errors from that removal

Crash was from BindStrict latching onto the implicit double converter to make both of its Expressions return type `double?`.  RxUI though at runtime uses reflection, and then finds the properties being pointed to aren't actually of that type and throws a fit.   The `BindStrict` system is a little better at catching errors than `Bind`, but this was one of the situations it can't catch.

The controls using Percent systems are utilizing the non-strict RxUI's `Bind` so that the registered fallback converter can be leveraged... rather than `BindStrict` where we'd have to supply the converter lambdas every time.  Might change this later, but it's fine for now.  The issue was `BindStrict` being used but being able to "lie" about the types matching due to the implicit operator's presence