### PR TITLE
Wrap disk scope in try/catch, default to unspecified if error.

### DIFF
--- a/Wabbajack.Common/Util/PhysicalDisk.cs
+++ b/Wabbajack.Common/Util/PhysicalDisk.cs
@@ -12,37 +12,43 @@ namespace Wabbajack.Common
             if (driveLetter.Length == 3 && (driveLetter[1] == ':' && driveLetter[2] == '\\')) driveLetter = driveLetter.Remove(driveLetter.Length - 2);
             if (driveLetter.Length > 3) Utils.Error("Incorrect drive name! Must be X, X: or X:\\");
 
-            Utils.Log($"Phsyical Disk: {driveLetter}");
-
-            // Connect to storage scope
-            var scope = new ManagementScope(@"\\.\root\microsoft\windows\storage");
-            scope.Connect();
-
-            // Search partitions that use requested the drive letter
-            var partitionSearcher = new ManagementObjectSearcher($"SELECT DiskNumber FROM MSFT_Partition WHERE DriveLetter='{driveLetter}'");
-            partitionSearcher.Scope = scope;
-            // Get first partition that matches
-            var partition = partitionSearcher.Get().OfType<ManagementObject>().First();
-
-            // Search for a disk where the device ID matches the one we got from the partition
-            var physicalSearcher = new ManagementObjectSearcher($"SELECT * FROM MSFT_PhysicalDisk WHERE DeviceId='{partition["DiskNumber"]}'");
-            physicalSearcher.Scope = scope;
-            // Get disk information
-            var physical = physicalSearcher.Get().Cast<ManagementBaseObject>().Single();
-
             DriveLetter = driveLetter;
-            DeviceId = (string)physical["DeviceId"];
-            MediaType = (MediaTypes)Convert.ToInt32(physical["MediaType"]);
-            BusType = (BusTypes)Convert.ToInt32(physical["BusType"]);
+
+            try {
+
+                // Connect to storage scope
+                var scope = new ManagementScope(@"\\.\root\microsoft\windows\storage");
+                scope.Connect();
+
+                // Search partitions that use requested the drive letter
+                var partitionSearcher = new ManagementObjectSearcher($"SELECT DiskNumber FROM MSFT_Partition WHERE DriveLetter='{driveLetter}'");
+                partitionSearcher.Scope = scope;
+                // Get first partition that matches
+                var partition = partitionSearcher.Get().OfType<ManagementObject>().First();
+
+                // Search for a disk where the device ID matches the one we got from the partition
+                var physicalSearcher = new ManagementObjectSearcher($"SELECT * FROM MSFT_PhysicalDisk WHERE DeviceId='{partition["DiskNumber"]}'");
+                physicalSearcher.Scope = scope;
+                // Get disk information
+                var physical = physicalSearcher.Get().Cast<ManagementBaseObject>().Single();
+
+                DeviceId = (string)physical["DeviceId"];
+                MediaType = (MediaTypes)Convert.ToInt32(physical["MediaType"]);
+                BusType = (BusTypes)Convert.ToInt32(physical["BusType"]);
+            } 
+            catch (Exception ex)
+            {
+                Utils.Log($"Caught error getting disk info: {ex.Message}. Treating disk as Unspecified.");
+            }
         }
 
         public string DriveLetter { get; }
 
-        public string DeviceId { get;  }
+        public string DeviceId { get; } = "-1";
 
-        public MediaTypes MediaType { get; }
+        public MediaTypes MediaType { get; } = MediaTypes.Unspecified;
 
-        public BusTypes BusType { get; }
+        public BusTypes BusType { get; } = BusTypes.Unknown;
 
         // https://docs.microsoft.com/en-us/previous-versions/windows/desktop/stormgmt/msft-physicaldisk#properties
         public enum MediaTypes

--- a/Wabbajack.Lib/MO2Installer.cs
+++ b/Wabbajack.Lib/MO2Installer.cs
@@ -56,8 +56,6 @@ namespace Wabbajack.Lib
             await Metrics.Send(Metrics.BeginInstall, ModList.Name);
             Utils.Log("Configuring Processor");
 
-            if (new PhysicalDisk(OutputFolder.DriveInfo().Name).MediaType == PhysicalDisk.MediaTypes.HDD && ReduceHDDThreads) DesiredThreads.OnNext(1); else DesiredThreads.OnNext(DiskThreads);
-
             FileExtractor2.FavorPerfOverRAM = FavorPerfOverRam;
 
             if (GameFolder == null)
@@ -120,12 +118,12 @@ namespace Wabbajack.Lib
                 }
             }
 
+            // Reduce to one thread if downloads on HDD, else use specified. Hashing on HDD has no benefit with more threads.
+            if (new PhysicalDisk(DownloadFolder.DriveInfo().Name).MediaType == PhysicalDisk.MediaTypes.HDD && ReduceHDDThreads) DesiredThreads.OnNext(1); else DesiredThreads.OnNext(DiskThreads);
+
             if (cancel.IsCancellationRequested) return false;
             UpdateTracker.NextStep("Optimizing ModList");
             await OptimizeModlist();
-
-            // Reduce to one thread if downloads on HDD, else use specified. Hashing on HDD has no benefit with more threads.
-            if (new PhysicalDisk(DownloadFolder.DriveInfo().Name).MediaType == PhysicalDisk.MediaTypes.HDD && ReduceHDDThreads) DesiredThreads.OnNext(1); else DesiredThreads.OnNext(DiskThreads);
 
             if (cancel.IsCancellationRequested) return false;
             UpdateTracker.NextStep("Hashing Archives");


### PR DESCRIPTION
Should fix RAID drives and other odd edge cases. Defaults to Unspecified, which treats the disk as non-HDD.