### PR TITLE
Multiple Bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Modlists now require a machine-readable version field 
 * Added support for games installed via the Bethesda Launcher
 * Cache disk benchmarking results to save startup time of compilation/install
+* Added VectorPlexus mods to the slideshow
 
 #### Version - 1.1.5.0 - 4/6/2020
 * Included LOOT configs are no longer Base64 encoded

--- a/Wabbajack.Common/Consts.cs
+++ b/Wabbajack.Common/Consts.cs
@@ -139,5 +139,7 @@ namespace Wabbajack.Common
         public static RelativePath ModOrganizer2Exe = (RelativePath)"ModOrganizer.exe";
         public static RelativePath ModOrganizer2Ini = (RelativePath)"ModOrganizer.ini";
         public static string AuthorAPIKeyFile = "author-api-key.txt";
+
+        public static Uri WabbajackOrg = new Uri("https://www.wabbajack.org/");
     }
 }

--- a/Wabbajack.Common/Paths.cs
+++ b/Wabbajack.Common/Paths.cs
@@ -119,7 +119,7 @@ namespace Wabbajack.Common
             }
         }
 
-        public long Size => new FileInfo(_path).Length;
+        public long Size => Exists ? new FileInfo(_path).Length : 0;
 
         public DateTime LastModified
         {

--- a/Wabbajack.Lib/ACompiler.cs
+++ b/Wabbajack.Lib/ACompiler.cs
@@ -106,7 +106,7 @@ namespace Wabbajack.Lib
             {
                 if (a.State is IMetaState metaState)
                 {
-                    if (metaState.URL == null)
+                    if (metaState.URL == null || metaState.URL == Consts.WabbajackOrg)
                         return;
 
                     var b = await metaState.LoadMetaData();
@@ -230,6 +230,8 @@ namespace Wabbajack.Lib
             result.Hash = archive.File.Hash;
             result.Meta = archive.Meta;
             result.Size = archive.File.Size;
+
+            await result.State!.GetDownloader().Prepare();
 
             if (result.State != null && !await result.State.Verify(result))
                 Error(

--- a/Wabbajack.Lib/Downloaders/AbstractIPS4Downloader.cs
+++ b/Wabbajack.Lib/Downloaders/AbstractIPS4Downloader.cs
@@ -82,7 +82,7 @@ namespace Wabbajack.Lib.Downloaders
             public string FileName { get; set; } = string.Empty;
             
             // from IMetaState
-            public Uri URL => new Uri($"{Site}/files/file/{FileName}");
+            public Uri URL => IsAttachment ? new Uri("https://www.wabbajack.org/") : new Uri($"{Site}/files/file/{FileName}");
             public string? Name { get; set; }
             public string? Author { get; set; }
             public string? Version { get; set; }

--- a/Wabbajack.Lib/Downloaders/LoversLabDownloader.cs
+++ b/Wabbajack.Lib/Downloaders/LoversLabDownloader.cs
@@ -78,6 +78,7 @@ namespace Wabbajack.Lib.Downloaders
                     .SelectNodes(
                         "//article[@class='ipsColumn ipsColumn_fluid']/div[@class='ipsPad']/section/div[@class='ipsType_richText ipsContained ipsType_break']/p/a/img[@class='ipsImage ipsImage_thumbnailed']")
                     ?.First().GetAttributeValue("src", ""));
+
                 if (!string.IsNullOrWhiteSpace(url))
                 {
                     ImageURL = new Uri(url);

--- a/Wabbajack.Lib/Downloaders/VectorPlexusDownloader.cs
+++ b/Wabbajack.Lib/Downloaders/VectorPlexusDownloader.cs
@@ -1,4 +1,8 @@
 ﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Web;
+using HtmlAgilityPack;
 using Wabbajack.Common.Serialization.Json;
 
 namespace Wabbajack.Lib.Downloaders
@@ -16,9 +20,53 @@ namespace Wabbajack.Lib.Downloaders
         {
         }
         
-        [JsonName("VectorPlexisDownloader")]
+        [JsonName("VectorPlexusDownloader")]
         public class State : State<VectorPlexusDownloader>
         {
+            public override async Task<bool> LoadMetaData()
+            {
+                var html = await Downloader.AuthedClient.GetStringAsync(URL);
+                var doc = new HtmlDocument();
+                doc.LoadHtml(html);
+                var node = doc.DocumentNode;
+
+                Name = HttpUtility.HtmlDecode(node
+                    .SelectNodes(
+                        "//h1[@class='ipsType_pageTitle ipsContained_container']/span[@class='ipsType_break ipsContained']")
+                    ?.First().InnerHtml);
+
+                Author = HttpUtility.HtmlDecode(node
+                    .SelectNodes(
+                        "//div[@class='ipsBox_alt']/div[@class='ipsPhotoPanel ipsPhotoPanel_tiny ipsClearfix ipsSpacer_bottom']/div/p[@class='ipsType_reset ipsType_large ipsType_blendLinks']/a")
+                    ?.First().InnerHtml);
+
+                Version = HttpUtility.HtmlDecode(node
+                    .SelectNodes("//section/h2[@class='ipsType_sectionHead']/span[@data-role='versionTitle']")
+                    ?
+                    .First().InnerHtml);
+
+                var url = HttpUtility.HtmlDecode(node
+                    .SelectNodes(
+                        "//div[@class='ipsBox ipsSpacer_top ipsSpacer_double']/section/div[@class='ipsPad ipsAreaBackground']/div[@class='ipsCarousel ipsClearfix']/div[@class='ipsCarousel_inner']/ul[@class='cDownloadsCarousel ipsClearfix']/li[@class='ipsCarousel_item ipsAreaBackground_reset ipsPad_half']/span[@class='ipsThumb ipsThumb_medium ipsThumb_bg ipsCursor_pointer']")
+                    ?.First().GetAttributeValue("data-fullurl", "none"));
+
+                if (!string.IsNullOrWhiteSpace(url))
+                {
+                    ImageURL = new Uri(url);
+                    return true;
+                }
+
+                url = HttpUtility.HtmlDecode(node
+                    .SelectNodes(
+                        "//article[@class='ipsColumn ipsColumn_fluid']/div[@class='ipsPad']/section/div[@class='ipsType_richText ipsContained ipsType_break']/p/a/img[@class='ipsImage ipsImage_thumbnailed']")
+                    ?.First().GetAttributeValue("src", ""));
+                if (!string.IsNullOrWhiteSpace(url))
+                {
+                    ImageURL = new Uri(url);
+                }
+
+                return true;
+            }
         }
     }
 }


### PR DESCRIPTION
- Added VectorPlexus mods to the slideshow
- Fixed AuthedClient not being prepared when using it (NullException)
- Attachment fix for the URL property

Turns out that VectorPlexus and LoversLab have the exact same site as the same XPaths work on both sites. Maybe wanna investigate this further and abstract that.