### PR TITLE
Made RocksDB Initialization Lazier

### DIFF
--- a/Wabbajack.Common.Test/MiscTests.cs
+++ b/Wabbajack.Common.Test/MiscTests.cs
@@ -23,7 +23,7 @@ namespace Wabbajack.Common.Test
             await testFile.WriteAllTextAsync(data);
             File.WriteAllText("test.data", data);
             Assert.Equal(Hash.FromBase64("eSIyd+KOG3s="), await testFile.FileHashCachedAsync());
-            Assert.True(Utils.TryGetHashCache(testFile, out var fileHash));
+            Assert.True(testFile.TryGetHashCache(out var fileHash));
             Assert.Equal(Hash.FromBase64("eSIyd+KOG3s="), fileHash);
         }
 

--- a/Wabbajack.Common/Utils.cs
+++ b/Wabbajack.Common/Utils.cs
@@ -24,7 +24,6 @@ using IniParser.Model.Configuration;
 using IniParser.Parser;
 using Microsoft.Win32;
 using Newtonsoft.Json;
-using RocksDbSharp;
 using Wabbajack.Common.StatusFeed;
 using Wabbajack.Common.StatusFeed.Errors;
 using YamlDotNet.Serialization;
@@ -60,9 +59,6 @@ namespace Wabbajack.Common
             LogFile = Consts.LogFile;
             Consts.LocalAppDataPath.CreateDirectory();
             Consts.LogsFolder.CreateDirectory();
-            
-            var options = new DbOptions().SetCreateIfMissing(true);
-            _hashCache = RocksDb.Open(options, (string)Consts.LocalAppDataPath.Combine("GlobalHashCache.rocksDb"));
 
             _startTime = DateTime.Now;
 
@@ -109,7 +105,6 @@ namespace Wabbajack.Common
                                                 Observable.FromEventPattern<FileSystemEventHandler, FileSystemEventArgs>(h => watcher.Deleted += h, h => watcher.Deleted -= h).Select(e => (FileEventType.Deleted, e.EventArgs)))
                                        .ObserveOn(Scheduler.Default);
             watcher.EnableRaisingEvents = true;
-            InitPatches();
         }
 
         private static readonly Subject<IStatusMessage> LoggerSubj = new Subject<IStatusMessage>();

--- a/Wabbajack.Test/DownloaderTests.cs
+++ b/Wabbajack.Test/DownloaderTests.cs
@@ -471,7 +471,7 @@ namespace Wabbajack.Test
 
             await converted.Download(new Archive(state: null!) { Name = "Update.esm" }, filename.Path);
 
-            Assert.Equal(Hash.FromBase64("/DLG/LjdGXI="), await Utils.FileHashAsync(filename.Path));
+            Assert.Equal(Hash.FromBase64("/DLG/LjdGXI="), await filename.Path.FileHashAsync());
             Assert.Equal(await filename.Path.ReadAllBytesAsync(), await Game.SkyrimSpecialEdition.MetaData().GameLocation().Combine("Data/Update.esm").ReadAllBytesAsync());
             Consts.TestMode = true;
         }


### PR DESCRIPTION
RocksDB was being initialized eagerly within Util's static constructor.   This was problematic for two reasons:
- Extra work for people that don't care
- The disk lock put in place by the init meant that only one app using Wabbajack.Common could exist at a time.  All other parallel processes error out trying to instantiate Utils.

I moved the initialization to other static classes, which only get referred to when needed.  The singleton lock nature of RocksDB is still in effect, but now users that don't utilize it should be unaffected.  

I kept forwarding functions within Utils, so that the API is the same for the WJ codebase.  The first caller to Utils.SomeRocksRelatedFunction will trigger the rocks init and create the lock.