### PR TITLE
Attachments for IPS4 sites

### DIFF
--- a/Wabbajack.Lib/ACompiler.cs
+++ b/Wabbajack.Lib/ACompiler.cs
@@ -91,6 +91,9 @@ namespace Wabbajack.Lib
             {
                 if (a.State is IMetaState metaState)
                 {
+                    if (string.IsNullOrWhiteSpace(metaState.URL))
+                        return;
+
                     var b = await metaState.LoadMetaData();
                     Utils.Log(b
                         ? $"Getting meta data for {a.Name} was successful!"

--- a/Wabbajack.Lib/Downloaders/AbstractIPS4Downloader.cs
+++ b/Wabbajack.Lib/Downloaders/AbstractIPS4Downloader.cs
@@ -193,7 +193,7 @@ namespace Wabbajack.Lib.Downloaders
 
             public override string GetManifestURL(Archive a)
             {
-                return IsAttachment ? "" : $"{Site}/files/file/{FileName}/?do=download&r={FileID}";
+                return IsAttachment ? FullURL : $"{Site}/files/file/{FileName}/?do=download&r={FileID}";
             }
 
             public override string[] GetMetaIni()

--- a/Wabbajack/View Models/SlideShow.cs
+++ b/Wabbajack/View Models/SlideShow.cs
@@ -89,6 +89,7 @@ namespace Wabbajack
                     return modList.SourceModList.Archives
                         .Select(m => m.State)
                         .OfType<IMetaState>()
+                        .Where(x => !string.IsNullOrEmpty(x.URL) && !string.IsNullOrEmpty(x.ImageURL))
                         .DistinctBy(x => x.URL)
                         // Shuffle it
                         .Shuffle(_random)


### PR DESCRIPTION
Attachments for IPS4 sites do not start with `/files/file/...` but `/applications/core/interface/file/attachment` (see #519 ).

Fixes #519 