### PR TITLE
Adjusted TempFolder init concepts

### DIFF
--- a/Wabbajack.App.Test/FilePickerTests.cs
+++ b/Wabbajack.App.Test/FilePickerTests.cs
@@ -191,7 +191,7 @@ namespace Wabbajack.Test
         public async Task FolderIfNotEmptyCheck_Exists()
         {
             var vm = new FilePickerVM();
-            await using (CreateSetFolder(vm))
+            await using (await CreateSetFolder(vm))
             {
                 vm.PathType = FilePickerVM.PathTypeOptions.Folder;
                 vm.ExistCheckOption = FilePickerVM.CheckOptions.IfPathNotEmpty;
@@ -220,7 +220,7 @@ namespace Wabbajack.Test
         public async Task FolderOnExistsCheck_Exists()
         {
             var vm = new FilePickerVM();
-            await using (CreateSetFolder(vm))
+            await using (await CreateSetFolder(vm))
             {
                 vm.PathType = FilePickerVM.PathTypeOptions.Folder;
                 vm.ExistCheckOption = FilePickerVM.CheckOptions.On;
@@ -275,7 +275,7 @@ namespace Wabbajack.Test
         public async Task FolderExistsButSetToFile()
         {
             var vm = new FilePickerVM();
-            await using (CreateSetFolder(vm))
+            await using (await CreateSetFolder(vm))
             {
                 vm.PathType = FilePickerVM.PathTypeOptions.File;
                 vm.ExistCheckOption = FilePickerVM.CheckOptions.On;
@@ -353,9 +353,9 @@ namespace Wabbajack.Test
             Assert.True(string.IsNullOrEmpty(vm.ErrorTooltip));
         }
 
-        private static TempFolder CreateSetFolder(FilePickerVM vm)
+        private static async Task<TempFolder> CreateSetFolder(FilePickerVM vm)
         {
-            var temp = new TempFolder();
+            var temp = await TempFolder.Create();
             vm.TargetPath = temp.Dir;
             return temp;
         }

--- a/Wabbajack.BuildServer.Test/ABuildServerSystemTest.cs
+++ b/Wabbajack.BuildServer.Test/ABuildServerSystemTest.cs
@@ -21,7 +21,7 @@ namespace Wabbajack.BuildServer.Test
         private CancellationTokenSource _token;
         private Task _task;
 
-        public readonly TempFolder _severTempFolder = new TempFolder();
+        public readonly TempFolder _severTempFolder = TempFolder.Create().Result;
         private bool _disposed = false;
         public AbsolutePath ServerTempFolder => _severTempFolder.Dir;
 

--- a/Wabbajack.Common/Util/TempFolder.cs
+++ b/Wabbajack.Common/Util/TempFolder.cs
@@ -15,22 +15,26 @@ namespace Wabbajack.Common
 
         static TempFolder()
         {
-            _cleanTask = "tmp_files".RelativeTo(AbsolutePath.EntryPoint).DeleteDirectory();
+            _cleanTask = Task.Run(() => "tmp_files".RelativeTo(AbsolutePath.EntryPoint).DeleteDirectory());
         }
 
-        public static async Task EnsureInited()
+        public static void Init()
         {
-            Utils.Log("Cleaning temp files");
-            await _cleanTask;
+            // Nothing to do, as work is done in static ctor
         }
 
-        public TempFolder(bool deleteAfter = true)
+        private TempFolder(bool deleteAfter = true)
         {
-            _cleanTask.Wait();
             Dir = Path.Combine("tmp_files", Guid.NewGuid().ToString()).RelativeTo(AbsolutePath.EntryPoint);
             if (!Dir.Exists) 
                 Dir.CreateDirectory();
             DeleteAfter = deleteAfter;
+        }
+
+        public static async Task<TempFolder> Create(bool deleteAfter = true)
+        {
+            await _cleanTask;
+            return new TempFolder(deleteAfter: deleteAfter);
         }
 
         public TempFolder(AbsolutePath dir, bool deleteAfter = true)
@@ -42,6 +46,7 @@ namespace Wabbajack.Common
             }
             DeleteAfter = deleteAfter;
         }
+
         public async ValueTask DisposeAsync()
         {
             Utils.Log($"Deleting {Dir}");

--- a/Wabbajack.Lib/Downloaders/YouTubeDownloader.cs
+++ b/Wabbajack.Lib/Downloaders/YouTubeDownloader.cs
@@ -102,7 +102,7 @@ namespace Wabbajack.Lib.Downloaders
                 try
                 {
                     using var queue = new WorkQueue();
-                    await using var folder = new TempFolder();
+                    await using var folder = await TempFolder.Create();
                     folder.Dir.Combine("tracks").CreateDirectory();
                     var client = new YoutubeClient(Common.Http.ClientFactory.Client);
                     var meta = await client.Videos.GetAsync(Key);

--- a/Wabbajack.Test/DownloaderTests.cs
+++ b/Wabbajack.Test/DownloaderTests.cs
@@ -531,7 +531,7 @@ namespace Wabbajack.Test
         [Fact]
         public async Task TestUpgrading()
         {
-            await using var folder = new TempFolder();
+            await using var folder = await TempFolder.Create();
             var dest = folder.Dir.Combine("Cori.7z");
             var archive = new Archive(
                 new NexusDownloader.State

--- a/Wabbajack.Test/MO2Tests.cs
+++ b/Wabbajack.Test/MO2Tests.cs
@@ -12,21 +12,21 @@ namespace Wabbajack.Test
         [Fact]
         public async Task CheckValidInstallPath_Empty()
         {
-            await using var tempDir = new TempFolder();
+            await using var tempDir = await TempFolder.Create();
             Assert.True(MO2Installer.CheckValidInstallPath(tempDir.Dir, downloadFolder: null).Succeeded);
         }
 
         [Fact]
         public async Task CheckValidInstallPath_DoesNotExist()
         {
-            await using var tempDir = new TempFolder();
+            await using var tempDir = await TempFolder.Create();
             Assert.True(MO2Installer.CheckValidInstallPath(tempDir.Dir.Combine("Subfolder"), downloadFolder: null).Succeeded);
         }
 
         [Fact]
         public async Task CheckValidInstallPath_HasModlist()
         {
-            await using var tempDir = new TempFolder();
+            await using var tempDir = await TempFolder.Create();
             await using var mo2 = tempDir.Dir.Combine("ModOrganizer.exe").Create();
             await using var molist = tempDir.Dir.Combine(((RelativePath)"modlist")).WithExtension(Consts.ModListExtension).Create();
             Assert.False(MO2Installer.CheckValidInstallPath(tempDir.Dir, downloadFolder: null).Succeeded);
@@ -35,7 +35,7 @@ namespace Wabbajack.Test
         [Fact]
         public async Task CheckValidInstallPath_ProperOverwrite()
         {
-            await using var tempDir = new TempFolder();
+            await using var tempDir = await TempFolder.Create();
             await using var tmp = tempDir.Dir.Combine(Consts.ModOrganizer2Exe).Create();
             Assert.True(MO2Installer.CheckValidInstallPath(tempDir.Dir, downloadFolder: null).Succeeded);
         }
@@ -43,7 +43,7 @@ namespace Wabbajack.Test
         [Fact]
         public async Task CheckValidInstallPath_ImproperOverwrite()
         {
-            await using var tempDir = new TempFolder();
+            await using var tempDir = await TempFolder.Create();
             await tempDir.Dir.DeleteDirectory();
             tempDir.Dir.CreateDirectory();
             await using var tmp = tempDir.Dir.Combine($"someFile.txt").Create();
@@ -53,7 +53,7 @@ namespace Wabbajack.Test
         [Fact]
         public async Task CheckValidInstallPath_OverwriteFilesInDownloads()
         {
-            await using var tempDir = new TempFolder();
+            await using var tempDir = await TempFolder.Create();
             var downloadsFolder = tempDir.Dir.Combine("downloads");
             downloadsFolder.CreateDirectory();
             await using var tmp = tempDir.Dir.Combine($"downloads/someFile.txt").Create();

--- a/Wabbajack.VirtualFileSystem/FileExtractor.cs
+++ b/Wabbajack.VirtualFileSystem/FileExtractor.cs
@@ -25,7 +25,7 @@ namespace Wabbajack.VirtualFileSystem
                 if (Consts.SupportedBSAs.Contains(source.Extension))
                     return await ExtractAllWithBSA(queue, source);
                 else if (source.Extension == Consts.OMOD)
-                    return ExtractAllWithOMOD(source);
+                    return await ExtractAllWithOMOD(source);
                 else if (source.Extension == Consts.EXE)
                     return await ExtractAllExe(source);
                 else
@@ -47,7 +47,7 @@ namespace Wabbajack.VirtualFileSystem
                 return await ExtractAllWith7Zip(source, null);
             }
 
-            var dest = new TempFolder();
+            var dest = await TempFolder.Create();
             Utils.Log($"Extracting {(string)source.FileName}");
 
             var process = new ProcessHelper
@@ -94,9 +94,9 @@ namespace Wabbajack.VirtualFileSystem
             }
         }
 
-        private static ExtractedFiles ExtractAllWithOMOD(AbsolutePath source)
+        private static async Task<ExtractedFiles> ExtractAllWithOMOD(AbsolutePath source)
         {
-            var dest = new TempFolder();
+            var dest = await TempFolder.Create();
             Utils.Log($"Extracting {(string)source.FileName}");
 
             Framework.Settings.TempPath = (string)dest.Dir;
@@ -128,7 +128,7 @@ namespace Wabbajack.VirtualFileSystem
         private static async Task<ExtractedFiles> ExtractAllWith7Zip(AbsolutePath source, IEnumerable<RelativePath> onlyFiles)
         {
             TempFile tmpFile = null;
-            var dest = new TempFolder();
+            var dest = await TempFolder.Create();
             Utils.Log(new GenericInfo($"Extracting {(string)source.FileName}", $"The contents of {(string)source.FileName} are being extracted to {(string)source.FileName} using 7zip.exe"));
 
             var process = new ProcessHelper

--- a/Wabbajack/App.xaml.cs
+++ b/Wabbajack/App.xaml.cs
@@ -20,7 +20,6 @@ namespace Wabbajack
     {
         public App()
         {
-            TempFolder.EnsureInited();
             CLIOld.ParseOptions(Environment.GetCommandLineArgs());
             if (CLIArguments.Help)
                 CLIOld.DisplayHelpText();

--- a/Wabbajack/Views/MainWindow.xaml.cs
+++ b/Wabbajack/Views/MainWindow.xaml.cs
@@ -23,6 +23,7 @@ namespace Wabbajack
 
         public MainWindow()
         {
+            TempFolder.Init();
             Helpers.Init();
             // Wire any unhandled crashing exceptions to log before exiting
             AppDomain.CurrentDomain.UnhandledException += (sender, e) =>


### PR DESCRIPTION
Went to do the Software render hotfix PR and noticed it was finished.  but, then happened to notice the init function wasn't being awaited in the App.cs ctor.

I think without an await or .Wait(), the ensure goal wasn't being enforced;  The program would continue on before it was finished, potentially.

Adjusted the API a bit so that TempFolder has a factory that can be awaited, that ensures it's initialized before returning.   A TempFolder.Init() call then is just a kickoff of that init process, but lets it continue in the background until a TempFolder.Create hooks it back in and checks that it's complete before using TempFolder