### PR TITLE
Added FilePicker Filters for Compilation and Installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### Changelog
 
+#### Version - next
+* Filters from the FilePicker are now being used
+
 #### Version - 2.1.2.0 - 7/13/2020
 * Can heal hand selected MEGA files
 * Several backend fixes

--- a/Wabbajack/View Models/Compilers/MO2CompilerVM.cs
+++ b/Wabbajack/View Models/Compilers/MO2CompilerVM.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
+using DynamicData;
 using Wabbajack.Common;
 using Wabbajack.Lib;
 
@@ -42,12 +43,14 @@ namespace Wabbajack
         public MO2CompilerVM(CompilerVM parent)
         {
             Parent = parent;
-            ModListLocation = new FilePickerVM()
+            ModListLocation = new FilePickerVM
             {
                 ExistCheckOption = FilePickerVM.CheckOptions.On,
                 PathType = FilePickerVM.PathTypeOptions.File,
-                PromptTitle = "Select a ModList"
+                PromptTitle = "Select a Modlist"
             };
+            ModListLocation.Filters.Add(new CommonFileDialogFilter("MO2 Profile (modlist.txt)", ".txt"));
+
             DownloadLocation = new FilePickerVM()
             {
                 ExistCheckOption = FilePickerVM.CheckOptions.On,

--- a/Wabbajack/View Models/Installers/InstallerVM.cs
+++ b/Wabbajack/View Models/Installers/InstallerVM.cs
@@ -20,6 +20,7 @@ using Wabbajack.Common.StatusFeed;
 using System.Reactive;
 using System.Collections.Generic;
 using System.Windows.Input;
+using Microsoft.WindowsAPICodePack.Dialogs;
 using Wabbajack.Common.IO;
 
 namespace Wabbajack
@@ -110,12 +111,13 @@ namespace Wabbajack
 
             MWVM = mainWindowVM;
 
-            ModListLocation = new FilePickerVM()
+            ModListLocation = new FilePickerVM
             {
                 ExistCheckOption = FilePickerVM.CheckOptions.On,
                 PathType = FilePickerVM.PathTypeOptions.File,
                 PromptTitle = "Select a ModList to install"
             };
+            ModListLocation.Filters.Add(new CommonFileDialogFilter("Wabbajack Modlist", ".wabbajack"));
 
             // Swap to proper sub VM based on selected type
             _installer = this.WhenAny(x => x.TargetManager)


### PR DESCRIPTION
Filters were not really used which made it weird. Still have to figure out how to filter not only be extension but also by name eg for `modlist.txt` instead of just `.txt`.