### PR TITLE
PR: Store settings.json in local appdata

### DIFF
--- a/Wabbajack.Common/Consts.cs
+++ b/Wabbajack.Common/Consts.cs
@@ -108,5 +108,6 @@ namespace Wabbajack.Common
         public static int MaxOldLogs = 50;
 
         public static string SettingsFile => Path.Combine(LocalAppDataPath, "settings.json");
+        public static byte SettingsVersion => 1;
     }
 }

--- a/Wabbajack.Common/Consts.cs
+++ b/Wabbajack.Common/Consts.cs
@@ -106,5 +106,7 @@ namespace Wabbajack.Common
 
         public static string LogsFolder = "logs";
         public static int MaxOldLogs = 50;
+
+        public static string SettingsFile => Path.Combine(LocalAppDataPath, "settings.json");
     }
 }

--- a/Wabbajack/Settings.cs
+++ b/Wabbajack/Settings.cs
@@ -1,10 +1,8 @@
 ﻿using Newtonsoft.Json;
-using ReactiveUI.Fody.Helpers;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reactive;
-using System.Reactive.Disposables;
 using System.Reactive.Subjects;
 using Wabbajack.Common;
 using Wabbajack.Lib;
@@ -14,6 +12,8 @@ namespace Wabbajack
     [JsonObject(MemberSerialization.OptOut)]
     public class MainSettings
     {
+        public byte Version { get; set; }
+
         public double PosX { get; set; }
         public double PosY { get; set; }
         public double Height { get; set; }
@@ -34,8 +34,20 @@ namespace Wabbajack
                 return false;
             }
 
+            // Version check
             settings = JsonConvert.DeserializeObject<MainSettings>(File.ReadAllText(Consts.SettingsFile));
-            return true;
+            if (settings.Version == Consts.SettingsVersion)
+                return true;
+
+            var backup = Consts.SettingsFile + "-backup.json";
+            if(File.Exists(backup))
+                File.Delete(backup);
+            
+            File.Copy(Consts.SettingsFile, backup);
+            File.Delete(Consts.SettingsFile);
+
+            settings = default;
+            return false;
         }
 
         public static void SaveSettings(MainSettings settings)
@@ -75,14 +87,14 @@ namespace Wabbajack
     [JsonObject(MemberSerialization.OptOut)]
     public class PerformanceSettings : ViewModel
     {
-        private bool _Manual = false;
-        public bool Manual { get => _Manual; set => this.RaiseAndSetIfChanged(ref _Manual, value); }
+        private bool _manual;
+        public bool Manual { get => _manual; set => RaiseAndSetIfChanged(ref _manual, value); }
 
-        private byte _MaxCores = byte.MaxValue;
-        public byte MaxCores { get => _MaxCores; set => this.RaiseAndSetIfChanged(ref _MaxCores, value); }
+        private byte _maxCores = byte.MaxValue;
+        public byte MaxCores { get => _maxCores; set => RaiseAndSetIfChanged(ref _maxCores, value); }
 
-        private Percent _TargetUsage = Percent.One;
-        public Percent TargetUsage { get => _TargetUsage; set => this.RaiseAndSetIfChanged(ref _TargetUsage, value); }
+        private Percent _targetUsage = Percent.One;
+        public Percent TargetUsage { get => _targetUsage; set => RaiseAndSetIfChanged(ref _targetUsage, value); }
 
         public void AttachToBatchProcessor(ABatchProcessor processor)
         {

--- a/Wabbajack/Settings.cs
+++ b/Wabbajack/Settings.cs
@@ -14,8 +14,6 @@ namespace Wabbajack
     [JsonObject(MemberSerialization.OptOut)]
     public class MainSettings
     {
-        private static string _filename = "settings.json";
-
         public double PosX { get; set; }
         public double PosY { get; set; }
         public double Height { get; set; }
@@ -30,12 +28,13 @@ namespace Wabbajack
 
         public static bool TryLoadTypicalSettings(out MainSettings settings)
         {
-            if (!File.Exists(_filename))
+            if (!File.Exists(Consts.SettingsFile))
             {
                 settings = default;
                 return false;
             }
-            settings = JsonConvert.DeserializeObject<MainSettings>(File.ReadAllText(_filename));
+
+            settings = JsonConvert.DeserializeObject<MainSettings>(File.ReadAllText(Consts.SettingsFile));
             return true;
         }
 
@@ -48,7 +47,7 @@ namespace Wabbajack
             //settings._saveSignal.OnCompleted();
             //await settings._saveSignal;
 
-            File.WriteAllText(_filename, JsonConvert.SerializeObject(settings, Formatting.Indented));
+            File.WriteAllText(Consts.SettingsFile, JsonConvert.SerializeObject(settings, Formatting.Indented));
         }
     }
 

--- a/Wabbajack/Views/MainWindow.xaml.cs
+++ b/Wabbajack/Views/MainWindow.xaml.cs
@@ -59,7 +59,10 @@ namespace Wabbajack
             };
             if (CLIArguments.NoSettings || !MainSettings.TryLoadTypicalSettings(out var settings))
             {
-                _settings = new MainSettings();
+                _settings = new MainSettings
+                {
+                    Version = Consts.SettingsVersion
+                };
                 RunWhenLoaded(DefaultSettings);
             }
             else


### PR DESCRIPTION
resolves #587 

The current settings file has to have the same version as specified in
`Wabbajack.Common.Consts.SettingsVersion` or else it will be backed-up and
deleted to ensure that no bad settings file are getting loaded.

This means that the `SettingsVersion` needs to be updated when a breaking
change to the settings is being introduced.