### PR TITLE
Fix compilation network issues

### DIFF
--- a/Compression.BSA/Compression.BSA.csproj
+++ b/Compression.BSA/Compression.BSA.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netstandard2.1</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <Platforms>x64</Platforms>
         <RuntimeIdentifier>win10-x64</RuntimeIdentifier>

--- a/Wabbajack.BuildServer/Controllers/IndexedFiles.cs
+++ b/Wabbajack.BuildServer/Controllers/IndexedFiles.cs
@@ -112,6 +112,9 @@ namespace Wabbajack.BuildServer.Controllers
                     Utils.Log("No valid INI parser for: \n" + iniString);
                     continue;
                 }
+                
+                if (data is ManualDownloader.State)
+                    continue;
 
                 var key = data.PrimaryKeyString;
                 var found = await Db.DownloadStates.AsQueryable().Where(f => f.Key == key).Take(1).ToListAsync();

--- a/Wabbajack.BuildServer/Models/Jobs/IndexJob.cs
+++ b/Wabbajack.BuildServer/Models/Jobs/IndexJob.cs
@@ -24,6 +24,9 @@ namespace Wabbajack.BuildServer.Models.Jobs
         public override bool UsesNexus { get => Archive.State is NexusDownloader.State; }
         public override async Task<JobResult> Execute(DBContext db, SqlService sql, AppSettings settings)
         {
+            if (Archive.State is ManualDownloader.State)
+                return JobResult.Success();
+            
             var pk = new List<object>();
             pk.Add(AbstractDownloadState.TypeToName[Archive.State.GetType()]);
             pk.AddRange(Archive.State.PrimaryKey);

--- a/Wabbajack.Common/Consts.cs
+++ b/Wabbajack.Common/Consts.cs
@@ -102,5 +102,6 @@ namespace Wabbajack.Common
         public const string MO2ModFolderName = "mods";
 
         public static string PatchCacheFolder => Path.Combine(LocalAppDataPath, "patch_cache");
+        public static int MaxConnectionsPerServer = 4;
     }
 }

--- a/Wabbajack.Common/Http/Client.cs
+++ b/Wabbajack.Common/Http/Client.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Wabbajack.Common.Http
+{
+    public class Client
+    {
+        public List<(string, string)> Headers => new List<(string, string)>();
+        public List<Cookie> Cookies = new List<Cookie>();
+        public async Task<HttpResponseMessage> GetAsync(string url, HttpCompletionOption responseHeadersRead = HttpCompletionOption.ResponseContentRead)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, url);
+            foreach (var (k, v) in Headers) 
+                request.Headers.Add(k, v);
+            return await SendAsync(request, responseHeadersRead);
+        }
+        
+        public async Task<string> GetStringAsync(string url)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, url);
+            foreach (var (k, v) in Headers) 
+                request.Headers.Add(k, v);
+            if (Cookies.Count > 0)
+                Cookies.ForEach(c => ClientFactory.Cookies.Add(c));
+                
+            return await SendStringAsync(request);
+        }
+
+        private async Task<string> SendStringAsync(HttpRequestMessage request)
+        {
+            var result = await SendAsync(request);
+            return await result.Content.ReadAsStringAsync();
+        }
+
+
+        public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage msg, HttpCompletionOption responseHeadersRead = HttpCompletionOption.ResponseContentRead)
+        {
+            int retries = 0;
+            TOP:
+            try
+            {
+                var response = await ClientFactory.Client.SendAsync(msg, responseHeadersRead);
+                return response;
+            }
+            catch (Exception)
+            {
+                if (retries > Consts.MaxHTTPRetries) throw;
+
+                retries++;
+                Utils.Log($"Http Connect error to {msg.RequestUri} retry {retries}");
+                await Task.Delay(100 * retries);
+                goto TOP;
+
+            }
+
+        }
+    }
+}

--- a/Wabbajack.Common/Http/Client.cs
+++ b/Wabbajack.Common/Http/Client.cs
@@ -9,7 +9,7 @@ namespace Wabbajack.Common.Http
 {
     public class Client
     {
-        public List<(string, string)> Headers => new List<(string, string)>();
+        public List<(string, string)> Headers = new List<(string, string)>();
         public List<Cookie> Cookies = new List<Cookie>();
         public async Task<HttpResponseMessage> GetAsync(string url, HttpCompletionOption responseHeadersRead = HttpCompletionOption.ResponseContentRead)
         {

--- a/Wabbajack.Common/Http/ClientFactory.cs
+++ b/Wabbajack.Common/Http/ClientFactory.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Net;
+using SysHttp = System.Net.Http;
+namespace Wabbajack.Common.Http
+{
+    public static class ClientFactory
+    {
+        private static SysHttp.SocketsHttpHandler _socketsHandler { get; }
+        internal static SysHttp.HttpClient Client { get; }
+        internal static CookieContainer Cookies { get; }
+
+        static ClientFactory()
+        {
+            Cookies = new CookieContainer();
+            _socketsHandler = new SysHttp.SocketsHttpHandler
+            {
+                CookieContainer = Cookies,
+                MaxConnectionsPerServer = 8,
+                PooledConnectionLifetime = TimeSpan.FromSeconds(2),
+                PooledConnectionIdleTimeout = TimeSpan.FromSeconds(2)
+            };
+            Client = new SysHttp.HttpClient(_socketsHandler);
+        }
+    }
+}

--- a/Wabbajack.Common/Wabbajack.Common.csproj
+++ b/Wabbajack.Common/Wabbajack.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netstandard2.1</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
         <Platforms>x64</Platforms>
         <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
         
@@ -39,6 +39,7 @@
         <PackageReference Include="ReactiveUI" Version="11.1.23" />
         <PackageReference Include="SharpZipLib" Version="1.2.0" />
         <PackageReference Include="System.Data.HashFunction.xxHash" Version="2.0.0" />
+        <PackageReference Include="System.Net.Http" Version="4.3.4" />
         <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.7.0" />
         <PackageReference Include="System.Security.Principal.Windows" Version="4.7.0" />
         <PackageReference Include="YamlDotNet" Version="8.1.0" />

--- a/Wabbajack.Lib/ACompiler.cs
+++ b/Wabbajack.Lib/ACompiler.cs
@@ -22,7 +22,7 @@ namespace Wabbajack.Lib
         public bool ReadmeIsWebsite;
         public string WabbajackVersion;
 
-        protected string _vfsCacheName => Path.Combine(Consts.LocalAppDataPath, $"vfs_compile_cache_{ModListName.StringSHA256Hex()}.bin");
+        protected string _vfsCacheName => Path.Combine(Consts.LocalAppDataPath, $"vfs_compile_cache_{ModListName?.StringSHA256Hex() ?? "_Unknown_"}.bin");
         /// <summary>
         /// A stream of tuples of ("Update Title", 0.25) which represent the name of the current task
         /// and the current progress.

--- a/Wabbajack.Lib/ACompiler.cs
+++ b/Wabbajack.Lib/ACompiler.cs
@@ -22,7 +22,7 @@ namespace Wabbajack.Lib
         public bool ReadmeIsWebsite;
         public string WabbajackVersion;
 
-        protected static string _vfsCacheName => Path.Combine(Consts.LocalAppDataPath, "vfs_compile_cache.bin");
+        protected string _vfsCacheName => Path.Combine(Consts.LocalAppDataPath, $"vfs_compile_cache_{ModListName.StringSHA256Hex()}.bin");
         /// <summary>
         /// A stream of tuples of ("Update Title", 0.25) which represent the name of the current task
         /// and the current progress.

--- a/Wabbajack.Lib/Downloaders/AbstractNeedsLoginDownloader.cs
+++ b/Wabbajack.Lib/Downloaders/AbstractNeedsLoginDownloader.cs
@@ -21,7 +21,7 @@ namespace Wabbajack.Lib.Downloaders
         private readonly string _encryptedKeyName;
         private readonly string _cookieDomain;
         private readonly string _cookieName;
-        internal HttpClient AuthedClient;
+        internal Common.Http.Client AuthedClient;
 
         /// <summary>
         /// Sets up all the login facilites needed for a INeedsLogin downloader based on having the user log
@@ -81,7 +81,7 @@ namespace Wabbajack.Lib.Downloaders
             return cookies;
         }
         
-        public async Task<HttpClient> GetAuthedClient()
+        public async Task<Common.Http.Client> GetAuthedClient()
         {
             Helpers.Cookie[] cookies;
             try

--- a/Wabbajack.Lib/Downloaders/GoogleDriveDownloader.cs
+++ b/Wabbajack.Lib/Downloaders/GoogleDriveDownloader.cs
@@ -53,7 +53,7 @@ namespace Wabbajack.Lib.Downloaders
             private async Task<HTTPDownloader.State> ToHttpState()
             {
                 var initialURL = $"https://drive.google.com/uc?id={Id}&export=download";
-                var client = new HttpClient();
+                var client = new Common.Http.Client();
                 var response = await client.GetAsync(initialURL);
                 if (!response.IsSuccessStatusCode)
                     throw new HttpException((int)response.StatusCode, response.ReasonPhrase);

--- a/Wabbajack.Lib/Downloaders/HTTPDownloader.cs
+++ b/Wabbajack.Lib/Downloaders/HTTPDownloader.cs
@@ -61,7 +61,7 @@ namespace Wabbajack.Lib.Downloaders
             public List<string> Headers { get; set; }
 
             [Exclude]
-            public HttpClient Client { get; set; }
+            public Common.Http.Client Client { get; set; }
 
             public override object[] PrimaryKey { get => new object[] {Url};}
 
@@ -86,8 +86,8 @@ namespace Wabbajack.Lib.Downloaders
 
                 using (var fs = download ? File.Open(destination, FileMode.Create) : null)
                 {
-                    var client = Client ?? new HttpClient();
-                    client.DefaultRequestHeaders.Add("User-Agent", Consts.UserAgent);
+                    var client = Client ?? new Common.Http.Client();
+                    client.Headers.Add(("User-Agent", Consts.UserAgent));
 
                     if (Headers != null)
                         foreach (var header in Headers)
@@ -95,7 +95,7 @@ namespace Wabbajack.Lib.Downloaders
                             var idx = header.IndexOf(':');
                             var k = header.Substring(0, idx);
                             var v = header.Substring(idx + 1);
-                            client.DefaultRequestHeaders.Add(k, v);
+                            client.Headers.Add((k, v));
                         }
 
                     long totalRead = 0;

--- a/Wabbajack.Lib/Downloaders/MediaFireDownloader.cs
+++ b/Wabbajack.Lib/Downloaders/MediaFireDownloader.cs
@@ -53,7 +53,7 @@ namespace Wabbajack.Lib.Downloaders
                     if (newURL == null || !newURL.StartsWith("http")) return null;
                     return new HTTPDownloader.State()
                     {
-                        Client = new HttpClient(),
+                        Client = new Common.Http.Client(),
                         Url = newURL
                     };
                 }

--- a/Wabbajack.Lib/LibCefHelpers/Init.cs
+++ b/Wabbajack.Lib/LibCefHelpers/Init.cs
@@ -16,13 +16,15 @@ namespace Wabbajack.Lib.LibCefHelpers
 {
     public static class Helpers
     {
-        public static HttpClient GetClient(IEnumerable<Cookie> cookies, string referer)
+        public static Common.Http.Client GetClient(IEnumerable<Cookie> cookies, string referer)
         {
+            throw new NotImplementedException("tt");
+            /*
             var container = ToCookieContainer(cookies);
             var handler = new HttpClientHandler { CookieContainer = container };
             var client = new HttpClient(handler);
             client.DefaultRequestHeaders.Referrer = new Uri(referer);
-            return client;
+            return client;*/
         }
 
         private static CookieContainer ToCookieContainer(IEnumerable<Cookie> cookies)

--- a/Wabbajack.Lib/LibCefHelpers/Init.cs
+++ b/Wabbajack.Lib/LibCefHelpers/Init.cs
@@ -18,13 +18,10 @@ namespace Wabbajack.Lib.LibCefHelpers
     {
         public static Common.Http.Client GetClient(IEnumerable<Cookie> cookies, string referer)
         {
-            throw new NotImplementedException("tt");
-            /*
-            var container = ToCookieContainer(cookies);
-            var handler = new HttpClientHandler { CookieContainer = container };
-            var client = new HttpClient(handler);
-            client.DefaultRequestHeaders.Referrer = new Uri(referer);
-            return client;*/
+            var client = new Common.Http.Client();
+            client.Headers.Add(("Referrer", referer));
+            client.Cookies.AddRange(cookies.Select(cookie => new System.Net.Cookie(cookie.Name, cookie.Value, cookie.Path, cookie.Domain)));
+            return client;
         }
 
         private static CookieContainer ToCookieContainer(IEnumerable<Cookie> cookies)

--- a/Wabbajack.Lib/StatusMessages/ManuallyDownloadFile.cs
+++ b/Wabbajack.Lib/StatusMessages/ManuallyDownloadFile.cs
@@ -12,8 +12,8 @@ namespace Wabbajack.Lib
         public override string ShortDescription { get; }
         public override string ExtendedDescription { get; }
         
-        private TaskCompletionSource<(Uri, HttpClient)> _tcs = new TaskCompletionSource<(Uri, HttpClient)>();
-        public Task<(Uri, HttpClient)> Task => _tcs.Task;
+        private TaskCompletionSource<(Uri, Common.Http.Client)> _tcs = new TaskCompletionSource<(Uri, Common.Http.Client)>();
+        public Task<(Uri, Common.Http.Client)> Task => _tcs.Task;
 
         private ManuallyDownloadFile(ManualDownloader.State state)
         {
@@ -30,7 +30,7 @@ namespace Wabbajack.Lib
             _tcs.SetCanceled();
         }
 
-        public void Resume(Uri s, HttpClient client)
+        public void Resume(Uri s, Common.Http.Client client)
         {
             _tcs.SetResult((s, client));
         }

--- a/Wabbajack.Lib/Wabbajack.Lib.csproj
+++ b/Wabbajack.Lib/Wabbajack.Lib.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netstandard2.1</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
         <Platforms>x64</Platforms>
         <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
     </PropertyGroup>

--- a/Wabbajack.VirtualFileSystem/Context.cs
+++ b/Wabbajack.VirtualFileSystem/Context.cs
@@ -24,7 +24,7 @@ namespace Wabbajack.VirtualFileSystem
             Utils.Log("Cleaning VFS, this may take a bit of time");
             Utils.DeleteDirectory(_stagingFolder);
         }
-        public const ulong FileVersion = 0x02;
+        public const ulong FileVersion = 0x03;
         public const string Magic = "WABBAJACK VFS FILE";
 
         private static readonly string _stagingFolder = "vfs_staging";
@@ -420,13 +420,16 @@ namespace Wabbajack.VirtualFileSystem
         public TemporaryDirectory(string name)
         {
             FullName = name;
+            if (!Directory.Exists(FullName))
+                Directory.CreateDirectory(FullName);
         }
 
         public string FullName { get; }
 
         public void Dispose()
         {
-            Utils.DeleteDirectory(FullName);
+            if (Directory.Exists(FullName)) 
+                Utils.DeleteDirectory(FullName);
         }
     }
 }

--- a/Wabbajack.VirtualFileSystem/VirtualFile.cs
+++ b/Wabbajack.VirtualFileSystem/VirtualFile.cs
@@ -112,6 +112,20 @@ namespace Wabbajack.VirtualFileSystem
                 return _thisAndAllChildren;
             }
         }
+        
+        
+        public T ThisAndAllChildrenReduced<T>(T acc, Func<T, VirtualFile, T> fn)
+        {
+            acc = fn(acc, this);
+            return this.Children.Aggregate(acc, (current, itm) => itm.ThisAndAllChildrenReduced<T>(current, fn));
+        }
+        
+        public void ThisAndAllChildrenReduced(Action<VirtualFile> fn)
+        {
+            fn(this);
+            foreach (var itm in Children)
+                itm.ThisAndAllChildrenReduced(fn);
+        }
 
 
         /// <summary>
@@ -233,6 +247,7 @@ namespace Wabbajack.VirtualFileSystem
         private void Write(BinaryWriter bw)
         {
             bw.Write(Name);
+            bw.Write(FullPath);
             bw.Write(Hash);
             bw.Write(Size);
             bw.Write(LastModified);
@@ -258,6 +273,7 @@ namespace Wabbajack.VirtualFileSystem
                 Context = context,
                 Parent = parent,
                 Name = br.ReadString(),
+                _fullPath = br.ReadString(),
                 Hash = br.ReadString(),
                 Size = br.ReadInt64(),
                 LastModified = br.ReadInt64(),

--- a/Wabbajack.VirtualFileSystem/Wabbajack.VirtualFileSystem.csproj
+++ b/Wabbajack.VirtualFileSystem/Wabbajack.VirtualFileSystem.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netstandard2.1</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
         <Platforms>x64</Platforms>
         <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
     </PropertyGroup>

--- a/Wabbajack.sln
+++ b/Wabbajack.sln
@@ -38,7 +38,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Wabbajack.Test", "Wabbajack
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Wabbajack.CLI", "Wabbajack.CLI\Wabbajack.CLI.csproj", "{685D8BB1-D178-4D2C-85C7-C54A36FB7454}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wabbajack.Launcher", "Wabbajack.Launcher\Wabbajack.Launcher.csproj", "{D6856DBF-C959-4867-A8A8-343DA2D2715E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Wabbajack.Launcher", "Wabbajack.Launcher\Wabbajack.Launcher.csproj", "{D6856DBF-C959-4867-A8A8-343DA2D2715E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -84,12 +84,14 @@ Global
 		{37E4D421-8FD3-4D57-8F3A-7A511D6ED5C5}.Release|Any CPU.ActiveCfg = Release|x64
 		{37E4D421-8FD3-4D57-8F3A-7A511D6ED5C5}.Release|x64.ActiveCfg = Release|x64
 		{37E4D421-8FD3-4D57-8F3A-7A511D6ED5C5}.Release|x64.Build.0 = Release|x64
-		{DE18D89E-39C5-48FD-8E42-16235E3C4593}.Debug|Any CPU.ActiveCfg = Debug|x64
-		{DE18D89E-39C5-48FD-8E42-16235E3C4593}.Debug|x64.ActiveCfg = Debug|x64
-		{DE18D89E-39C5-48FD-8E42-16235E3C4593}.Debug|x64.Build.0 = Debug|x64
-		{DE18D89E-39C5-48FD-8E42-16235E3C4593}.Release|Any CPU.ActiveCfg = Release|x64
-		{DE18D89E-39C5-48FD-8E42-16235E3C4593}.Release|x64.ActiveCfg = Release|x64
-		{DE18D89E-39C5-48FD-8E42-16235E3C4593}.Release|x64.Build.0 = Release|x64
+		{DE18D89E-39C5-48FD-8E42-16235E3C4593}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DE18D89E-39C5-48FD-8E42-16235E3C4593}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DE18D89E-39C5-48FD-8E42-16235E3C4593}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DE18D89E-39C5-48FD-8E42-16235E3C4593}.Debug|x64.Build.0 = Debug|Any CPU
+		{DE18D89E-39C5-48FD-8E42-16235E3C4593}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DE18D89E-39C5-48FD-8E42-16235E3C4593}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DE18D89E-39C5-48FD-8E42-16235E3C4593}.Release|x64.ActiveCfg = Release|Any CPU
+		{DE18D89E-39C5-48FD-8E42-16235E3C4593}.Release|x64.Build.0 = Release|Any CPU
 		{6ED08CFB-B879-4B55-8741-663A4A3491CE}.Debug|Any CPU.ActiveCfg = Debug|x64
 		{6ED08CFB-B879-4B55-8741-663A4A3491CE}.Debug|x64.ActiveCfg = Debug|x64
 		{6ED08CFB-B879-4B55-8741-663A4A3491CE}.Debug|x64.Build.0 = Debug|x64


### PR DESCRIPTION
We were (and still are in some cases) abusing HttpClient. This code switches to a singleton HttpClient (which pools connections) and is backed by the new SocketsHttpHandler. 