### PR TITLE
More hotfixes for Elder Souls / FO4 compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ### Changelog
+#### Version - 2.0.4.4 - 5/11/2020
+* BA2s store file names as UTF8 instead of UTF7
+* Check for a BSA file by header magic not by extension (allows .bsa.bak files to be extracted)
+* Exclude the game `Data` directory from compilation
 
 #### Version - 2.0.4.3 - 5/10/2020
 * Hotfix: tell the WJ CDN downloader to create the parent folder if it doesn't exist

--- a/Compression.BSA/BA2Builder.cs
+++ b/Compression.BSA/BA2Builder.cs
@@ -87,7 +87,7 @@ namespace Compression.BSA
 
             foreach (var entry in _entries)
             {
-                var bytes = Encoding.UTF7.GetBytes(entry.FullName);
+                var bytes = Encoding.UTF8.GetBytes(entry.FullName);
                 bw.Write((ushort)bytes.Length);
                 await bw.BaseStream.WriteAsync(bytes, 0, bytes.Length);
             }

--- a/Compression.BSA/BA2Reader.cs
+++ b/Compression.BSA/BA2Reader.cs
@@ -94,7 +94,7 @@ namespace Compression.BSA
             {
                 _rdr.BaseStream.Seek((long) _nameTableOffset, SeekOrigin.Begin);
                 foreach (var file in files)
-                    file.FullPath = Encoding.UTF7.GetString(_rdr.ReadBytes(_rdr.ReadInt16()));
+                    file.FullPath = Encoding.UTF8.GetString(_rdr.ReadBytes(_rdr.ReadInt16()));
             }
             Files = files;
 

--- a/Compression.BSA/BSADispatch.cs
+++ b/Compression.BSA/BSADispatch.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using Wabbajack.Common;
 
@@ -21,6 +22,14 @@ namespace Compression.BSA
             if (fourcc == "BTDX")
                 return new BA2Reader(filename);
             throw new InvalidDataException("Filename is not a .bsa or .ba2, magic " + fourcc);
+        }
+
+        private static HashSet<string> MagicStrings = new HashSet<string> {TES3Reader.TES3_MAGIC, "BSA\0", "BTDX"};
+        public static bool MightBeBSA(AbsolutePath filename)
+        {
+            using var file = filename.OpenRead();
+            var fourcc = Encoding.ASCII.GetString(new BinaryReader(file).ReadBytes(4));
+            return MagicStrings.Contains(fourcc);
         }
     }
 }

--- a/Wabbajack.Lib/MO2Compiler.cs
+++ b/Wabbajack.Lib/MO2Compiler.cs
@@ -550,6 +550,9 @@ namespace Wabbajack.Lib
                 // Ignore the ModOrganizer.ini file it contains info created by MO2 on startup
                 new IncludeStubbedConfigFiles(this),
                 new IncludeLootFiles(this),
+                new IgnoreStartsWith(this, Path.Combine((string)Consts.GameFolderFilesDir, "Data")),
+                new IgnoreStartsWith(this, Path.Combine((string)Consts.GameFolderFilesDir, "Papyrus Compiler")),
+                new IgnoreStartsWith(this, Path.Combine((string)Consts.GameFolderFilesDir, "Skyrim")),                
                 new IgnoreRegex(this, Consts.GameFolderFilesDir + "\\\\.*\\.bsa"),
                 new IncludeRegex(this, "^[^\\\\]*\\.bat$"),
                 new IncludeModIniData(this),

--- a/Wabbajack.VirtualFileSystem/FileExtractor.cs
+++ b/Wabbajack.VirtualFileSystem/FileExtractor.cs
@@ -22,7 +22,7 @@ namespace Wabbajack.VirtualFileSystem
         {
             try
             {
-                if (Consts.SupportedBSAs.Contains(source.Extension))
+                if (BSADispatch.MightBeBSA(source))
                     return await ExtractAllWithBSA(queue, source);
                 else if (source.Extension == Consts.OMOD)
                     return await ExtractAllWithOMOD(source);


### PR DESCRIPTION
* BA2s store file names as UTF8 instead of UTF7
* Check for a BSA file by header magic not by extension (allows .bsa.bak files to be extracted)
* Exclude the game `Data` directory from compilation
