### PR TITLE
Fixed detected zEdit path

### DIFF
--- a/Wabbajack.Lib/zEditIntegration.cs
+++ b/Wabbajack.Lib/zEditIntegration.cs
@@ -28,6 +28,9 @@ namespace Wabbajack.Lib
                 var zEditPath = FindzEditPath(compiler);
                 var havezEdit = zEditPath != default;
 
+                if (zEditPath.IsFile)
+                    zEditPath = zEditPath.Parent;
+
                 Utils.Log(havezEdit ? $"Found zEdit at {zEditPath}" : "zEdit not detected, disabling zEdit routines");
 
                 if (!havezEdit)


### PR DESCRIPTION
`zEditPath` ended with `/zEdit.exe` in my case which leads to some funny paths when using `zEditPath.Combine`.