### PR TITLE
updated Dishonored Meta

### DIFF
--- a/Wabbajack.Common/GameMetaData.cs
+++ b/Wabbajack.Common/GameMetaData.cs
@@ -455,7 +455,7 @@ namespace Wabbajack.Common
                     {
                         "Binaries\\Win32\\Dishonored.exe"
                     },
-                    MainExecutable = "Binaries\\Win32\\Dishonored.exe"
+                    MainExecutable = @"Binaries\Win32\Dishonored.exe"
                 }
             },
             {	


### PR DESCRIPTION
Set the entry for the MainExecutable to be similar to the TW3 one.
For consistency and in the hopes to fix the game detection for the generic compiler.