### PR TITLE
LOOT configs are no longer Base64 encoded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### Changelog
 
+#### Version - Next
+* Included LOOT configs are no longer Base64 encoded
+
 #### Version - 3/30/2020
 * Added support for Morrowind on GOG
 * Fix a bug in the Author file uploader (Sync Error)

--- a/Wabbajack.Lib/CompilationSteps/IncludeLOOTFiles.cs
+++ b/Wabbajack.Lib/CompilationSteps/IncludeLOOTFiles.cs
@@ -18,7 +18,7 @@ namespace Wabbajack.Lib.CompilationSteps
         {
             if (!source.Path.StartsWith(_prefix)) return null;
             var result = source.EvolveTo<InlineFile>();
-            result.SourceDataID = _compiler.IncludeFile(File.ReadAllBytes(source.AbsolutePath).ToBase64());
+            result.SourceDataID = _compiler.IncludeFile(File.ReadAllBytes(source.AbsolutePath));
             return result;
         }
 


### PR DESCRIPTION
Fixes: #666 