### PR TITLE
Readded a nuked feature

### DIFF
--- a/Wabbajack.Lib/CompilationSteps/IncludeThisProfile.cs
+++ b/Wabbajack.Lib/CompilationSteps/IncludeThisProfile.cs
@@ -44,7 +44,7 @@ namespace Wabbajack.Lib.CompilationSteps
             var alwaysEnabled = _mo2Compiler.ModInis.Where(f => IgnoreDisabledMods.IsAlwaysEnabled(f.Value))
                 .Select(f => f.Key)
                 .Distinct();
-            var lines = File.ReadAllLines(absolutePath.ToString()).Where(l =>
+            var lines = (await absolutePath.ReadAllLinesAsync()).Where(l =>
             {
                 return l.StartsWith("+")
                        || alwaysEnabled.Any(x => x.Equals(l.Substring(1)))

--- a/Wabbajack.Lib/CompilationSteps/IncludeThisProfile.cs
+++ b/Wabbajack.Lib/CompilationSteps/IncludeThisProfile.cs
@@ -39,10 +39,17 @@ namespace Wabbajack.Lib.CompilationSteps
             return new State();
         }
 
-        private static async Task<byte[]> ReadAndCleanModlist(AbsolutePath absolutePath)
+        private async Task<byte[]> ReadAndCleanModlist(AbsolutePath absolutePath)
         {
-            var lines = await absolutePath.ReadAllLinesAsync();
-            lines = lines.Where(line => !(line.StartsWith("-") && !line.EndsWith("_separator"))).ToArray();
+            var alwaysEnabled = _mo2Compiler.ModInis.Where(f => IgnoreDisabledMods.IsAlwaysEnabled(f.Value))
+                .Select(f => f.Key)
+                .Distinct();
+            var lines = File.ReadAllLines(absolutePath.ToString()).Where(l =>
+            {
+                return l.StartsWith("+")
+                       || alwaysEnabled.Any(x => x.Equals(l.Substring(1)))
+                       || l.EndsWith("_separator");
+            }).ToArray();
             return Encoding.UTF8.GetBytes(string.Join("\r\n", lines));
         }
 


### PR DESCRIPTION
Was originally from this commit: 7fba212ba365bf2d8906df8be0178c3952199020

I think a merge (35f99b710030d05a413a57e2a740c2b9e865ed78) unintentionally removed a feature erri had added.

Worked with johanlh to find the missing snippet.

Had to do a bit of refactoring to accommodate the new AbsolutePath struct, so a glance over would be nice.