### PR TITLE
Fix version tooltip displaying incorrectly.

### DIFF
--- a/Wabbajack/Views/MainWindow.xaml
+++ b/Wabbajack/Views/MainWindow.xaml
@@ -56,9 +56,7 @@
                 Command="{Binding CopyVersionCommand}"
                 Content="{Binding VersionDisplay}">
                 <Button.ToolTip>
-                    <TextBlock>
-                        Wabbajack Version<LineBreak />
-                        Click to copy to clipboard</TextBlock>
+                    <ToolTip Content="Wabbajack Version&#x0a;Click to copy to clipboard"/>
                 </Button.ToolTip>
             </Button>
             <Button Grid.Column="1"


### PR DESCRIPTION
This minor bug (https://github.com/wabbajack-tools/wabbajack/issues/1075) actually took a fair bit of trial and error. For some reason, the previous method WJ used to display a multiline tooltip is no longer working. I'm not quite sure why, but I've been able to return it back to function.

Although this is minor, if someone would like to take a more in-depth look into it, feel free, it has me stumped. In the mean time, here's a quick-fix PR.