### PR TITLE
Fix manifest URLs being broken for Wabbajack CDN links

### DIFF
--- a/Wabbajack/Views/ManifestView.xaml.cs
+++ b/Wabbajack/Views/ManifestView.xaml.cs
@@ -61,6 +61,7 @@ namespace Wabbajack
                 url = url.Substring(0, url.IndexOf("release", StringComparison.Ordinal));
 
             //url = url.Replace("&", "^&");
+            url = url.Replace(" ", "%20");
             Process.Start(new ProcessStartInfo("cmd", $"/c start {url}") {CreateNoWindow = true});
 
             e.Handled = true;


### PR DESCRIPTION
Wabbajack URLs to the CDN also had the issue with the spaces. Replacing with %20 fixes it again