### PR TITLE
Don't attempt to compress files smaller than the disk cluster size.

### DIFF
--- a/Wabbajack.Common/Paths/FileCompaction.cs
+++ b/Wabbajack.Common/Paths/FileCompaction.cs
@@ -60,11 +60,17 @@ namespace Wabbajack.Common
 
         public static async Task CompactFolder(this AbsolutePath folder, WorkQueue queue, Algorithm algorithm)
         {
+            var driveInfo = folder.DriveInfo().DiskSpaceInfo;
+            var clusterSize = driveInfo.SectorsPerCluster * driveInfo.BytesPerSector;
+
             await folder.EnumerateFiles(true)
                 .PMap(queue, async path =>
                 {
-                    Utils.Status($"Compacting {path.FileName}");
-                    await path.Compact(algorithm);
+                    if (path.Size > clusterSize)
+                    {
+                        Utils.Status($"Compacting {path.FileName}");
+                        await path.Compact(algorithm);
+                    }
                 });
         }
     }

--- a/Wabbajack.Common/Paths/FileCompaction.cs
+++ b/Wabbajack.Common/Paths/FileCompaction.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Linq;
+using System.Threading.Tasks;
 using Wabbajack.Common.IO;
 
 namespace Wabbajack.Common
@@ -63,14 +64,13 @@ namespace Wabbajack.Common
             var driveInfo = folder.DriveInfo().DiskSpaceInfo;
             var clusterSize = driveInfo.SectorsPerCluster * driveInfo.BytesPerSector;
 
-            await folder.EnumerateFiles(true)
+            await folder
+                .EnumerateFiles(true)
+                .Where(f => f.Size > clusterSize)
                 .PMap(queue, async path =>
                 {
-                    if (path.Size > clusterSize)
-                    {
-                        Utils.Status($"Compacting {path.FileName}");
-                        await path.Compact(algorithm);
-                    }
+                    Utils.Status($"Compacting {path.FileName}");
+                    await path.Compact(algorithm);
                 });
         }
     }


### PR DESCRIPTION
While Windows' compact function won't compress files less than the cluster size, we still pass the file(s) to be compressed. 

This PR simply checks the file size against the cluster size before attempting to compress.

In tests, using the SME(FT) list these are my results:

**Before PR**:
```
16.68 - Compacting files
109.62 - Installation complete! You may exit the program.
```
Compacting took 92.94 seconds.

**After PR**:
```
16.2 - Compacting files
50.05 - Installation complete! You may exit the program.
```
Compacting took 33.85 seconds.