### PR TITLE
Work without build server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ### Changelog
 
+#### Version - next
+* Wabbajack will continue working even if the build server is down
+* Fixed an issue where the main window does not appear after the splash screen
+
 #### Version - 2.1.2.0 - 7/13/2020
 * Can heal hand selected MEGA files
 * Several backend fixes

--- a/Wabbajack.Lib/ClientAPI.cs
+++ b/Wabbajack.Lib/ClientAPI.cs
@@ -19,12 +19,12 @@ namespace Wabbajack.Lib
 
         private static bool CheckBuildServer()
         {
-            var client = new Wabbajack.Lib.Http.Client();
+            var client = new Http.Client();
 
             try
             {
                 var result = client.GetAsync($"{Consts.WabbajackBuildServerUri}heartbeat").Result;
-                _isBuildServerDown = result.StatusCode != HttpStatusCode.OK;
+                _isBuildServerDown = result.StatusCode != HttpStatusCode.OK && result.StatusCode != HttpStatusCode.InternalServerError;
             }
             catch (Exception)
             {

--- a/Wabbajack.Lib/FileUploader/AuthorAPI.cs
+++ b/Wabbajack.Lib/FileUploader/AuthorAPI.cs
@@ -40,7 +40,6 @@ namespace Wabbajack.Lib.FileUploader
         {
             var client = await GetAuthorizedClient();
             return await client.GetStringAsync($"{Consts.WabbajackBuildServerUri}jobs/enqueue_job/{jobtype}");
-            
         }
 
         public static async Task<string> UpdateNexusCache()

--- a/Wabbajack.Lib/MO2Compiler.cs
+++ b/Wabbajack.Lib/MO2Compiler.cs
@@ -101,6 +101,9 @@ namespace Wabbajack.Lib
             Info("Using Profiles: " + string.Join(", ", SelectedProfiles.OrderBy(p => p)));
 
             Utils.Log($"VFS File Location: {VFSCacheName}");
+            Utils.Log($"MO2 Folder: {MO2Folder}");
+            Utils.Log($"Downloads Folder: {MO2DownloadsFolder}");
+            Utils.Log($"Game Folder: {GamePath}");
 
             if (cancel.IsCancellationRequested) return false;
             
@@ -174,7 +177,6 @@ namespace Wabbajack.Lib
             if (cancel.IsCancellationRequested) return false;
             UpdateTracker.NextStep("Inferring metas for game file downloads");
             await InferMetas();
-            
 
             if (cancel.IsCancellationRequested) return false;
             UpdateTracker.NextStep("Reindexing downloads after meta inferring");
@@ -410,8 +412,6 @@ namespace Wabbajack.Lib
                 var vf = VFS.Index.ByRootPath[f];
 
                 var meta = await ClientAPI.InferDownloadState(vf.Hash);
-
-
 
                 if (meta == null)
                 {

--- a/Wabbajack.Lib/Metrics.cs
+++ b/Wabbajack.Lib/Metrics.cs
@@ -86,6 +86,9 @@ namespace Wabbajack.Lib
         /// <param name="value"></param>
         public static async Task Send(string action, string value)
         {
+            if (BuildServerStatus.IsBuildServerDown)
+                return;
+
             var key = await GetMetricsKey();
             Utils.Log($"File hash check (-42) {key}");
             var client = new Http.Client();

--- a/Wabbajack/View Models/MainWindowVM.cs
+++ b/Wabbajack/View Models/MainWindowVM.cs
@@ -126,7 +126,8 @@ namespace Wabbajack
                 var fvi = FileVersionInfo.GetVersionInfo(assembly.Location);
                 VersionDisplay = $"v{fvi.FileVersion}";
                 Utils.Log($"Wabbajack Version: {fvi.FileVersion}");
-                var tsk = Metrics.Send("started_wabbajack", fvi.FileVersion);
+                
+                Task.Run(() => Metrics.Send("started_wabbajack", fvi.FileVersion));
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Does a simple check to see if the build server is alive and caches that value. Also fixed the problem where the main window does not appear after the splash screen. Apparently was an issue with `Metrics.Send("started_wabbajack", fvi.FileVersion)`. Wrapping that in `Task.Run(() => ...)` so it doesn't block solved the issue.