### PR TITLE
Added ability for WJ to ignore tagged folders.

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,10 @@ You can create an empty `tagfile` with no extention in any folder you want to ap
 | Flag/File | Description | Notes |
 |------|-------------|-------|
 | `WABBAJACK_INCLUDE` | All files in this folder will be inlined into the `.wabbajack` file | |
-| `WABBAJACK_NOMATCH_INCLUDE` | All files in this folder will be inlined into the `.wabbajack` file even if Wabbajack did not found a match for them | Useful for generated files.|
+| `WABBAJACK_NOMATCH_INCLUDE` | All files in this folder will be inlined into the `.wabbajack` file even if Wabbajack did not found a match for them. | Useful for generated files.|
+| `WABBAJACK_IGNORE` | All files in this folder will be ignored by Wabbajack and therefore not be put into into the `.wabbajack` file. | Useful for tools or other things outside a mod you don't want/need reproduced on a users machine. Handle with care since excluded stuff can potentially break a setup.\* |
+
+\*It will finish the installation of a modlist, but the installed list might not run if you excluded a crutial part of it.
 
 #### Patches
 

--- a/Wabbajack.Common/Consts.cs
+++ b/Wabbajack.Common/Consts.cs
@@ -46,6 +46,7 @@ namespace Wabbajack.Common
         public static string WABBAJACK_ALWAYS_ENABLE = "WABBAJACK_ALWAYS_ENABLE";
         public static string WABBAJACK_ALWAYS_DISABLE = "WABBAJACK_ALWAYS_DISABLE";
         public static string WABBAJACK_NOMATCH_INCLUDE = "WABBAJACK_NOMATCH_INCLUDE";
+        public static string WABBAJACK_IGNORE = "WABBAJACK_IGNORE";
 
         public static string GAME_PATH_MAGIC_BACK = "{--||GAME_PATH_MAGIC_BACK||--}";
         public static string GAME_PATH_MAGIC_DOUBLE_BACK = "{--||GAME_PATH_MAGIC_DOUBLE_BACK||--}";

--- a/Wabbajack.Lib/CompilationSteps/IgnoreTaggedFolders.cs
+++ b/Wabbajack.Lib/CompilationSteps/IgnoreTaggedFolders.cs
@@ -8,36 +8,36 @@ using Wabbajack.Common;
 
 namespace Wabbajack.Lib.CompilationSteps
 {
-    public class IncludeTaggedFolders : ACompilationStep
+    public class IgnoreTaggedFolders : ACompilationStep
     {
-        private readonly IEnumerable<AbsolutePath> _includeDirectly = new List<AbsolutePath>();
+        private readonly IEnumerable<AbsolutePath> _ignoreDirecrtory = new List<AbsolutePath>();
         private readonly string _tag;
         private readonly ACompiler _aCompiler;
         private readonly AbsolutePath _sourcePath;
+        private readonly string _reason;
 
-        public IncludeTaggedFolders(ACompiler compiler, string tag) : base(compiler)
-        {   
+        public IgnoreTaggedFolders(ACompiler compiler, string tag) : base(compiler)
+        {
             _aCompiler = (ACompiler)compiler;
             _sourcePath = _aCompiler.SourcePath;
             _tag = tag;
             string rootDirectory = (string)_sourcePath;
+            _reason = $"Ignored because folder was tagged with {_tag}";
 
-            _includeDirectly = Directory.EnumerateFiles(rootDirectory, _tag, SearchOption.AllDirectories).Select(str => (AbsolutePath)str.Replace(_tag, ""));
+            _ignoreDirecrtory = Directory.EnumerateFiles(rootDirectory, _tag, SearchOption.AllDirectories).Select(str => (AbsolutePath)str.Replace(_tag, ""));
         }
-
 
         public override async ValueTask<Directive?> Run(RawSourceFile source)
         {
-            foreach (var folderpath in _includeDirectly)
+            foreach (var folderpath in _ignoreDirecrtory)
             {
                 if (!source.AbsolutePath.InFolder(folderpath)) continue;
-                var result = source.EvolveTo<InlineFile>();
-                result.SourceDataID = await _compiler.IncludeFile(source.AbsolutePath);
+                var result = source.EvolveTo<IgnoredDirectly>();
+                result.Reason = _reason;
                 return result;
             }
 
             return null;
         }
     }
-
 }

--- a/Wabbajack.Lib/MO2Compiler.cs
+++ b/Wabbajack.Lib/MO2Compiler.cs
@@ -437,6 +437,7 @@ namespace Wabbajack.Lib
                 new IgnorePathContains(this, "SSEEdit Cache"),
                 new IgnoreOtherProfiles(this),
                 new IgnoreDisabledMods(this),
+                new IgnoreTaggedFolders(this,Consts.WABBAJACK_IGNORE),
                 new IncludeThisProfile(this),
                 // Ignore the ModOrganizer.ini file it contains info created by MO2 on startup
                 new IncludeStubbedConfigFiles(this),

--- a/Wabbajack.Lib/NativeCompiler.cs
+++ b/Wabbajack.Lib/NativeCompiler.cs
@@ -279,11 +279,12 @@ namespace Wabbajack.Lib
             return step[0] switch
             {
                 "IgnoreStartsWith" => new IgnoreStartsWith(this, step[1]),
+                "IgnoreTaggedFolders" => new IgnoreTaggedFolders(this, Consts.WABBAJACK_IGNORE),
                 "IncludeTaggedFolders" => new IncludeTaggedFolders(this, Consts.WABBAJACK_INCLUDE),
                 "IncludeConfigs" => new IncludeAllConfigs(this),
                 "IncludeDirectMatches" => new DirectMatch(this),
                 "IncludePatches" => new IncludePatches(this),
-                "IncludeMissingFilesInTaggedFolders" => new IncludeTaggedFolders(this, Consts.WABBAJACK_NOMATCH_INCLUDE),
+                "IncludeUnmatchedFilesInTaggedFolders" => new IncludeTaggedFolders(this, Consts.WABBAJACK_NOMATCH_INCLUDE),
                 _ => throw new ArgumentException($"No interpretation for step {step[0]}")
             };
         }


### PR DESCRIPTION
added:
+ ability to tag folders for ignoring
+ (instructions in the readme)

the `native_compiler_settings.json` in the Wiki for the NativeCompiler needs to be updated to:

```json
{
 "ModListName": "MechWarrior5Mercenaries",
 "CompilingGame": "MW5Test",
 "CompilationSteps": [
   ["IgnoreStartsWith", "downloads"],
   ["IgnoreTaggedFolders"],
   ["IncludeConfigs"],
   ["IncludeDirectMatches"],
   ["IncludePatches"],
   ["IncludeTaggedFolders"],
   ["IncludeUnmatchedFilesInTaggedFolders"] 
  ]

}
```