### PR TITLE
Fix checking the file association for needed updates

### DIFF
--- a/Wabbajack.Common/ModListAssociationManager1.cs
+++ b/Wabbajack.Common/ModListAssociationManager1.cs
@@ -32,7 +32,7 @@ namespace Wabbajack.Common
             var tempKey = progIDKey?.OpenSubKey("shell\\open\\command");
             if (progIDKey == null || tempKey == null) return true;
             var value = tempKey.GetValue("");
-            return value == null || value.ToString().Equals($"\"{appPath}\" -i=\"%1\"");
+            return value == null || !value.ToString().Equals($"\"{appPath}\" -i=\"%1\"");
         }
 
         public static bool IsAssociated()


### PR DESCRIPTION
Previously, this would fail to notice that the file association needed
to be updated.  This would lead to Windows trying to open non-existent
copies of Wabbajack or to Wabbajack selecting "-i" as the chosen mod list
instead of the file selected.