### PR TITLE
Remove auto-vacuum task from PatchCache.

### DIFF
--- a/Wabbajack.Lib/ABatchProcessor.cs
+++ b/Wabbajack.Lib/ABatchProcessor.cs
@@ -185,7 +185,6 @@ namespace Wabbajack.Lib
                 {
                     Utils.Log("Vacuuming databases");
                     HashCache.VacuumDatabase();
-                    PatchCache.VacuumDatabase();
                     VirtualFile.VacuumDatabase();
                     Utils.Log("Vacuuming completed");
                     _isRunning.OnNext(false);


### PR DESCRIPTION
Gains are most likely in the megabytes, not worth the excessive time to run after each compile since this cache can get quite large.