### PR TITLE
Utilize hash cache on install.

### DIFF
--- a/Wabbajack.Common/Hash.cs
+++ b/Wabbajack.Common/Hash.cs
@@ -202,6 +202,10 @@ namespace Wabbajack.Common
             bw.Write((ulong)hash);
             _hashCache.Put(Encoding.UTF8.GetBytes(file.Normalize()), ms.ToArray());
         }
+        public static void FileHashWriteCache(this AbsolutePath file, Hash hash)
+        {
+            WriteHashCache(file, hash);
+        }
 
         public static async Task<Hash> FileHashCachedAsync(this AbsolutePath file, bool nullOnIOError = false)
         {

--- a/Wabbajack.Lib/AInstaller.cs
+++ b/Wabbajack.Lib/AInstaller.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
@@ -226,6 +226,11 @@ namespace Wabbajack.Lib
                         await toFile.DeleteAsync();
                         Utils.ErrorThrow(new Exception($"Virus scan of patched executable reported possible malware: {toFile.ToString()} ({(long)hash})"));
                     }
+                }
+
+                foreach (var file in group)
+                {
+                    file.To.RelativeTo(OutputFolder).FileHashWriteCache(file.Hash);
                 }
 
                 if (UseCompression)


### PR DESCRIPTION
This is a relatively simple PR that makes Wabbajack add the file details and pre-computed hash to the cache. This should dramatically speed up updates over existing installs as Wabbajack doesn't need to rehash every file.