### PR TITLE
Fix detection of Windows 10 versions

### DIFF
--- a/Wabbajack/Views/MainWindow.xaml.cs
+++ b/Wabbajack/Views/MainWindow.xaml.cs
@@ -42,7 +42,8 @@ namespace Wabbajack
 
                 Utils.Log($"Detected Windows Version: {p.WindowsVersion}");
 
-                if (!(p.WindowsVersion.Major >= 6 && p.WindowsVersion.Minor >= 2))
+                if (!((p.WindowsVersion.Major >= 10 && p.WindowsVersion.Minor >= 0) ||
+                      (p.WindowsVersion.Major >=  6 && p.WindowsVersion.Minor >= 2)))
                     Utils.Log(
                         $"You are not running a recent version of Windows (version 10 or greater), Wabbajack is not supported on OS versions older than Windows 10.");
 
@@ -83,7 +84,7 @@ namespace Wabbajack
             catch (Exception ex)
             {
                 Utils.LogStraightToFile("Error");
-                Utils.LogStraightToFile(ex.ToString()); 
+                Utils.LogStraightToFile(ex.ToString());
                 Environment.Exit(-1);
             }
         }

--- a/Wabbajack/Views/MainWindow.xaml.cs
+++ b/Wabbajack/Views/MainWindow.xaml.cs
@@ -42,8 +42,7 @@ namespace Wabbajack
 
                 Utils.Log($"Detected Windows Version: {p.WindowsVersion}");
 
-                if (!((p.WindowsVersion.Major >= 10 && p.WindowsVersion.Minor >= 0) ||
-                      (p.WindowsVersion.Major >=  6 && p.WindowsVersion.Minor >= 2)))
+                if (!(p.WindowsVersion.Major >= 10 && p.WindowsVersion.Minor >= 0))
                     Utils.Log(
                         $"You are not running a recent version of Windows (version 10 or greater), Wabbajack is not supported on OS versions older than Windows 10.");
 


### PR DESCRIPTION
I'm honestly a little skeptical of this.  My logs are indeed reporting my version as `10.0.19042.0` which makes sense for version 20H2.  The main question I have is why was it checking 6.2 before and why WJ seems to think I have a different version of Windows now.