### PR TITLE
Fixed path with whitespace in archive not being extracted

### DIFF
--- a/Wabbajack.VirtualFileSystem/FileExtractor.cs
+++ b/Wabbajack.VirtualFileSystem/FileExtractor.cs
@@ -142,8 +142,8 @@ namespace Wabbajack.VirtualFileSystem
                 //It's stupid that we have to do this, but 7zip's file pattern matching isn't very fuzzy
                 IEnumerable<string> AllVariants(string input)
                 {
-                    yield return input;
-                    yield return "\\" + input;
+                    yield return $"\"{input}\"";
+                    yield return $"\"\\{input}\"";
                 }
                 
                 tmpFile = new TempFile();


### PR DESCRIPTION
The Rustic Dragon Corpse 4k Edition has this path:
` Skyrim SSE 4K\Data\textures\actors\dragon\dragonskeleton.dds`. The whitespace at the start lead to 7z not extracting the archive so using `"` that problem is fixed and the path is now:
`" Skyrim SSE 4K\Data\textures\actors\dragon\dragonskeleton.dds"`