### PR TITLE
Re-added Darkest Dungeons

### DIFF
--- a/Wabbajack.Common/GameMetaData.cs
+++ b/Wabbajack.Common/GameMetaData.cs
@@ -27,7 +27,10 @@ namespace Wabbajack.Common
         [Description("Skyrim VR")]
         SkyrimVR,
         [Description("Fallout 4 VR")]
-        Fallout4VR
+        Fallout4VR,
+        //MO2 Non-BGS Games
+        [Description("Darkest Dungeon")]
+        DarkestDungeon
     }
 
     public static class GameExtensions
@@ -42,6 +45,8 @@ namespace Wabbajack.Common
     {
         public Game Game { get; internal set; }
         public ModManager SupportedModManager { get; internal set; }
+
+        public bool IsGenericMO2Plugin { get; internal set; }
 
         public string? MO2ArchiveName { get; internal set; }
         public string? NexusName { get; internal set; }
@@ -394,6 +399,22 @@ namespace Wabbajack.Common
                     },
                     MainExecutable = "Fallout4VR.exe",
                     CommonlyConfusedWith = new [] {Game.Fallout4}
+                }
+            },
+            {
+                Game.DarkestDungeon, new GameMetaData
+                {
+                    Game = Game.DarkestDungeon,
+                    NexusName = "darkestdungeon",
+                    MO2Name = "Darkest Dungeon",
+                    NexusGameId = 804,
+                    SteamIDs = new List<int> {262060},
+                    GOGIDs = new List<int>{1450711444},
+                    IsGenericMO2Plugin = true,
+                    RequiredFiles = new List<string>
+                    {
+                        "_windows\\Darkest.exe"
+                    }
                 }
             }
         };

--- a/Wabbajack.Common/GameMetaData.cs
+++ b/Wabbajack.Common/GameMetaData.cs
@@ -414,7 +414,8 @@ namespace Wabbajack.Common
                     RequiredFiles = new List<string>
                     {
                         "_windows\\Darkest.exe"
-                    }
+                    },
+                    MainExecutable = "_windows\\Darkest.exe"
                 }
             }
         };

--- a/Wabbajack.Lib/CompilationSteps/IncludeGenericGamePlugin.cs
+++ b/Wabbajack.Lib/CompilationSteps/IncludeGenericGamePlugin.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Wabbajack.Common;
+
+namespace Wabbajack.Lib.CompilationSteps
+{
+    public class IncludeGenericGamePlugin : ACompilationStep
+    {
+        private readonly bool _validGame;
+        private readonly string _pluginsFolder = string.Empty;
+        private readonly string _gameName = string.Empty;
+        
+        public IncludeGenericGamePlugin(ACompiler compiler) : base(compiler)
+        {
+            if (!(compiler is MO2Compiler mo2Compiler))
+                return;
+
+            if (mo2Compiler.CompilingGame.NexusName == null)
+                return;
+
+            _validGame = mo2Compiler.CompilingGame.IsGenericMO2Plugin;
+            _pluginsFolder = mo2Compiler.MO2Folder.Combine("plugins").ToString();
+            _gameName = $"game_{mo2Compiler.CompilingGame.NexusName}.py";
+        }
+
+        private static Regex regex = new Regex(@"^game_$");
+
+        public override async ValueTask<Directive?> Run(RawSourceFile source)
+        {
+            if (!_validGame)
+                return null;
+
+            if (!source.AbsolutePath.ToString().StartsWith(_pluginsFolder))
+                return null;
+
+            if(!source.AbsolutePath.FileName.ToString().Equals(_gameName, StringComparison.InvariantCultureIgnoreCase))
+                return null;
+
+            var res = source.EvolveTo<InlineFile>();
+            res.SourceDataID = await _compiler.IncludeFile(await source.AbsolutePath.ReadAllBytesAsync());
+            return res;
+        }
+
+        public override IState GetState()
+        {
+            return new State();
+        }
+
+        [JsonObject("IncludeGenericGamePlugin")]
+        public class State : IState
+        {
+            public ICompilationStep CreateStep(ACompiler compiler)
+            {
+                return new IncludeGenericGamePlugin(compiler);
+            }
+        }
+    }
+}


### PR DESCRIPTION
New property: `IsGenericMO2Plugin`. We can use this to identify games that only have MO2 support using a [Game Generic](https://github.com/Al12rs/modorganizer-game_generic) plugin.