### PR TITLE
Switching TextViewer from Window to mahWindow

### DIFF
--- a/Wabbajack/View Models/ModListVM.cs
+++ b/Wabbajack/View Models/ModListVM.cs
@@ -100,27 +100,27 @@ namespace Wabbajack
             }
             else
             {
-                using (var fs = new FileStream(ModListPath, FileMode.Open, FileAccess.Read, FileShare.Read))
-                using (var ar = new ZipArchive(fs, ZipArchiveMode.Read))
-                using (var ms = new MemoryStream())
+                using var fs = new FileStream(ModListPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+                using var ar = new ZipArchive(fs, ZipArchiveMode.Read);
+                using var ms = new MemoryStream();
+
+                var entry = ar.GetEntry(Readme);
+                if (entry == null)
                 {
-                    var entry = ar.GetEntry(Readme);
-                    if (entry == null)
-                    {
-                        Utils.Log($"Tried to open a non-existent readme: {Readme}");
-                        return;
-                    }
-                    using (var e = entry.Open())
-                    {
-                        e.CopyTo(ms);
-                    }
-                    ms.Seek(0, SeekOrigin.Begin);
-                    using (var reader = new StreamReader(ms))
-                    {
-                        var viewer = new TextViewer(reader.ReadToEnd(), Name);
-                        viewer.Show();
-                    }
+                    Utils.Log($"Tried to open a non-existent readme: {Readme}");
+                    return;
                 }
+
+                using (var e = entry.Open())
+                {
+                    e.CopyTo(ms);
+                }
+                ms.Seek(0, SeekOrigin.Begin);
+
+                using var reader = new StreamReader(ms);
+
+                var viewer = new TextViewer(reader.ReadToEnd(), Name);
+                viewer.Show();
             }
         }
 

--- a/Wabbajack/Views/TextViewer.xaml
+++ b/Wabbajack/Views/TextViewer.xaml
@@ -1,14 +1,15 @@
-﻿<Window
+﻿<mah:MetroWindow
     x:Class="Wabbajack.TextViewer"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:local="clr-namespace:Wabbajack"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:local="clr-namespace:Wabbajack"
+    xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
     Title="TextViewer"
     Width="800"
     Height="450"
-    Icon="../Resources/Icons/wabbajack.ico"
+    WindowTitleBrush="{StaticResource MahApps.Brushes.Accent}"
     Style="{StaticResource {x:Type Window}}"
     mc:Ignorable="d">
     <Grid>
@@ -17,4 +18,4 @@
             FontSize="20"
             TextWrapping="Wrap" />
     </Grid>
-</Window>
+</mah:MetroWindow>

--- a/Wabbajack/Views/TextViewer.xaml.cs
+++ b/Wabbajack/Views/TextViewer.xaml.cs
@@ -1,8 +1,6 @@
-﻿using System.Windows;
-
-namespace Wabbajack
+﻿namespace Wabbajack
 {
-    public partial class TextViewer : Window
+    public partial class TextViewer
     {
         public TextViewer(string text, string title)
         {


### PR DESCRIPTION
Fixes #645

#645 is very funny. The modlist had a text file as a readme set which would open at the end of installation. I actually want to remove the `TextViewer` and think it's better if only online documentation is allowed.