### PR TITLE
Switch from BSDiff to OctoDiff for patch generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Version - 0.9.22.0
 * Server side fixes for CORS support and FTP uploads
+* Use OctoDiff instead of BSDiff for better performance during diff generation 
 
 #### Version - 0.9.21.0 - 2/23/2020
 * Fix never ending hash issue

--- a/Wabbajack.Common/OctoDiff.cs
+++ b/Wabbajack.Common/OctoDiff.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.IO;
+using Octodiff.Core;
+using Octodiff.Diagnostics;
+
+namespace Wabbajack.Common
+{
+    public class OctoDiff
+    {
+        private static ProgressReporter reporter = new ProgressReporter();
+        public static void Create(byte[] oldData, byte[] newData, Stream output)
+        {
+            using var signature = CreateSignature(oldData);
+            using var oldStream = new MemoryStream(oldData);
+            using var newStream = new MemoryStream(newData);
+            var db = new DeltaBuilder {ProgressReporter = reporter};
+            db.BuildDelta(newStream, new SignatureReader(signature, reporter), new AggregateCopyOperationsDecorator(new BinaryDeltaWriter(output)));
+        }
+
+        private static Stream CreateSignature(byte[] oldData)
+        {
+            Utils.Status("Creating Patch Signature");
+            using var oldDataStream = new MemoryStream(oldData);
+            var sigStream = new MemoryStream();
+            var signatureBuilder = new SignatureBuilder();
+            signatureBuilder.Build(oldDataStream, new SignatureWriter(sigStream));
+            sigStream.Position = 0;
+            return sigStream;
+        }
+
+        private class ProgressReporter : IProgressReporter
+        {
+            public void ReportProgress(string operation, long currentPosition, long total)
+            {
+                Utils.Status(operation, new Percent(total, currentPosition));
+            }
+        }
+
+        public static void Apply(Stream input, Func<Stream> openPatchStream, Stream output)
+        {
+            using var deltaStream = openPatchStream();
+            var deltaApplier = new DeltaApplier();
+            deltaApplier.Apply(input, new BinaryDeltaReader(deltaStream, reporter), output);
+        }
+    }
+}

--- a/Wabbajack.Common/Util/Percent.cs
+++ b/Wabbajack.Common/Util/Percent.cs
@@ -24,6 +24,11 @@ namespace Wabbajack.Common
             }
         }
 
+        public Percent(long max, long current) : this((double)current / max)
+        {
+            
+        }
+
         public Percent(double d)
             : this(d, check: true)
         {

--- a/Wabbajack.Common/Wabbajack.Common.csproj
+++ b/Wabbajack.Common/Wabbajack.Common.csproj
@@ -36,6 +36,7 @@
         <PackageReference Include="ini-parser-netstandard" Version="2.5.2" />
         <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
         <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+        <PackageReference Include="Octodiff" Version="1.2.1" />
         <PackageReference Include="OMODFramework" Version="2.0.0" />
         <PackageReference Include="ReactiveUI" Version="11.1.23" />
         <PackageReference Include="SharpZipLib" Version="1.2.0" />

--- a/Wabbajack.Lib/MO2Installer.cs
+++ b/Wabbajack.Lib/MO2Installer.cs
@@ -298,7 +298,7 @@ namespace Wabbajack.Lib
             using (var output = File.Open(toFile, FileMode.Create))
             using (var input = File.OpenRead(gameFile))
             {
-                BSDiff.Apply(input, () => new MemoryStream(patchData), output);
+                Utils.ApplyPatch(input, () => new MemoryStream(patchData), output);
             }
         }
 

--- a/Wabbajack.Lib/zEditIntegration.cs
+++ b/Wabbajack.Lib/zEditIntegration.cs
@@ -176,7 +176,7 @@ namespace Wabbajack.Lib
                     var patch_data = installer.LoadBytesFromPath(m.PatchID);
 
                     using (var fs = File.Open(Path.Combine(installer.OutputFolder, m.To), FileMode.Create)) 
-                        BSDiff.Apply(new MemoryStream(src_data), () => new MemoryStream(patch_data), fs);
+                        Utils.ApplyPatch(new MemoryStream(src_data), () => new MemoryStream(patch_data), fs);
                 });
         }
     }

--- a/Wabbajack.Test/TestUtils.cs
+++ b/Wabbajack.Test/TestUtils.cs
@@ -15,16 +15,16 @@ namespace Wabbajack.Test
 {
     public class TestUtils : IDisposable
     {
+        private static Random _rng = new Random();
         public TestUtils()
         {
-            RNG = new Random();
             ID = RandomName();
             WorkingDirectory = Path.Combine(Directory.GetCurrentDirectory(), "tmp_data");
         }
 
         public string WorkingDirectory { get;}
         public string ID { get; }
-        public Random RNG { get; }
+        public Random RNG => _rng;
 
         public Game Game { get; set; }
 
@@ -111,6 +111,15 @@ namespace Wabbajack.Test
             }
 
             File.WriteAllBytes(full_path, bytes);
+        }
+
+        public static byte[] RandomData(int? size = null, int maxSize = 1024)
+        {
+            if (size == null)
+                size = _rng.Next(1, maxSize);
+            var arr = new byte[(int) size];
+            _rng.NextBytes(arr);
+            return arr;
         }
 
         public void Dispose()
@@ -249,6 +258,11 @@ namespace Wabbajack.Test
                 Directory.CreateDirectory(dir);
             GenerateRandomFileData(full_path, i);
             return full_path;
+        }
+
+        public static object RandomeOne(params object[] opts)
+        {
+            return opts[_rng.Next(0, opts.Length)];
         }
     }
 }

--- a/Wabbajack.Test/UtilsTests.cs
+++ b/Wabbajack.Test/UtilsTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -11,6 +12,7 @@ namespace Wabbajack.Test
     [TestClass]
     public class UtilsTests
     {
+       
         [TestMethod]
         public void IsInPathTests()
         {
@@ -21,6 +23,48 @@ namespace Wabbajack.Test
             Assert.IsTrue("c:\\foo\\bar.exe".IsInPath("c:\\fOo"));
             Assert.IsTrue("c:\\foo\\bar.exe".IsInPath("c:\\foo\\"));
             Assert.IsTrue("c:\\foo\\bar\\".IsInPath("c:\\foo\\"));
+        }
+
+
+        [TestMethod]
+        [DataTestMethod]
+        [DynamicData(nameof(PatchData), DynamicDataSourceType.Method)]
+        public async Task DiffCreateAndApply(byte[] src, byte[] dest, DiffMethod method)
+        {
+            await using var ms = new MemoryStream();
+            switch (method)
+            {
+                case DiffMethod.Default:
+                    await Utils.CreatePatch(src, dest, ms);
+                    break;
+                case DiffMethod.BSDiff:
+                    BSDiff.Create(src, dest, ms);
+                    break;
+                case DiffMethod.OctoDiff:
+                    OctoDiff.Create(src, dest, ms);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(method), method, null);
+            }
+
+            ms.Position = 0;
+            var patch = ms.ToArray();
+            await using var resultStream = new MemoryStream();
+            Utils.ApplyPatch(new MemoryStream(src), () => new MemoryStream(patch), resultStream);
+            CollectionAssert.AreEqual(dest, resultStream.ToArray());
+        }
+
+
+        public enum DiffMethod
+        {
+            Default,
+            BSDiff,
+            OctoDiff
+        }
+        public static IEnumerable<object[]> PatchData()
+        {
+            var maxSize = 1024 * 1024 * 8;
+            return Enumerable.Range(0, 10).Select(x => new[] {TestUtils.RandomData(maxSize:maxSize), TestUtils.RandomData(maxSize:maxSize), TestUtils.RandomeOne(DiffMethod.Default, DiffMethod.OctoDiff, DiffMethod.BSDiff)});
         }
     }
 }


### PR DESCRIPTION
BSDiff gave terrible performance in some situations. Switched to OctoDiff for better performance.