### PR TITLE
Optimise SQLite database store and IO.

### DIFF
--- a/Wabbajack.Common/Hash.cs
+++ b/Wabbajack.Common/Hash.cs
@@ -127,7 +127,7 @@ namespace Wabbajack.Common
 
         static HashCache()
         {
-            _connectionString = String.Intern($"URI=file:{DBLocation};Pooling=True;Max Pool Size=100;");
+            _connectionString = String.Intern($"URI=file:{DBLocation};Pooling=True;Max Pool Size=100; Journal Mode=Memory;");
             _conn = new SQLiteConnection(_connectionString);
             _conn.Open();
 
@@ -135,7 +135,8 @@ namespace Wabbajack.Common
             cmd.CommandText = @"CREATE TABLE IF NOT EXISTS HashCache (
             Path TEXT PRIMARY KEY,
             LastModified BIGINT,
-            Hash BIGINT)";
+            Hash BIGINT)
+            WITHOUT ROWID";
             cmd.ExecuteNonQuery();
 
 
@@ -179,6 +180,15 @@ namespace Wabbajack.Common
             cmd.Parameters.AddWithValue("@hash", (long)hash);
             cmd.PrepareAsync();
             
+            cmd.ExecuteNonQuery();
+        }
+
+        public static void VacuumDatabase()
+        {
+            using var cmd = new SQLiteCommand(_conn);
+            cmd.CommandText = @"VACUUM";
+            cmd.PrepareAsync();
+
             cmd.ExecuteNonQuery();
         }
 

--- a/Wabbajack.Common/Patches.cs
+++ b/Wabbajack.Common/Patches.cs
@@ -15,7 +15,7 @@ namespace Wabbajack.Common
 
         static PatchCache()
         {
-            _connectionString = String.Intern($"URI=file:{DBLocation};Pooling=True;Max Pool Size=100;");
+            _connectionString = String.Intern($"URI=file:{DBLocation};Pooling=True;Max Pool Size=100; Journal Mode=Memory;");
             _conn = new SQLiteConnection(_connectionString);
             _conn.Open();
 
@@ -25,7 +25,8 @@ namespace Wabbajack.Common
             ToHash BIGINT,
             PatchSize BLOB,
             Patch BLOB,
-            PRIMARY KEY (FromHash, ToHash))";
+            PRIMARY KEY (FromHash, ToHash))
+            WITHOUT ROWID";
             cmd.ExecuteNonQuery();
 
         }
@@ -142,6 +143,15 @@ namespace Wabbajack.Common
 
 
 
+        }
+
+        public static void VacuumDatabase()
+        {
+            using var cmd = new SQLiteCommand(_conn);
+            cmd.CommandText = @"VACUUM";
+            cmd.PrepareAsync();
+
+            cmd.ExecuteNonQuery();
         }
 
         public static void ApplyPatch(Stream input, Func<Stream> openPatchStream, Stream output)

--- a/Wabbajack.Lib/ABatchProcessor.cs
+++ b/Wabbajack.Lib/ABatchProcessor.cs
@@ -177,6 +177,11 @@ namespace Wabbajack.Lib
                 }
                 finally
                 {
+                    Utils.Log("Vacuuming databases");
+                    HashCache.VacuumDatabase();
+                    PatchCache.VacuumDatabase();
+                    VirtualFile.VacuumDatabase();
+                    Utils.Log("Vacuuming completed");
                     _isRunning.OnNext(false);
                 }
             });

--- a/Wabbajack.VirtualFileSystem/VirtualFile.cs
+++ b/Wabbajack.VirtualFileSystem/VirtualFile.cs
@@ -22,14 +22,15 @@ namespace Wabbajack.VirtualFileSystem
 
         static VirtualFile()
         {
-            _connectionString = String.Intern($"URI=file:{DBLocation};Pooling=True;Max Pool Size=100;");
+            _connectionString = String.Intern($"URI=file:{DBLocation};Pooling=True;Max Pool Size=100; Journal Mode=Memory;");
             _conn = new SQLiteConnection(_connectionString);
             _conn.Open();
 
             using var cmd = new SQLiteCommand(_conn);
             cmd.CommandText = @"CREATE TABLE IF NOT EXISTS VFSCache (
-            Hash BIGINT PRIMARY KEY ,
-            Contents BLOB)";
+            Hash BIGINT PRIMARY KEY,
+            Contents BLOB)
+            WITHOUT ROWID";
             cmd.ExecuteNonQuery();
 
         }
@@ -272,6 +273,14 @@ namespace Wabbajack.VirtualFileSystem
                     return;
                 throw;
             }
+        }
+        public static void VacuumDatabase()
+        {
+            using var cmd = new SQLiteCommand(_conn);
+            cmd.CommandText = @"VACUUM";
+            cmd.PrepareAsync();
+
+            cmd.ExecuteNonQuery();
         }
 
         internal void FillFullPath()


### PR DESCRIPTION
Remove the unnecessary default [ROWID](https://www.sqlite.org/withoutrowid.html) column from the databases since we manually set and use a PRIMARY KEY. This reduces the total database size in my test compile from 7,745,536 bytes to 5,226,496 bytes. This will only effect *new* databases, existing ones will not benefit from this.

Set the [JOURNAL_MODE](https://www.sqlite.org/pragma.html#pragma_journal_mode) to MEMORY, this massively reduces disk IO as the default is to write and delete the journal file _every transaction_. However, if Wabbajack were to crash during a transaction, it could potentially corrupt the store. Considering that outright crashes are rare (and the databases aren't super important if they did break), I think this is a fine trade.

Run [VACUUM](https://sqlite.org/lang_vacuum.html) after every install/compile. This further reduces the database size quite considerably, 5,226,496 bytes to 3,518,464 bytes. This command is quite fast and can process a 280K row table in 1.3s (Hash cache after installing Skyrimified). I'm looking for feedback on if this change is implemented in the correct location.