### PR TITLE
add ability to include folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,15 @@ There are some special cases where you want to change the default Wabbajack beha
 | `WABBAJACK_ALWAYS_ENABLE` | The mod will not be ignored by Wabbajack even if it's disabled | Wabbajack will normally ignore all mods you disabled in MO2 but there are some cases where you might want to give some choice to the end user and want to have the mod included |
 | `WABBAJACK_ALWAYS_DISABLE` | The mod will always be ignored by Wabbajack | Useful if you don't want some mods included in the Modlist but still want to keep it active in your own setup |
 
+#### Folder Tags
+
+You can create an empty `tagfile` with no extention in any folder you want to apply this tags to. This is meant to be used with folders that aren't mods.
+
+| Flag/File | Description | Notes |
+|------|-------------|-------|
+| `WABBAJACK_INCLUDE` | All files in this folder will be inlined into the `.wabbajack` file | |
+| `WABBAJACK_NOMATCH_INCLUDE` | All files in this folder will be inlined into the `.wabbajack` file even if Wabbajack did not found a match for them | Useful for generated files.|
+
 #### Patches
 
 Reading all the previous section you might wonder if Wabbajack is able to detect modified files and how it deals with them. Wabbajack can't include the modified file so instead we just include the difference between the original and modified version.

--- a/Wabbajack.Lib/CompilationSteps/IncludeTaggedFolders.cs
+++ b/Wabbajack.Lib/CompilationSteps/IncludeTaggedFolders.cs
@@ -12,13 +12,13 @@ namespace Wabbajack.Lib.CompilationSteps
     {
         private readonly IEnumerable<AbsolutePath> _includeDirectly = new List<AbsolutePath>();
         private readonly string _tag;
-        private readonly NativeCompiler _nativeCompiler;
+        private readonly ACompiler _aCompiler;
         private readonly AbsolutePath _sourcePath;
 
         public IncludeTaggedFolders(ACompiler compiler, string tag) : base(compiler)
         {   
-            _nativeCompiler = (NativeCompiler)compiler;
-            _sourcePath = _nativeCompiler.SourcePath;
+            _aCompiler = (ACompiler)compiler;
+            _sourcePath = _aCompiler.SourcePath;
             _tag = tag;
             string rootDirectory = (string)_sourcePath;
 

--- a/Wabbajack.Lib/CompilationSteps/IncludeTaggedFolders.cs
+++ b/Wabbajack.Lib/CompilationSteps/IncludeTaggedFolders.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Wabbajack.Common;
+
+namespace Wabbajack.Lib.CompilationSteps
+{
+    public class IncludeTaggedFolders : ACompilationStep
+    {
+        private readonly IEnumerable<AbsolutePath> _includeDirectly = new List<AbsolutePath>();
+        private readonly string _tag;
+        private readonly NativeCompiler _nativeCompiler;
+        private readonly AbsolutePath _sourcePath;
+
+        public IncludeTaggedFolders(ACompiler compiler, string tag) : base(compiler)
+        {   
+            _nativeCompiler = (NativeCompiler)compiler;
+            _sourcePath = _nativeCompiler.SourcePath;
+            _tag = tag;
+            string rootDirectory = (string)_sourcePath;
+
+            _includeDirectly = Directory.EnumerateFiles(rootDirectory, _tag, SearchOption.AllDirectories).Select(str => (AbsolutePath)str.Replace(_tag, ""));
+        }
+
+
+        public override async ValueTask<Directive?> Run(RawSourceFile source)
+        {
+            foreach (var folderpath in _includeDirectly)
+            {
+                Utils.Log($"IncludeTaggedFolders Taggedfolder: {folderpath}");
+                if (!source.AbsolutePath.InFolder(folderpath)) continue;
+                var result = source.EvolveTo<InlineFile>();
+                result.SourceDataID = await _compiler.IncludeFile(source.AbsolutePath);
+                return result;
+            }
+
+            return null;
+        }
+    }
+
+}

--- a/Wabbajack.Lib/MO2Compiler.cs
+++ b/Wabbajack.Lib/MO2Compiler.cs
@@ -449,6 +449,7 @@ namespace Wabbajack.Lib
                 new IncludeModIniData(this),
                 new DirectMatch(this),
                 new IncludeTaggedMods(this, Consts.WABBAJACK_INCLUDE),
+                new IncludeTaggedFolders(this, Consts.WABBAJACK_INCLUDE),
                 new IgnoreEndsWith(this, ".pyc"),
                 new IgnoreEndsWith(this, ".log"),
                 new DeconstructBSAs(
@@ -478,6 +479,7 @@ namespace Wabbajack.Lib
                 new IncludeAllConfigs(this),
                 new zEditIntegration.IncludeZEditPatches(this),
                 new IncludeTaggedMods(this, Consts.WABBAJACK_NOMATCH_INCLUDE),
+                new IncludeTaggedFolders(this,Consts.WABBAJACK_NOMATCH_INCLUDE),
                 new IgnorePathContains(this,@"\Edit Scripts\Export\"),
                 new DropAll(this)
             };

--- a/Wabbajack.Lib/NativeCompiler.cs
+++ b/Wabbajack.Lib/NativeCompiler.cs
@@ -279,9 +279,11 @@ namespace Wabbajack.Lib
             return step[0] switch
             {
                 "IgnoreStartsWith" => new IgnoreStartsWith(this, step[1]),
+                "IncludeTaggedFolders" => new IncludeTaggedFolders(this, Consts.WABBAJACK_INCLUDE),
                 "IncludeConfigs" => new IncludeAllConfigs(this),
                 "IncludeDirectMatches" => new DirectMatch(this),
                 "IncludePatches" => new IncludePatches(this),
+                "IncludeMissingFilesInTaggedFolders" => new IncludeTaggedFolders(this, Consts.WABBAJACK_NOMATCH_INCLUDE),
                 _ => throw new ArgumentException($"No interpretation for step {step[0]}")
             };
         }


### PR DESCRIPTION
this adds a new way of making wabbajack include tagged folders in the .wabbajack file by placing a
`WABBAJACK_INCLUDE` or `WABBAJACK_NOMATCH_INCLUDE` file in the folder.