### PR TITLE
Fix no match for zMerge seq files

### DIFF
--- a/Wabbajack.Lib/zEditIntegration.cs
+++ b/Wabbajack.Lib/zEditIntegration.cs
@@ -73,15 +73,15 @@ namespace Wabbajack.Lib
                             return false;
                         }
 
-                        if (settings.modsPath != Path.Combine(_mo2Compiler.MO2Folder, "mods"))
+                        if (settings.modsPath != Path.Combine(_mo2Compiler.MO2Folder, Consts.MO2ModFolderName))
                         {
-                            Utils.Log($"zEdit settings file {f}: modsPath is not {_mo2Compiler.MO2Folder}\\mods but {settings.modsPath}!");
+                            Utils.Log($"zEdit settings file {f}: modsPath is not {_mo2Compiler.MO2Folder}\\{Consts.MO2ModFolderName} but {settings.modsPath}!");
                             return false;
                         }
 
-                        if (settings.mergePath != Path.Combine(_mo2Compiler.MO2Folder, "mods"))
+                        if (settings.mergePath != Path.Combine(_mo2Compiler.MO2Folder, Consts.MO2ModFolderName))
                         {
-                            Utils.Log($"zEdit settings file {f}: modsPath is not {_mo2Compiler.MO2Folder}\\mods but {settings.modsPath}!");
+                            Utils.Log($"zEdit settings file {f}: modsPath is not {_mo2Compiler.MO2Folder}\\{Consts.MO2ModFolderName} but {settings.modsPath}!");
                             return false;
                         }
 

--- a/Wabbajack.Test/ZEditIntegrationTests.cs
+++ b/Wabbajack.Test/ZEditIntegrationTests.cs
@@ -27,6 +27,18 @@ namespace Wabbajack.Test
 
 
             Directory.CreateDirectory(Path.Combine(utils.MO2Folder, "tools", "mator", "bleh", "profiles", "myprofile"));
+
+            var settings = new zEditIntegration.zEditSettings()
+            {
+                modManager = "Mod Organizer 2",
+                managerPath = utils.MO2Folder,
+                modsPath = Path.Combine(utils.MO2Folder, Consts.MO2ModFolderName),
+                mergePath = Path.Combine(utils.MO2Folder, Consts.MO2ModFolderName)
+            };
+
+            settings.ToJSON(Path.Combine(utils.MO2Folder, "tools", "mator", "bleh", "profiles", "myprofile",
+                "settings.json"));
+
             new List<zEditIntegration.zEditMerge>()
             {
                 new zEditIntegration.zEditMerge()


### PR DESCRIPTION
Problem was that those `.seq` files are being created by zMerge but we did not know from where they came since they have a new file name. What I ended up doing is checking if the seq file is in the merge folder and then inlining it.

Fixes #544 