### PR TITLE
Better validation for existing installs.

### DIFF
--- a/Wabbajack.Common/Consts.cs
+++ b/Wabbajack.Common/Consts.cs
@@ -113,6 +113,7 @@ namespace Wabbajack.Common
         public static int WabbajackCachePort = 80;
         public static int MaxHTTPRetries = 4;
         public static RelativePath MO2ModFolderName = (RelativePath)"mods";
+        public static RelativePath MO2ProfilesFolderName = (RelativePath)"profiles";
 
         public static AbsolutePath PatchCacheFolder => LocalAppDataPath.Combine("patch_cache");
         public static int MaxConnectionsPerServer = 4;

--- a/Wabbajack.Lib/MO2Installer.cs
+++ b/Wabbajack.Lib/MO2Installer.cs
@@ -21,6 +21,7 @@ using Directory = Alphaleonis.Win32.Filesystem.Directory;
 using File = Alphaleonis.Win32.Filesystem.File;
 using Path = Alphaleonis.Win32.Filesystem.Path;
 using SectionData = Wabbajack.Common.SectionData;
+using System.Collections.Generic;
 
 namespace Wabbajack.Lib
 {
@@ -428,8 +429,18 @@ namespace Wabbajack.Lib
                 return ErrorResponse.Fail($"Cannot install into a folder with a Wabbajack ModList inside of it");
             }
 
-            // Check folder is either empty, or a likely valid previous install
+            // Check if folder is empty
             if (path.IsEmptyDirectory)
+            {
+                return ErrorResponse.Success;
+            }
+
+            // Check if folders indicative of a previous install exist
+            var checks = new List<RelativePath>() {
+                Consts.MO2ModFolderName, 
+                Consts.MO2ProfilesFolderName
+            };
+            if (checks.All(c => path.Combine(c).Exists))
             {
                 return ErrorResponse.Success;
             }


### PR DESCRIPTION
This PR makes WJ detect if certain folders that usually mean a previous install exist in the selected directory.

The reason for this is that if a user stops an install to continue it later, unless the MO2 executable has been extracted (which is towards the end of the install), they will have to delete all files and start again.

There is a list of folders that can be added to if need be. Currently it checks for "mods" and "profiles".