### PR TITLE
[Feature] added more information on modlist tiles

### DIFF
--- a/Wabbajack.Lib/ModListRegistry/ModListMetadata.cs
+++ b/Wabbajack.Lib/ModListRegistry/ModListMetadata.cs
@@ -29,6 +29,9 @@ namespace Wabbajack.Lib.ModListRegistry
         [JsonProperty("official")]
         public bool Official { get; set; }
 
+        [JsonProperty("tags")]
+        public List<string> tags { get; set; } = new List<string>();
+
         [JsonProperty("nsfw")]
         public bool NSFW { get; set; }
 

--- a/Wabbajack/Util/UIUtils.cs
+++ b/Wabbajack/Util/UIUtils.cs
@@ -120,5 +120,23 @@ namespace Wabbajack
                     }
                 });
         }
+
+        /// <summary>
+        /// Format bytes to a greater unit
+        /// </summary>
+        /// <param name="bytes">number of bytes</param>
+        /// <returns></returns>
+        public static string FormatBytes(long bytes)
+        {
+            string[] Suffix = { "B", "KB", "MB", "GB", "TB" };
+            int i;
+            double dblSByte = bytes;
+            for (i = 0; i < Suffix.Length && bytes >= 1024; i++, bytes /= 1024)
+            {
+                dblSByte = bytes / 1024.0;
+            }
+
+            return String.Format("{0:0.##} {1}", dblSByte, Suffix[i]);
+        }
     }
 }

--- a/Wabbajack/View Models/Gallery/ModListMetadataVM.cs
+++ b/Wabbajack/View Models/Gallery/ModListMetadataVM.cs
@@ -40,6 +40,12 @@ namespace Wabbajack
         public bool IsBroken { get; private set; }
 
         [Reactive]
+        public string DownloadSizeText { get; private set; }
+
+        [Reactive]
+        public string InstallSizeText { get; private set; }
+
+        [Reactive]
         public IErrorResponse Error { get; private set; }
 
         private readonly ObservableAsPropertyHelper<BitmapImage> _Image;
@@ -49,10 +55,12 @@ namespace Wabbajack
         public bool LoadingImage => _LoadingImage.Value;
 
         public ModListMetadataVM(ModListGalleryVM parent, ModlistMetadata metadata)
-        {
+        {            
             _parent = parent;
             Metadata = metadata;
             Location = Consts.ModListDownloadFolder.Combine(Metadata.Links.MachineURL + (string)Consts.ModListExtension);
+            DownloadSizeText = "Download size : " + UIUtils.FormatBytes(Metadata.DownloadMetadata.SizeOfArchives);
+            InstallSizeText = "Installation size : " + UIUtils.FormatBytes(Metadata.DownloadMetadata.SizeOfInstalledFiles);
             IsBroken = metadata.ValidationSummary.HasFailures;
             OpenWebsiteCommand = ReactiveCommand.Create(() => Utils.OpenWebsite(new Uri($"https://www.wabbajack.org/modlist/{Metadata.Links.MachineURL}")));
             ExecuteCommand = ReactiveCommand.CreateFromObservable<Unit, Unit>(

--- a/Wabbajack/View Models/Gallery/ModListMetadataVM.cs
+++ b/Wabbajack/View Models/Gallery/ModListMetadataVM.cs
@@ -20,6 +20,17 @@ using Wabbajack.Lib.ModListRegistry;
 
 namespace Wabbajack
 {
+
+    public struct ModListTag
+    {
+        public ModListTag(string name)
+        {
+            Name = name;
+        }
+
+        public string Name { get; }
+    }
+
     public class ModListMetadataVM : ViewModel
     {
         public ModlistMetadata Metadata { get; }
@@ -32,6 +43,9 @@ namespace Wabbajack
         public bool Exists => _Exists.Value;
 
         public AbsolutePath Location { get; }
+
+        [Reactive]
+        public List<ModListTag> ModListTagList { get; private set; }
 
         [Reactive]
         public Percent ProgressPercent { get; private set; }
@@ -59,6 +73,11 @@ namespace Wabbajack
             _parent = parent;
             Metadata = metadata;
             Location = Consts.ModListDownloadFolder.Combine(Metadata.Links.MachineURL + (string)Consts.ModListExtension);
+            ModListTagList = new List<ModListTag>();
+            Metadata.tags.ForEach(tag =>
+            {
+                ModListTagList.Add(new ModListTag(tag));
+            });
             DownloadSizeText = "Download size : " + UIUtils.FormatBytes(Metadata.DownloadMetadata.SizeOfArchives);
             InstallSizeText = "Installation size : " + UIUtils.FormatBytes(Metadata.DownloadMetadata.SizeOfInstalledFiles);
             IsBroken = metadata.ValidationSummary.HasFailures;

--- a/Wabbajack/Views/ModListTileView.xaml
+++ b/Wabbajack/Views/ModListTileView.xaml
@@ -146,7 +146,12 @@
                             </Style>
                         </Ellipse.Style>
                     </Ellipse>
-                    <Label Content="{Binding DownloadSizeText}" HorizontalAlignment="Left" Margin="10,289,0,0" VerticalAlignment="Top">
+                    <Label 
+                        Content="{Binding DownloadSizeText}" 
+                        HorizontalAlignment="Left" 
+                        Margin="10,289,0,0" 
+                        VerticalAlignment="Top"
+                        Opacity="0" >
                         <Label.Style>
                             <Style TargetType="Label">
                                 <Style.Triggers>
@@ -176,7 +181,12 @@
                             </Style>
                         </Label.Style>
                     </Label>
-                    <Label Content="{Binding InstallSizeText}" HorizontalAlignment="Left" Margin="10,305,0,0" VerticalAlignment="Top">
+                    <Label 
+                        Content="{Binding InstallSizeText}" 
+                        HorizontalAlignment="Left" 
+                        Margin="10,305,0,0" 
+                        VerticalAlignment="Top"
+                        Opacity="0" >
                         <Label.Style>
                             <Style TargetType="Label">
                                 <Style.Triggers>

--- a/Wabbajack/Views/ModListTileView.xaml
+++ b/Wabbajack/Views/ModListTileView.xaml
@@ -146,10 +146,34 @@
                             </Style>
                         </Ellipse.Style>
                     </Ellipse>
+                    <ItemsControl ItemsSource="{Binding ModListTagList}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <WrapPanel/>
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Border 
+                                    BorderThickness="1" 
+                                    Grid.Row="0" 
+                                    Grid.ColumnSpan="2"
+                                    CornerRadius="7,7,7,7"
+                                    Opacity="0.90"
+                                    Background="{StaticResource Analogous1Brush}"
+                                    Margin="10,5,0,5">
+                                    <TextBlock 
+                                        Margin="5,5,5,5"
+                                        FontSize="15"
+                                        Text="{Binding Name}"/>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
                     <Label 
                         Content="{Binding DownloadSizeText}" 
                         HorizontalAlignment="Left" 
-                        Margin="10,289,0,0" 
+                        Margin="10,257,0,0" 
                         VerticalAlignment="Top"
                         Opacity="0" >
                         <Label.Style>
@@ -184,7 +208,7 @@
                     <Label 
                         Content="{Binding InstallSizeText}" 
                         HorizontalAlignment="Left" 
-                        Margin="10,305,0,0" 
+                        Margin="10,272,0,0" 
                         VerticalAlignment="Top"
                         Opacity="0" >
                         <Label.Style>

--- a/Wabbajack/Views/ModListTileView.xaml
+++ b/Wabbajack/Views/ModListTileView.xaml
@@ -146,6 +146,66 @@
                             </Style>
                         </Ellipse.Style>
                     </Ellipse>
+                    <Label Content="{Binding DownloadSizeText}" HorizontalAlignment="Left" Margin="10,289,0,0" VerticalAlignment="Top">
+                        <Label.Style>
+                            <Style TargetType="Label">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding IsMouseOver, ElementName=ModListTile}" Value="True">
+                                        <DataTrigger.EnterActions>
+                                            <BeginStoryboard>
+                                                <Storyboard>
+                                                    <DoubleAnimation
+                                                        Storyboard.TargetProperty="Opacity"
+                                                        To="1"
+                                                        Duration="0:0:0.08" />
+                                                </Storyboard>
+                                            </BeginStoryboard>
+                                        </DataTrigger.EnterActions>
+                                        <DataTrigger.ExitActions>
+                                            <BeginStoryboard>
+                                                <Storyboard>
+                                                    <DoubleAnimation
+                                                        Storyboard.TargetProperty="Opacity"
+                                                        To="0"
+                                                        Duration="0:0:0.08" />
+                                                </Storyboard>
+                                            </BeginStoryboard>
+                                        </DataTrigger.ExitActions>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Label.Style>
+                    </Label>
+                    <Label Content="{Binding InstallSizeText}" HorizontalAlignment="Left" Margin="10,305,0,0" VerticalAlignment="Top">
+                        <Label.Style>
+                            <Style TargetType="Label">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding IsMouseOver, ElementName=ModListTile}" Value="True">
+                                        <DataTrigger.EnterActions>
+                                            <BeginStoryboard>
+                                                <Storyboard>
+                                                    <DoubleAnimation
+                                                        Storyboard.TargetProperty="Opacity"
+                                                        To="1"
+                                                        Duration="0:0:0.08" />
+                                                </Storyboard>
+                                            </BeginStoryboard>
+                                        </DataTrigger.EnterActions>
+                                        <DataTrigger.ExitActions>
+                                            <BeginStoryboard>
+                                                <Storyboard>
+                                                    <DoubleAnimation
+                                                        Storyboard.TargetProperty="Opacity"
+                                                        To="0"
+                                                        Duration="0:0:0.08" />
+                                                </Storyboard>
+                                            </BeginStoryboard>
+                                        </DataTrigger.ExitActions>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Label.Style>
+                    </Label>
                 </Grid>
             </Border>
             <local:UnderMaintenanceOverlay


### PR DESCRIPTION
### Description

this add more informations to the modlist tile : 
* Modlist tags
* Download Size on hover
* Installation Size on hover
### Specifications

the modlist listTags is is implemented straight from the metadata so any new tags get shown.
same thing with the Download Size and Installation Size.
### Preview

https://i.imgur.com/qs0e244.gifv

i am thinking maybe a filter by tags would be interesting ?