### PR TITLE
Disk info utility and Reduce HDD threads option.

### DIFF
--- a/Wabbajack.Common/Util/PhysicalDisk.cs
+++ b/Wabbajack.Common/Util/PhysicalDisk.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Linq;
+using System.Management;
+
+namespace Wabbajack.Common
+{
+    public class PhysicalDisk
+    {
+        public PhysicalDisk(string driveLetter)
+        {
+            if (driveLetter.Length == 2 && driveLetter[1] == ':') driveLetter = driveLetter.Remove(driveLetter.Length - 1);
+            if (driveLetter.Length == 3 && (driveLetter[1] == ':' && driveLetter[2] == '\\')) driveLetter = driveLetter.Remove(driveLetter.Length - 2);
+            if (driveLetter.Length > 3) Utils.Error("Incorrect drive name! Must be X, X: or X:\\");
+
+            Utils.Log($"Phsyical Disk: {driveLetter}");
+
+            // Connect to storage scope
+            var scope = new ManagementScope(@"\\.\root\microsoft\windows\storage");
+            scope.Connect();
+
+            // Search partitions that use requested the drive letter
+            var partitionSearcher = new ManagementObjectSearcher($"SELECT DiskNumber FROM MSFT_Partition WHERE DriveLetter='{driveLetter}'");
+            partitionSearcher.Scope = scope;
+            // Get first partition that matches
+            var partition = partitionSearcher.Get().OfType<ManagementObject>().First();
+
+            // Search for a disk where the device ID matches the one we got from the partition
+            var physicalSearcher = new ManagementObjectSearcher($"SELECT * FROM MSFT_PhysicalDisk WHERE DeviceId='{partition["DiskNumber"]}'");
+            physicalSearcher.Scope = scope;
+            // Get disk information
+            var physical = physicalSearcher.Get().Cast<ManagementBaseObject>().Single();
+
+            DriveLetter = driveLetter;
+            DeviceId = (string)physical["DeviceId"];
+            MediaType = (MediaTypes)Convert.ToInt32(physical["MediaType"]);
+            BusType = (BusTypes)Convert.ToInt32(physical["BusType"]);
+        }
+
+        public string DriveLetter { get; }
+
+        public string DeviceId { get;  }
+
+        public MediaTypes MediaType { get; }
+
+        public BusTypes BusType { get; }
+
+        // https://docs.microsoft.com/en-us/previous-versions/windows/desktop/stormgmt/msft-physicaldisk#properties
+        public enum MediaTypes
+        {
+            Unspecified = 0,
+            HDD = 3,
+            SSD = 4,
+            SCM = 5
+        }
+
+        public enum BusTypes
+        {
+            Unknown = 0,
+            USB = 7,
+            SATA = 11,
+            NVMe = 17
+        }
+    }
+}

--- a/Wabbajack.Common/Wabbajack.Common.csproj
+++ b/Wabbajack.Common/Wabbajack.Common.csproj
@@ -57,6 +57,7 @@
         <PackageReference Include="SharpZipLib" Version="1.3.1" />
         <PackageReference Include="System.Data.HashFunction.xxHash" Version="2.0.0" />
         <PackageReference Include="System.Data.SQLite.Core" Version="1.0.113.7" />
+        <PackageReference Include="System.Management" Version="5.0.0" />
         <PackageReference Include="System.Net.Http" Version="4.3.4" />
         <PackageReference Include="System.Reactive" Version="5.0.0" />
         <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="5.0.0" />

--- a/Wabbajack.Lib/ABatchProcessor.cs
+++ b/Wabbajack.Lib/ABatchProcessor.cs
@@ -15,8 +15,9 @@ namespace Wabbajack.Lib
     {
         public WorkQueue Queue { get; } = new WorkQueue();
 
-        public int DownloadThreads { get; set; } = Environment.ProcessorCount;
+        public int DownloadThreads { get; set; } = Environment.ProcessorCount <= 8 ? Environment.ProcessorCount : 8;
         public int DiskThreads { get; set; } = Environment.ProcessorCount;
+        public bool ReduceHDDThreads { get; set; } = true;
         public bool FavorPerfOverRam { get; set; } = false;
         
         public Context VFS { get; }

--- a/Wabbajack.Lib/AInstaller.cs
+++ b/Wabbajack.Lib/AInstaller.cs
@@ -114,6 +114,7 @@ namespace Wabbajack.Lib
 
         public async Task InstallArchives()
         {
+
             var grouped = ModList.Directives
                 .OfType<FromArchive>()
                 .Select(a => new {VF = VFS.Index.FileForArchiveHashPath(a.ArchiveHashPath), Directive = a})
@@ -218,8 +219,6 @@ namespace Wabbajack.Lib
                 }
             }
 
-            DesiredThreads.OnNext(DownloadThreads);
-
             await missing.Where(a => a.State.GetType() != typeof(ManualDownloader.State))
                 .PMap(Queue, UpdateTracker, async archive =>
                 {
@@ -240,9 +239,6 @@ namespace Wabbajack.Lib
 
                     return await DownloadArchive(archive, download, outputPath);
                 });
-            
-            DesiredThreads.OnNext(DiskThreads);
-
         }
 
         private async Task SendDownloadMetrics(List<Archive> missing)
@@ -289,7 +285,7 @@ namespace Wabbajack.Lib
             var toHash = ModList.Archives.Where(a => hashDict.ContainsKey(a.Size)).SelectMany(a => hashDict[a.Size]).ToList();
             
             Utils.Log($"Found {allFiles.Count} total files, {toHash.Count} matching filesize");
-            
+
             var hashResults = await 
                 toHash
                 .PMap(Queue, UpdateTracker,async e => (await e.FileHashCachedAsync(), e)); 

--- a/Wabbajack/Settings.cs
+++ b/Wabbajack/Settings.cs
@@ -116,9 +116,10 @@ namespace Wabbajack
     {
         public PerformanceSettings()
         {
+            _reduceHDDThreads = true;
             _favorPerfOverRam = false;
             _diskThreads = Environment.ProcessorCount;
-            _downloadThreads = Environment.ProcessorCount;
+            _downloadThreads = Environment.ProcessorCount <= 8 ? Environment.ProcessorCount : 8;
         }
 
         private int _downloadThreads;
@@ -126,7 +127,10 @@ namespace Wabbajack
         
         private int _diskThreads;
         public int DiskThreads { get => _diskThreads; set => RaiseAndSetIfChanged(ref _diskThreads, value); }
-        
+
+        private bool _reduceHDDThreads;
+        public bool ReduceHDDThreads { get => _reduceHDDThreads; set => RaiseAndSetIfChanged(ref _reduceHDDThreads, value); }
+
         private bool _favorPerfOverRam;
         public bool FavorPerfOverRam { get => _favorPerfOverRam; set => RaiseAndSetIfChanged(ref _favorPerfOverRam, value); }
 
@@ -135,6 +139,7 @@ namespace Wabbajack
         {
             processor.DownloadThreads = DownloadThreads;
             processor.DiskThreads = DiskThreads;
+            processor.ReduceHDDThreads = ReduceHDDThreads;
             processor.FavorPerfOverRam = FavorPerfOverRam;
         }
     }

--- a/Wabbajack/Views/Settings/PerformanceSettingsView.xaml
+++ b/Wabbajack/Views/Settings/PerformanceSettingsView.xaml
@@ -26,6 +26,7 @@
                 <RowDefinition Height="25" />
                 <RowDefinition Height="25" />
                 <RowDefinition Height="25" />
+                <RowDefinition Height="25" />
                 <RowDefinition Height="*" />
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
@@ -67,10 +68,20 @@
                                Maximum="128"
                                Minimum="2" />
             <TextBlock Grid.Row="5" Grid.Column="0"
+                       x:Name="ReduceHDDThreadsLabel"
+                       VerticalAlignment="Center"
+                       Text="Reduce HDD threads (Recommended)" />
+            <CheckBox Grid.Row="5" Grid.Column="2"
+                      x:Name="ReduceHDDThreads"
+                      HorizontalAlignment="Right"
+                      VerticalAlignment="Center"
+                      Foreground="White"
+                ></CheckBox>
+            <TextBlock Grid.Row="6" Grid.Column="0"
                        x:Name="FavorPerfOverRamLabel"
                        VerticalAlignment="Center"
                        Text="Favor performance over RAM Usage" />
-            <CheckBox Grid.Row="5" Grid.Column="2"
+            <CheckBox Grid.Row="6" Grid.Column="2"
                       x:Name="FavorPerfOverRam"
                       HorizontalAlignment="Right"
                       VerticalAlignment="Center"

--- a/Wabbajack/Views/Settings/PerformanceSettingsView.xaml.cs
+++ b/Wabbajack/Views/Settings/PerformanceSettingsView.xaml.cs
@@ -39,6 +39,8 @@ namespace Wabbajack
                         vmToViewConverter: x => x,
                         viewToVmConverter: x => (int)(x ?? 0))
                     .DisposeWith(disposable);
+                this.BindStrict(this.ViewModel, x => x.ReduceHDDThreads, x => x.ReduceHDDThreads.IsChecked)
+                    .DisposeWith(disposable);
                 this.BindStrict(this.ViewModel, x => x.FavorPerfOverRam, x => x.FavorPerfOverRam.IsChecked)
                     .DisposeWith(disposable);
             });


### PR DESCRIPTION
Added a PhysicalDisk class that gives low level information about a drive, such as media type (HDD, SSD) and bus type (SATA, USB, NVMe).

I have added an option to the performance settings that when enabled (default) if a disk is detected as a hard drive, will reduce the disk threads for various steps.

I have moved the DesiredThread's from AInstaller to MO2Installer, where I have added a disk check and adjusted the thread count accordingly.

In my (albeit small) tests, hashing on a HDD has no improvement on any more than one thread, however install/extracting *seems* to improve slightly with two threads, as there is hanging on starting/finishing operations, so this always has *something* happening.

I have also set an initial maximum for the download threads to 8, a user can still adjust this if they want.

I'm unsure of the best practises here and don't know if we want to add more detection in other various places (such as if it's NVMe or USB, etc)