### PR TITLE
NSFW option for Modlists

### DIFF
--- a/Wabbajack.Lib/ACompiler.cs
+++ b/Wabbajack.Lib/ACompiler.cs
@@ -18,6 +18,7 @@ namespace Wabbajack.Lib
         public string? ModListName, ModListAuthor, ModListDescription, ModListWebsite, ModlistReadme;
         public Version? ModlistVersion;
         public AbsolutePath ModListImage;
+        public bool ModlistIsNSFW;
         protected Version? WabbajackVersion;
 
         public abstract AbsolutePath VFSCacheName { get; }

--- a/Wabbajack.Lib/Data.cs
+++ b/Wabbajack.Lib/Data.cs
@@ -109,6 +109,11 @@ namespace Wabbajack.Lib
         public Version Version = new Version(1, 0, 0, 0);
 
         /// <summary>
+        ///     Whether the Modlist is NSFW or not
+        /// </summary>
+        public bool IsNSFW;
+
+        /// <summary>
         ///     The size of all the archives once they're downloaded
         /// </summary>
         [JsonIgnore]

--- a/Wabbajack.Lib/MO2Compiler.cs
+++ b/Wabbajack.Lib/MO2Compiler.cs
@@ -303,7 +303,8 @@ namespace Wabbajack.Lib
                 Description = ModListDescription ?? "",
                 Readme = ModlistReadme ?? "",
                 Image = ModListImage != default ? ModListImage.FileName : default,
-                Website = ModListWebsite != null ? new Uri(ModListWebsite) : null
+                Website = !string.IsNullOrWhiteSpace(ModListWebsite) ? new Uri(ModListWebsite) : null,
+                IsNSFW = ModlistIsNSFW
             };
 
             UpdateTracker.NextStep("Running Validation");

--- a/Wabbajack.Lib/ModListRegistry/ModListMetadata.cs
+++ b/Wabbajack.Lib/ModListRegistry/ModListMetadata.cs
@@ -29,6 +29,9 @@ namespace Wabbajack.Lib.ModListRegistry
         [JsonProperty("official")]
         public bool Official { get; set; }
 
+        [JsonProperty("nsfw")]
+        public bool NSFW { get; set; }
+
         [JsonProperty("links")]
         public LinksObject Links { get; set; } = new LinksObject();
 

--- a/Wabbajack/Settings.cs
+++ b/Wabbajack/Settings.cs
@@ -130,6 +130,7 @@ namespace Wabbajack
         public string Description { get; set; }
         public string Website { get; set; }
         public string Readme { get; set; }
+        public bool IsNSFW { get; set; }
         public AbsolutePath SplashScreen { get; set; }
     }
 

--- a/Wabbajack/View Models/Compilers/ModlistSettingsEditorVM.cs
+++ b/Wabbajack/View Models/Compilers/ModlistSettingsEditorVM.cs
@@ -20,7 +20,7 @@ namespace Wabbajack
         [Reactive]
         public string VersionText { get; set; }
 
-        private ObservableAsPropertyHelper<Version> _version;
+        private readonly ObservableAsPropertyHelper<Version> _version;
         public Version Version => _version.Value;
 
         [Reactive]
@@ -36,6 +36,9 @@ namespace Wabbajack
 
         [Reactive]
         public string Website { get; set; }
+
+        [Reactive]
+        public bool IsNSFW { get; set; }
 
         public IObservable<bool> InError { get; }
 
@@ -81,6 +84,7 @@ namespace Wabbajack
             ImagePath.TargetPath = _settings.SplashScreen;
             Website = _settings.Website;
             VersionText = _settings.Version;
+            IsNSFW = _settings.IsNSFW;
         }
 
         public void Save()
@@ -92,6 +96,7 @@ namespace Wabbajack
             _settings.Readme = Readme;
             _settings.SplashScreen = ImagePath.TargetPath;
             _settings.Website = Website;
+            _settings.IsNSFW = IsNSFW;
         }
     }
 }

--- a/Wabbajack/View Models/ModListVM.cs
+++ b/Wabbajack/View Models/ModListVM.cs
@@ -22,6 +22,7 @@ namespace Wabbajack
         public Uri Website => SourceModList?.Website;
         public ModManager ModManager => SourceModList?.ModManager ?? ModManager.MO2;
         public Version Version => SourceModList?.Version;
+        public bool IsNSFW => SourceModList?.IsNSFW ?? false;
 
         // Image isn't exposed as a direct property, but as an observable.
         // This acts as a caching mechanism, as interested parties will trigger it to be created,

--- a/Wabbajack/Views/Compilers/CompilerView.xaml
+++ b/Wabbajack/Views/Compilers/CompilerView.xaml
@@ -147,6 +147,11 @@
                     Text="Readme"
                     ToolTip="Link to the Readme." />
                 <TextBox x:Name="ReadmeSetting" Style="{StaticResource ValueStyle}"/>
+                <StackPanel Orientation="Horizontal" Margin="0 6 0 0">
+                    <TextBlock>NSFW:</TextBlock>
+                    <CheckBox x:Name="NSFWSetting" Margin="8 1 0 0" 
+                              ToolTip="Select this if your Modlist has adult themed content such as SexLab or other mods involving sexual acts. Nude body replacer do not fall under this category neither do slutty outfits or gore."/>
+                </StackPanel>
             </StackPanel>
         </ScrollViewer>
         <Border

--- a/Wabbajack/Views/Compilers/CompilerView.xaml
+++ b/Wabbajack/Views/Compilers/CompilerView.xaml
@@ -147,11 +147,9 @@
                     Text="Readme"
                     ToolTip="Link to the Readme." />
                 <TextBox x:Name="ReadmeSetting" Style="{StaticResource ValueStyle}"/>
-                <StackPanel Orientation="Horizontal" Margin="0 6 0 0">
-                    <TextBlock>NSFW:</TextBlock>
-                    <CheckBox x:Name="NSFWSetting" Margin="8 1 0 0" 
-                              ToolTip="Select this if your Modlist has adult themed content such as SexLab or other mods involving sexual acts. Nude body replacer do not fall under this category neither do slutty outfits or gore."/>
-                </StackPanel>
+                <CheckBox x:Name="NSFWSetting"
+                          Content="NSFW"
+                          ToolTip="Select this if your Modlist has adult themed content such as SexLab or other mods involving sexual acts. Nude body replacer do not fall under this category neither do revealing outfits or gore."/>
             </StackPanel>
         </ScrollViewer>
         <Border

--- a/Wabbajack/Views/Compilers/CompilerView.xaml.cs
+++ b/Wabbajack/Views/Compilers/CompilerView.xaml.cs
@@ -61,20 +61,22 @@ namespace Wabbajack
                     .Select(x => !x)
                     .BindToStrict(this, x => x.SettingsScrollViewer.IsEnabled)
                     .DisposeWith(dispose);
-                this.BindStrict(this.ViewModel, x => x.CurrentModlistSettings.ModListName, x => x.ModListNameSetting.Text)
+                this.BindStrict(ViewModel, x => x.CurrentModlistSettings.ModListName, x => x.ModListNameSetting.Text)
                     .DisposeWith(dispose);
                 this.BindStrict(ViewModel, x => x.CurrentModlistSettings.VersionText, x => x.VersionSetting.Text)
                     .DisposeWith(dispose);
-                this.BindStrict(this.ViewModel, x => x.CurrentModlistSettings.AuthorText, x => x.AuthorNameSetting.Text)
+                this.BindStrict(ViewModel, x => x.CurrentModlistSettings.AuthorText, x => x.AuthorNameSetting.Text)
                     .DisposeWith(dispose);
-                this.BindStrict(this.ViewModel, x => x.CurrentModlistSettings.Description, x => x.DescriptionSetting.Text)
+                this.BindStrict(ViewModel, x => x.CurrentModlistSettings.Description, x => x.DescriptionSetting.Text)
                     .DisposeWith(dispose);
                 this.WhenAny(x => x.ViewModel.CurrentModlistSettings.ImagePath)
                     .BindToStrict(this, x => x.ImageFilePicker.PickerVM)
                     .DisposeWith(dispose);
-                this.BindStrict(this.ViewModel, x => x.CurrentModlistSettings.Website, x => x.WebsiteSetting.Text)
+                this.BindStrict(ViewModel, x => x.CurrentModlistSettings.Website, x => x.WebsiteSetting.Text)
                     .DisposeWith(dispose);
-                this.BindStrict(this.ViewModel, x => x.CurrentModlistSettings.Readme, x => x.ReadmeSetting.Text)
+                this.BindStrict(ViewModel, x => x.CurrentModlistSettings.Readme, x => x.ReadmeSetting.Text)
+                    .DisposeWith(dispose);
+                this.BindStrict(ViewModel, x => x.CurrentModlistSettings.IsNSFW, x => x.NSFWSetting.IsChecked)
                     .DisposeWith(dispose);
 
                 // Bottom Compiler Settings

--- a/Wabbajack/Views/ModListGalleryView.xaml
+++ b/Wabbajack/Views/ModListGalleryView.xaml
@@ -107,6 +107,12 @@
                 Width="160"
                 VerticalContentAlignment="Center" />
             <CheckBox
+                x:Name="ShowNSFW"
+                Margin="20,0,10,0"
+                VerticalAlignment="Center"
+                Content="Show NSFW"
+                Foreground="{StaticResource ForegroundBrush}"/>
+            <CheckBox
                 x:Name="OnlyInstalledCheckbox"
                 Margin="20,0,10,0"
                 VerticalAlignment="Center"

--- a/Wabbajack/Views/ModListGalleryView.xaml.cs
+++ b/Wabbajack/Views/ModListGalleryView.xaml.cs
@@ -56,10 +56,12 @@ namespace Wabbajack
                     .BindToStrict(this, x => x.ErrorIcon.Visibility)
                     .DisposeWith(dispose);
 
-                this.BindStrict(this.ViewModel, vm => vm.Search, x => x.SearchBox.Text)
+                this.BindStrict(ViewModel, vm => vm.Search, x => x.SearchBox.Text)
                     .DisposeWith(dispose);
 
-                this.BindStrict(this.ViewModel, vm => vm.OnlyInstalled, x => x.OnlyInstalledCheckbox.IsChecked)
+                this.BindStrict(ViewModel, vm => vm.OnlyInstalled, x => x.OnlyInstalledCheckbox.IsChecked)
+                    .DisposeWith(dispose);
+                this.BindStrict(ViewModel, vm => vm.ShowNSFW, x => x.ShowNSFW.IsChecked)
                     .DisposeWith(dispose);
 
                 this.WhenAny(x => x.ViewModel.ClearFiltersCommand)


### PR DESCRIPTION
This PR adds a checkbox when compiling to specify the modlist as "NSFW". NSFW is defined as follows:

> Select this if your Modlist has adult themed content such as SexLab or other mods involving sexual acts. Nude body replacer do not fall under this category neither do revealing outfits or gore.

The gallery also got a filter option "Show NSFW", this requires the `modlists.json` file to be updated with the new field. This is backwards compatible since it's just a bool and will default to `false` if not set.