### PR TITLE
Misc fixes

### DIFF
--- a/Wabbajack.Common/StatusUpdateTracker.cs
+++ b/Wabbajack.Common/StatusUpdateTracker.cs
@@ -40,16 +40,23 @@ namespace Wabbajack.Common
             MakeUpdate(Percent.Zero);
         }
 
-        private Percent OverAllStatus(Percent sub_status)
+        /// <summary>
+        /// Converts a percent that's within the scope of a single step
+        /// to the overall percent when all steps are considered
+        /// </summary>
+        /// <param name="singleStepPercent">Percent progress of the current single step</param>
+        /// <returns>Overall progress in relation to all steps</returns>
+        private Percent OverAllStatus(Percent singleStepPercent)
         {
             var per_step = 1.0f / _internalMaxStep;
             var macro = _internalCurrentStep * per_step;
-            return Percent.FactoryPutInRange(macro + (per_step * sub_status.Value));
+            return Percent.FactoryPutInRange(macro + (per_step * singleStepPercent.Value));
         }
 
         public void MakeUpdate(Percent progress)
         {
-            _progress.OnNext(progress);
+            // Need to convert from single step progress to overall progress for output subject
+            _progress.OnNext(OverAllStatus(progress));
         }
 
         public void MakeUpdate(int max, int curr)

--- a/Wabbajack.Lib/Downloaders/NexusDownloader.cs
+++ b/Wabbajack.Lib/Downloaders/NexusDownloader.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Reactive;
@@ -38,11 +38,6 @@ namespace Wabbajack.Lib.Downloaders
 
         public NexusDownloader()
         {
-            if (CLIArguments.ApiKey != null)
-            {
-                CLIArguments.ApiKey.ToEcryptedJson("nexusapikey");
-            }
-
             TriggerLogin = ReactiveCommand.CreateFromTask(
                 execute: () => Utils.CatchAndLog(NexusApiClient.RequestAndCacheAPIKey), 
                 canExecute: IsLoggedIn.Select(b => !b).ObserveOnGuiThread());
@@ -115,6 +110,11 @@ namespace Wabbajack.Lib.Downloaders
                 // Could have become prepared while we waited for the lock
                 if (!_prepared)
                 {
+                    if (CLIArguments.ApiKey != null)
+                    {
+                        await CLIArguments.ApiKey.ToEcryptedJson("nexusapikey");
+                    }
+
                     _client = await NexusApiClient.Get();
                     _status = await _client.GetUserStatus();
                     if (!_client.IsAuthenticated)

--- a/Wabbajack/Themes/Styles.xaml
+++ b/Wabbajack/Themes/Styles.xaml
@@ -3472,6 +3472,7 @@
 
     <Style BasedOn="{StaticResource MahApps.Styles.TabControl}" TargetType="TabControl" />
     <Style BasedOn="{StaticResource MahApps.Styles.TabItem}" TargetType="{x:Type TabItem}" />
+    <Style BasedOn="{StaticResource MahApps.Styles.Slider}" TargetType="Slider" />
 
     <Style BasedOn="{StaticResource MahApps.Styles.ToolTip}" TargetType="ToolTip">
         <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Control.Background}" />

--- a/Wabbajack/View Models/Compilers/CompilerVM.cs
+++ b/Wabbajack/View Models/Compilers/CompilerVM.cs
@@ -212,12 +212,12 @@ namespace Wabbajack
                 .QueryWhenChanged(query => query.FirstOrDefault())
                 .ToGuiProperty(this, nameof(ActiveGlobalUserIntervention));
 
-            CloseWhenCompleteCommand = ReactiveCommand.Create(
+            CloseWhenCompleteCommand = ReactiveCommand.CreateFromTask(
                 canExecute: this.WhenAny(x => x.Completed)
                     .Select(x => x != null),
-                execute: () =>
+                execute: async () =>
                 {
-                    MWVM.ShutdownApplication();
+                    await MWVM.ShutdownApplication();
                 });
 
             GoToCommand = ReactiveCommand.Create(

--- a/Wabbajack/View Models/Installers/InstallerVM.cs
+++ b/Wabbajack/View Models/Installers/InstallerVM.cs
@@ -412,12 +412,12 @@ namespace Wabbajack
                 .QueryWhenChanged(query => query.FirstOrDefault())
                 .ToGuiProperty(this, nameof(ActiveGlobalUserIntervention));
 
-            CloseWhenCompleteCommand = ReactiveCommand.Create(
+            CloseWhenCompleteCommand = ReactiveCommand.CreateFromTask(
                 canExecute: this.WhenAny(x => x.Completed)
                     .Select(x => x != null),
-                execute: () =>
+                execute: async () =>
                 {
-                    MWVM.ShutdownApplication();
+                    await MWVM.ShutdownApplication();
                 });
 
             GoToInstallCommand = ReactiveCommand.Create(

--- a/Wabbajack/View Models/MainWindowVM.cs
+++ b/Wabbajack/View Models/MainWindowVM.cs
@@ -143,12 +143,12 @@ namespace Wabbajack
                     .Select(active => !SettingsPane.IsValueCreated || !object.ReferenceEquals(active, SettingsPane.Value)),
                 execute: () => NavigateTo(SettingsPane.Value));
 
-            OpenTerminalCommand = ReactiveCommand.Create(() => OpenTerminal());
+            OpenTerminalCommand = ReactiveCommand.CreateFromTask(() => OpenTerminal());
             
 
         }
 
-        private void OpenTerminal()
+        private async Task OpenTerminal()
         {
             var process = new ProcessStartInfo
             {
@@ -156,7 +156,7 @@ namespace Wabbajack
                 WorkingDirectory = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location)
             };
             Process.Start(process);
-            ShutdownApplication();
+            await ShutdownApplication();
         }
 
         private static bool IsStartingFromModlist(out AbsolutePath modlistPath)
@@ -193,14 +193,14 @@ namespace Wabbajack
             ActivePane = vm;
         }
 
-        public void ShutdownApplication()
+        public async Task ShutdownApplication()
         {
             Dispose();
             Settings.PosX = MainWindow.Left;
             Settings.PosY = MainWindow.Top;
             Settings.Width = MainWindow.Width;
             Settings.Height = MainWindow.Height;
-            MainSettings.SaveSettings(Settings).AsTask().Wait();
+            await MainSettings.SaveSettings(Settings);
             Application.Current.Shutdown();
         }
     }

--- a/Wabbajack/View Models/MainWindowVM.cs
+++ b/Wabbajack/View Models/MainWindowVM.cs
@@ -1,4 +1,4 @@
-using DynamicData;
+﻿using DynamicData;
 using DynamicData.Binding;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
@@ -46,7 +46,6 @@ namespace Wabbajack
         public ICommand CopyVersionCommand { get; }
         public ICommand ShowLoginManagerVM { get; }
         public ICommand OpenSettingsCommand { get; }
-        public ICommand OpenTerminalCommand { get; }
 
         public string VersionDisplay { get; }
 
@@ -142,21 +141,6 @@ namespace Wabbajack
                 canExecute: this.WhenAny(x => x.ActivePane)
                     .Select(active => !SettingsPane.IsValueCreated || !object.ReferenceEquals(active, SettingsPane.Value)),
                 execute: () => NavigateTo(SettingsPane.Value));
-
-            OpenTerminalCommand = ReactiveCommand.CreateFromTask(() => OpenTerminal());
-            
-
-        }
-
-        private async Task OpenTerminal()
-        {
-            var process = new ProcessStartInfo
-            {
-                FileName = "cmd.exe", 
-                WorkingDirectory = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location)
-            };
-            Process.Start(process);
-            await ShutdownApplication();
         }
 
         private static bool IsStartingFromModlist(out AbsolutePath modlistPath)
@@ -170,7 +154,6 @@ namespace Wabbajack
             modlistPath = (AbsolutePath)CLIArguments.InstallPath;
             return true;
         }
-
 
         public void OpenInstaller(AbsolutePath path)
         {

--- a/Wabbajack/View Models/MainWindowVM.cs
+++ b/Wabbajack/View Models/MainWindowVM.cs
@@ -76,14 +76,11 @@ namespace Wabbajack
                 .Subscribe()
                 .DisposeWith(CompositeDisposable);
             
-            var singleton_lock = new AsyncLock();
-
             Utils.LogMessages
                 .OfType<IUserIntervention>()
                 .ObserveOnGuiThread()
                 .SelectTask(async msg =>
                 {
-                    using var _ = await singleton_lock.WaitAsync();
                     try
                     {
                         await UserInterventionHandlers.Handle(msg);

--- a/Wabbajack/View Models/MainWindowVM.cs
+++ b/Wabbajack/View Models/MainWindowVM.cs
@@ -1,4 +1,4 @@
-﻿using DynamicData;
+using DynamicData;
 using DynamicData.Binding;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
@@ -127,7 +127,7 @@ namespace Wabbajack
                 VersionDisplay = $"v{fvi.FileVersion}";
                 Utils.Log($"Wabbajack Version: {fvi.FileVersion}");
                 
-                Task.Run(() => Metrics.Send("started_wabbajack", fvi.FileVersion));
+                Task.Run(() => Metrics.Send("started_wabbajack", fvi.FileVersion)).FireAndForget();
             }
             catch (Exception ex)
             {

--- a/Wabbajack/View Models/Settings/SettingsVM.cs
+++ b/Wabbajack/View Models/Settings/SettingsVM.cs
@@ -1,8 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows.Input;
 using ReactiveUI;
 using Wabbajack.Lib;
 
@@ -15,7 +19,9 @@ namespace Wabbajack
         public PerformanceSettings Performance { get; }
         public FiltersSettings Filters { get; }
         public AuthorFilesVM AuthorFile { get; }
-        
+
+        public ICommand OpenTerminalCommand { get; }
+
         public SettingsVM(MainWindowVM mainWindowVM)
             : base(mainWindowVM)
         {
@@ -24,7 +30,18 @@ namespace Wabbajack
             Performance = mainWindowVM.Settings.Performance;
             AuthorFile = new AuthorFilesVM(this);
             Filters = mainWindowVM.Settings.Filters;
+            OpenTerminalCommand = ReactiveCommand.CreateFromTask(() => OpenTerminal());
         }
 
+        private async Task OpenTerminal()
+        {
+            var process = new ProcessStartInfo
+            {
+                FileName = "cmd.exe",
+                WorkingDirectory = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location)
+            };
+            Process.Start(process);
+            await MWVM.ShutdownApplication();
+        }
     }
 }

--- a/Wabbajack/Views/MainWindow.xaml
+++ b/Wabbajack/Views/MainWindow.xaml
@@ -69,14 +69,6 @@
                     Height="17"
                     Kind="Cog" />
             </Button>
-            <Button Grid.Column="1"
-                Margin="5,0"
-                Command="{Binding OpenTerminalCommand}">
-                <icon:PackIconMaterial
-                    Width="17"
-                    Height="17"
-                    Kind="Console" />
-            </Button>
         </mahapps:WindowCommands>
     </mahapps:MetroWindow.RightWindowCommands>
 </mahapps:MetroWindow>

--- a/Wabbajack/Views/MainWindow.xaml.cs
+++ b/Wabbajack/Views/MainWindow.xaml.cs
@@ -162,7 +162,7 @@ namespace Wabbajack
 
         private void Window_Closing(object sender, CancelEventArgs e)
         {
-            _mwvm.ShutdownApplication();
+            _mwvm.ShutdownApplication().Wait();
         }
     }
 }

--- a/Wabbajack/Views/Settings/MiscSettingsView.xaml
+++ b/Wabbajack/Views/Settings/MiscSettingsView.xaml
@@ -1,5 +1,5 @@
 ﻿<rxui:ReactiveUserControl
-    x:Class="Wabbajack.ModlistGallerySettingsView"
+    x:Class="Wabbajack.MiscSettingsView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/Wabbajack/Views/Settings/MiscSettingsView.xaml
+++ b/Wabbajack/Views/Settings/MiscSettingsView.xaml
@@ -9,7 +9,7 @@
     xmlns:xwpf="http://schemas.xceed.com/wpf/xaml/toolkit"
     d:DesignHeight="450"
     d:DesignWidth="800"
-    x:TypeArguments="local:FiltersSettings"
+    x:TypeArguments="local:SettingsVM"
     mc:Ignorable="d">
     <Border
         x:Name="PerformanceView"
@@ -42,6 +42,7 @@
                     <RowDefinition />
                     <RowDefinition />
                     <RowDefinition />
+                    <RowDefinition />
                 </Grid.RowDefinitions>
                 <Grid.Resources>
                     <Style BasedOn="{StaticResource MainButtonStyle}" TargetType="Button">
@@ -55,21 +56,21 @@
                     </Style>
                 </Grid.Resources>
                 <CheckBox Grid.Row="0"
-                          Name="FilterPersistCheckBox"
-                          Margin="0,5,0,0"
-                          HorizontalAlignment="Left"
-                          VerticalAlignment="Top"
-                          Content="Gallery filters are saved on exit">
+                    Name="FilterPersistCheckBox"
+                    Margin="0,5,0,0"
+                    HorizontalAlignment="Left"
+                    VerticalAlignment="Top"
+                    Content="Gallery filters are saved on exit">
                     <CheckBox.LayoutTransform>
                         <ScaleTransform ScaleX="1.2" ScaleY="1.2" />
                     </CheckBox.LayoutTransform>
                 </CheckBox>
                 <CheckBox Grid.Row="1"
-                          Name="UseCompressionCheckBox"
-                          Margin="0,5,0,0"
-                          HorizontalAlignment="Left"
-                          VerticalAlignment="Top"
-                          Content="Use NTFS LZS compression during install">
+                    Name="UseCompressionCheckBox"
+                    Margin="0,5,0,0"
+                    HorizontalAlignment="Left"
+                    VerticalAlignment="Top"
+                    Content="Use NTFS LZS compression during install">
                     <CheckBox.LayoutTransform>
                         <ScaleTransform ScaleX="1.2" ScaleY="1.2" />
                     </CheckBox.LayoutTransform>
@@ -78,6 +79,10 @@
                     Name="ClearCefCache"
                     Margin="0,5,0,0"
                     Content="Clear In-App Browser Cache" />
+                <Button Grid.Row="3"
+                    Name="OpenTerminal"
+                    Margin="0,5,0,0"
+                    Content="Open Terminal and Close WJ" />
             </Grid>
         </Grid>
     </Border>

--- a/Wabbajack/Views/Settings/MiscSettingsView.xaml.cs
+++ b/Wabbajack/Views/Settings/MiscSettingsView.xaml.cs
@@ -23,7 +23,7 @@ namespace Wabbajack
     /// <summary>
     /// Interaction logic for MiscSettingsView.xaml
     /// </summary>
-    public partial class MiscSettingsView : ReactiveUserControl<FiltersSettings>
+    public partial class MiscSettingsView : ReactiveUserControl<SettingsVM>
     {
         public MiscSettingsView()
         {
@@ -32,9 +32,12 @@ namespace Wabbajack
             this.WhenActivated(disposable =>
             {
                 // Bind Values
-                this.Bind(this.ViewModel, x => x.IsPersistent, x => x.FilterPersistCheckBox.IsChecked)
+                this.BindStrict(this.ViewModel, x => x.Filters.IsPersistent, x => x.FilterPersistCheckBox.IsChecked)
                     .DisposeWith(disposable);
-                this.Bind(this.ViewModel, x => x.UseCompression, x => x.UseCompressionCheckBox.IsChecked)
+                this.BindStrict(this.ViewModel, x => x.Filters.UseCompression, x => x.UseCompressionCheckBox.IsChecked)
+                    .DisposeWith(disposable);
+                this.WhenAnyValue(x => x.ViewModel.OpenTerminalCommand)
+                    .BindToStrict(this, x => x.OpenTerminal.Command)
                     .DisposeWith(disposable);
 
                 this.ClearCefCache.Click += (sender, args) => {Driver.ClearCache();};

--- a/Wabbajack/Views/Settings/MiscSettingsView.xaml.cs
+++ b/Wabbajack/Views/Settings/MiscSettingsView.xaml.cs
@@ -21,11 +21,11 @@ using Wabbajack.Lib.WebAutomation;
 namespace Wabbajack
 {
     /// <summary>
-    /// Interaction logic for ModlistGallerySettingsView.xaml
+    /// Interaction logic for MiscSettingsView.xaml
     /// </summary>
-    public partial class ModlistGallerySettingsView : ReactiveUserControl<FiltersSettings>
+    public partial class MiscSettingsView : ReactiveUserControl<FiltersSettings>
     {
-        public ModlistGallerySettingsView()
+        public MiscSettingsView()
         {
             InitializeComponent();
 

--- a/Wabbajack/Views/Settings/SettingsView.xaml
+++ b/Wabbajack/Views/Settings/SettingsView.xaml
@@ -43,7 +43,7 @@
             <WrapPanel>
                 <local:LoginSettingsView x:Name="LoginView" />
                 <local:PerformanceSettingsView x:Name="PerformanceView" />
-                <local:ModlistGallerySettingsView x:Name="ModlistGalleryView" />
+                <local:MiscSettingsView x:Name="MiscGalleryView" />
                 <local:AuthorFilesView x:Name="AuthorFilesView" />
             </WrapPanel>
         </ScrollViewer>

--- a/Wabbajack/Views/Settings/SettingsView.xaml.cs
+++ b/Wabbajack/Views/Settings/SettingsView.xaml.cs
@@ -34,8 +34,7 @@ namespace Wabbajack
                     .DisposeWith(disposable);
                 this.OneWayBindStrict(this.ViewModel, x => x.Performance, x => x.PerformanceView.ViewModel)
                     .DisposeWith(disposable);
-                this.OneWayBindStrict(this.ViewModel, x => x.Filters, x => x.MiscGalleryView.ViewModel)
-                    .DisposeWith(disposable);
+                this.MiscGalleryView.ViewModel = this.ViewModel;
             });
         }
     }

--- a/Wabbajack/Views/Settings/SettingsView.xaml.cs
+++ b/Wabbajack/Views/Settings/SettingsView.xaml.cs
@@ -34,7 +34,7 @@ namespace Wabbajack
                     .DisposeWith(disposable);
                 this.OneWayBindStrict(this.ViewModel, x => x.Performance, x => x.PerformanceView.ViewModel)
                     .DisposeWith(disposable);
-                this.OneWayBindStrict(this.ViewModel, x => x.Filters, x => x.ModlistGalleryView.ViewModel)
+                this.OneWayBindStrict(this.ViewModel, x => x.Filters, x => x.MiscGalleryView.ViewModel)
                     .DisposeWith(disposable);
             });
         }


### PR DESCRIPTION
- Fix for progress bar display.  The code that translated a single step's progress to the overall progress "space" had been removed.
- Adjusted shutdown mechanics to await rather than .Wait().  Helps let the GUI shutdown on click as the user expects, vs freezing until all background tasks are complete.
- Style fix for sliders
- **Moved NexusDownloader init step to Prepare.  Was needing an await, but couldn't since it was in the ctor**
- Moved the Open Terminal button to within "misc settings".  Was a bit too dangerous of a button to have next to minimize, and/or just be in all the users' faces without tooltips.  One click and everything nukes itself.
- Renamed MiscSettingsView as it was improperly named

Make sure the issue in bold makes sense to you.  Wasn't quite sure what those lines were doing to know if it was safe to move like that