### PR TITLE
Added Darkest Dungeon EGS Support

### DIFF
--- a/Wabbajack.Common/GameMetaData.cs
+++ b/Wabbajack.Common/GameMetaData.cs
@@ -448,12 +448,13 @@ namespace Wabbajack.Common
                     NexusGameId = 804,
                     SteamIDs = new List<int> {262060},
                     GOGIDs = new List<int>{1450711444},
+                    EpicGameStoreIDs = new List<string> {"b4eecf70e3fe4e928b78df7855a3fc2d"},
                     IsGenericMO2Plugin = true,
                     RequiredFiles = new List<string>
                     {
-                        "_windows\\Darkest.exe"
+                        "_windowsnosteam\\Darkest.exe"
                     },
-                    MainExecutable = "_windows\\Darkest.exe"
+                    MainExecutable = "_windowsnosteam\\Darkest.exe"
                 }
             },
             {


### PR DESCRIPTION
- changed the used executable to use the executable located in `_windowsnosteam\\Darkest.exe` cause it is present in all available versions of the game.
  - authors would need to use the updated `darkestdungeon.py` from the basic-games Github for optimized executable detection. The install folder will still only be auto detected for GOG and Steam in that plugin, but Wabbajack should be able to handle this with its own detection. This updated version should be able to auto-select the needed executable so steam users still get the steam achievements. [Explanations about the changes to the .py can be found here.](https://github.com/ModOrganizer2/modorganizer-basic_games/pull/22)
- added the ESG Store ID