### PR TITLE
Missing IDownloader.Prepare awaits

### DIFF
--- a/Wabbajack.BuildServer/Models/Jobs/UpdateModLists.cs
+++ b/Wabbajack.BuildServer/Models/Jobs/UpdateModLists.cs
@@ -44,7 +44,7 @@ namespace Wabbajack.BuildServer.Models.Jobs
             return JobResult.Success();
         }
         
-         private async Task ValidateList(SqlService sql, ModlistMetadata list, WorkQueue queue, ValidateModlist whitelists)
+        private async Task ValidateList(SqlService sql, ModlistMetadata list, WorkQueue queue, ValidateModlist whitelists)
         {
             var modlistPath = Consts.ModListDownloadFolder.Combine(list.Links.MachineURL + Consts.ModListExtension);
 
@@ -68,7 +68,7 @@ namespace Wabbajack.BuildServer.Models.Jobs
 
             Utils.Log($"{installer.Archives.Count} archives to validate");
 
-            DownloadDispatcher.PrepareAll(installer.Archives.Select(a => a.State));
+            await DownloadDispatcher.PrepareAll(installer.Archives.Select(a => a.State));
 
 
             var validated = (await installer.Archives

--- a/Wabbajack.CLI/Verbs/DownloadUrl.cs
+++ b/Wabbajack.CLI/Verbs/DownloadUrl.cs
@@ -24,7 +24,7 @@ namespace Wabbajack.CLI.Verbs
             if (state == null)
                 return CLIUtils.Exit($"Could not find download source for URL {Url}", ExitCode.Error);
 
-            DownloadDispatcher.PrepareAll(new []{state});
+            await DownloadDispatcher.PrepareAll(new []{state});
 
             using var queue = new WorkQueue();
             queue.Status

--- a/Wabbajack.Lib/Downloaders/DownloadDispatcher.cs
+++ b/Wabbajack.Lib/Downloaders/DownloadDispatcher.cs
@@ -58,7 +58,6 @@ namespace Wabbajack.Lib.Downloaders
         public static T GetInstance<T>() where T : IDownloader
         {
             var inst = (T)IndexedDownloaders[typeof(T)];
-            inst.Prepare().FireAndForget();
             return inst;
         }
 

--- a/Wabbajack.Test/DownloaderTests.cs
+++ b/Wabbajack.Test/DownloaderTests.cs
@@ -44,9 +44,9 @@ namespace Wabbajack.Test
         }
 
         [Fact]
-        public void TestAllPrepares()
+        public async Task TestAllPrepares()
         {
-            DownloadDispatcher.Downloaders.Do(d => d.Prepare());
+            await Task.WhenAll(DownloadDispatcher.Downloaders.Select(d => d.Prepare()));
         }
 
         [Fact]


### PR DESCRIPTION
Noticed IDownloader.Prepare wasn't being awaited everywhere it was called.  Added most of them.

The only oddball worth talking about is DownloadDispatcher.GetInstance's call of Prepare.   GetInstance is not async, and I'm not sure we want to make it async, as that would affect a large swath of its users?  It also seems/feels like most callers of GetInstance are also calling the downloader's prepare function themselves, and then awaiting that.

So GetInstance's call of Prepare almost feels like it's a good candidate for `FireAndForget`?

Still, it doesn't quite feel right to me because:
1)  If the user of GetInstance doesn't call prepare themselves, then there's potential that the prepare that was called (by GetInstance itself) isn't finished yet by the time they start using it.  This could lead to odd threading errors.
2)  If the user of GetInstance DOES call prepare themselves, then at least **one** prepare was awaited and completed, yes.  But it's also uncertain what the side effects of two prepares on the same object being called are, one of which wasn't awaited and (in theory) could still be trying to run in the background and messing things up.  The burden is then on the downloader to be able to handle multiple concurrent calls to its Prepare.  Maybe they already are good for this?

My suggestion is either:
1)  Make GetInstance async, so that its Prepare can be properly awaited.  (lots of code would then have to be modified to await it)
2)  Don't prepare within GetInstance at all.  Put that burden on the user every time.

Not sure exactly what the right call is.