### PR TITLE
mark WJ installed archives as installed in MO2.

### DIFF
--- a/Wabbajack.Lib/Downloaders/AbstractDownloadState.cs
+++ b/Wabbajack.Lib/Downloaders/AbstractDownloadState.cs
@@ -100,7 +100,7 @@ namespace Wabbajack.Lib.Downloaders
 
         public string GetMetaIniString()
         {
-            return string.concat(string.Join("\n", GetMetaIni()), " installed=true");
+            return return $"{string.Join("\n", GetMetaIni())}\ninstalled=true";
         }
 
         public async Task<(Archive? Archive, TempFile NewFile)> ServerFindUpgrade(Archive a)

--- a/Wabbajack.Lib/Downloaders/AbstractDownloadState.cs
+++ b/Wabbajack.Lib/Downloaders/AbstractDownloadState.cs
@@ -100,7 +100,7 @@ namespace Wabbajack.Lib.Downloaders
 
         public string GetMetaIniString()
         {
-            return string.Join("\n", GetMetaIni(), "\n", "installed=true");
+            return string.concat(string.Join("\n", [GetMetaIni()), " installed=true");
         }
 
         public async Task<(Archive? Archive, TempFile NewFile)> ServerFindUpgrade(Archive a)

--- a/Wabbajack.Lib/Downloaders/AbstractDownloadState.cs
+++ b/Wabbajack.Lib/Downloaders/AbstractDownloadState.cs
@@ -100,7 +100,7 @@ namespace Wabbajack.Lib.Downloaders
 
         public string GetMetaIniString()
         {
-            return string.concat(string.Join("\n", [GetMetaIni()), " installed=true");
+            return string.concat(string.Join("\n", GetMetaIni()), " installed=true");
         }
 
         public async Task<(Archive? Archive, TempFile NewFile)> ServerFindUpgrade(Archive a)

--- a/Wabbajack.Lib/Downloaders/AbstractDownloadState.cs
+++ b/Wabbajack.Lib/Downloaders/AbstractDownloadState.cs
@@ -100,7 +100,7 @@ namespace Wabbajack.Lib.Downloaders
 
         public string GetMetaIniString()
         {
-            return return $"{string.Join("\n", GetMetaIni())}\ninstalled=true";
+            return return $"{string.Join("\n", GetMetaIni())} installed=true";
         }
 
         public async Task<(Archive? Archive, TempFile NewFile)> ServerFindUpgrade(Archive a)

--- a/Wabbajack.Lib/Downloaders/AbstractDownloadState.cs
+++ b/Wabbajack.Lib/Downloaders/AbstractDownloadState.cs
@@ -100,7 +100,7 @@ namespace Wabbajack.Lib.Downloaders
 
         public string GetMetaIniString()
         {
-            return string.Join("\n", GetMetaIni());
+            return string.Join("\n", GetMetaIni(), "\n", "installed=true");
         }
 
         public async Task<(Archive? Archive, TempFile NewFile)> ServerFindUpgrade(Archive a)

--- a/Wabbajack.Lib/Downloaders/AbstractDownloadState.cs
+++ b/Wabbajack.Lib/Downloaders/AbstractDownloadState.cs
@@ -100,7 +100,7 @@ namespace Wabbajack.Lib.Downloaders
 
         public string GetMetaIniString()
         {
-            return $"{string.Join("\n", GetMetaIni())} installed=true";
+            return $"{string.Join("\n", GetMetaIni())}\ninstalled=true";
         }
 
         public async Task<(Archive? Archive, TempFile NewFile)> ServerFindUpgrade(Archive a)

--- a/Wabbajack.Lib/Downloaders/AbstractDownloadState.cs
+++ b/Wabbajack.Lib/Downloaders/AbstractDownloadState.cs
@@ -100,7 +100,7 @@ namespace Wabbajack.Lib.Downloaders
 
         public string GetMetaIniString()
         {
-            return return $"{string.Join("\n", GetMetaIni())} installed=true";
+            return $"{string.Join("\n", GetMetaIni())} installed=true";
         }
 
         public async Task<(Archive? Archive, TempFile NewFile)> ServerFindUpgrade(Archive a)


### PR DESCRIPTION
A simple change to the the way .meta files get handled by Wabbajack to mark archives used by Wabbajack as installed when launching ModOrganizer2.