### PR TITLE
Make more path comparisons ignore case

### DIFF
--- a/Wabbajack.Common/Paths/AbsolutePath.cs
+++ b/Wabbajack.Common/Paths/AbsolutePath.cs
@@ -275,7 +275,7 @@ namespace Wabbajack.Common
 
         public bool InFolder(AbsolutePath folder)
         {
-            return _path.StartsWith(folder._path + Path.DirectorySeparator);
+            return _path.StartsWith(folder._path + Path.DirectorySeparator, StringComparison.OrdinalIgnoreCase);
         }
 
         public async Task<byte[]> ReadAllBytesAsync()
@@ -386,7 +386,7 @@ namespace Wabbajack.Common
 
         public int CompareTo(AbsolutePath other)
         {
-            return string.Compare(_path, other._path, StringComparison.Ordinal);
+            return string.Compare(_path, other._path, StringComparison.OrdinalIgnoreCase);
         }
 
         public string ReadAllText()

--- a/Wabbajack.Common/Paths/RelativePath.cs
+++ b/Wabbajack.Common/Paths/RelativePath.cs
@@ -136,12 +136,12 @@ namespace Wabbajack.Common
 
         public bool StartsWith(string s)
         {
-            return _path.StartsWith(s);
+            return _path.StartsWith(s, StringComparison.OrdinalIgnoreCase);
         }
         
         public bool StartsWith(RelativePath s)
         {
-            return _path.StartsWith(s._path);
+            return _path.StartsWith(s._path, StringComparison.OrdinalIgnoreCase);
         }
 
         public RelativePath Combine(params RelativePath[] paths )
@@ -156,7 +156,7 @@ namespace Wabbajack.Common
 
         public int CompareTo(RelativePath other)
         {
-            return string.Compare(_path, other._path, StringComparison.Ordinal);
+            return string.Compare(_path, other._path, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/Wabbajack.Common/Utils.cs
+++ b/Wabbajack.Common/Utils.cs
@@ -866,7 +866,7 @@ namespace Wabbajack.Common
 
         public static bool IsInPath(this string path, string parent)
         {
-            return path.ToLower().TrimEnd('\\').StartsWith(parent.ToLower().TrimEnd('\\') + "\\");
+            return path.ToLower().TrimEnd('\\').StartsWith(parent.ToLower().TrimEnd('\\') + "\\", StringComparison.OrdinalIgnoreCase);
         }
         
         public static async Task CopyToLimitAsync(this Stream frm, Stream tw, long limit)

--- a/Wabbajack.Lib/CompilationSteps/IgnoreGameFiles.cs
+++ b/Wabbajack.Lib/CompilationSteps/IgnoreGameFiles.cs
@@ -15,7 +15,7 @@ namespace Wabbajack.Lib.CompilationSteps
 
         public override async ValueTask<Directive?> Run(RawSourceFile source)
         {
-            if (!((string)source.Path).StartsWith(_startDir)) return null;
+            if (!((string)source.Path).StartsWith(_startDir, System.StringComparison.OrdinalIgnoreCase)) return null;
             var i = source.EvolveTo<IgnoredDirectly>();
             i.Reason = "Default game file";
             return i;


### PR DESCRIPTION
Paths for Windows should be case-agnostic.  The primary impetus for
this change is to prevent WJ from deleting downloads if the case of
the folder name doesn't match the case of the install setting.
Normally this would be caught by the GUI validation but several users
have managed to get around that.