### PR TITLE
More fixes to Origin game detection

### DIFF
--- a/Wabbajack.Common/GameMetaData.cs
+++ b/Wabbajack.Common/GameMetaData.cs
@@ -79,6 +79,7 @@ namespace Wabbajack.Common
         // to get these ids, split the numbers from the letters in file names found in
         // C:\ProgramData\Origin\LocalContent\{game name)\*.mfst
         // So for DA:O this is "DR208591800.mfst" -> "DR:208591800"
+        // EAPlay games may have @subscription appended to the file name
         public List<string> OriginIDs { get; set; } = new();
 
         public List<string> EpicGameStoreIDs { get; internal set; } = new List<string>();

--- a/Wabbajack.Common/StoreHandlers/OriginHandler.cs
+++ b/Wabbajack.Common/StoreHandlers/OriginHandler.cs
@@ -15,7 +15,7 @@ namespace Wabbajack.Common.StoreHandlers
 
         public override StoreType Type { get; internal set; } = StoreType.Origin;
 
-        private static Regex SplitRegex = new Regex("[0-9]+");
+        private static Regex SplitRegex = new Regex("(.*)([0-9]+)(@subscription)?", RegexOptions.RightToLeft);
         public override bool Init()
         {
             try
@@ -30,8 +30,8 @@ namespace Wabbajack.Common.StoreHandlers
                     {
                         var result = SplitRegex.Match(f);
                         if (result == null) return default;
-                        var a = f.Substring(0, result.Index);
-                        var b = f.Substring(result.Index);
+                        var a = result.Groups[1];
+                        var b = result.Groups[2];
                         return a + ":" + b;
                     })
                     .Where(t => t != default)


### PR DESCRIPTION
1. Games downloaded with EAPlay will have "@subscription" in their
   manifest file name.

2. Apparently numbers can be in the name of the manifest so you want
   to search from right-to-left.