### PR TITLE
Ignore some unnecessary warnings and fix UTF-7 ignore.

### DIFF
--- a/Compression.BSA/Utils.cs
+++ b/Compression.BSA/Utils.cs
@@ -7,7 +7,7 @@ using Wabbajack.Common;
 using Path = Alphaleonis.Win32.Filesystem.Path;
 
 // Yeah, we know, but BSAs use UTF7, that's how old they are
-#pragma warning disable 618
+#pragma warning disable CS0618, SYSLIB0001
 
 namespace Compression.BSA
 {

--- a/Wabbajack.Lib/Wabbajack.Lib.csproj
+++ b/Wabbajack.Lib/Wabbajack.Lib.csproj
@@ -12,6 +12,7 @@
       </PackageReference>
       <PackageReference Include="CefSharp.OffScreen">
         <Version>89.0.170</Version>
+        <NoWarn>NU1701</NoWarn>
       </PackageReference>
       <PackageReference Include="F23.StringSimilarity">
         <Version>4.0.0</Version>

--- a/Wabbajack.sln
+++ b/Wabbajack.sln
@@ -141,6 +141,11 @@ Global
 		{BA8A3E49-60D2-4BA2-B285-CB09FFDB6D32}.Release|Any CPU.ActiveCfg = Release|x64
 		{BA8A3E49-60D2-4BA2-B285-CB09FFDB6D32}.Release|x64.ActiveCfg = Release|x64
 		{BA8A3E49-60D2-4BA2-B285-CB09FFDB6D32}.Release|x64.Build.0 = Release|x64
+		{44E30B97-D4A8-40A6-81D5-5CAB1F3D45CB}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{44E30B97-D4A8-40A6-81D5-5CAB1F3D45CB}.Debug|x64.ActiveCfg = Debug|x64
+		{44E30B97-D4A8-40A6-81D5-5CAB1F3D45CB}.Debug|x64.Build.0 = Debug|x64
+		{44E30B97-D4A8-40A6-81D5-5CAB1F3D45CB}.Release|Any CPU.ActiveCfg = Release|x64
+		{44E30B97-D4A8-40A6-81D5-5CAB1F3D45CB}.Release|x64.ActiveCfg = Release|x64
 		{3E11B700-8405-433D-BF47-6C356087A7C2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{3E11B700-8405-433D-BF47-6C356087A7C2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3E11B700-8405-433D-BF47-6C356087A7C2}.Debug|x64.ActiveCfg = Debug|Any CPU
@@ -157,7 +162,6 @@ Global
 		{9DEC8DC8-B6E0-469B-9571-C4BAC0776D07}.Release|Any CPU.Build.0 = Release|Any CPU
 		{9DEC8DC8-B6E0-469B-9571-C4BAC0776D07}.Release|x64.ActiveCfg = Release|Any CPU
 		{9DEC8DC8-B6E0-469B-9571-C4BAC0776D07}.Release|x64.Build.0 = Release|Any CPU
-		{44E30B97-D4A8-40A6-81D5-5CAB1F3D45CB}.Release|x64.ActiveCfg = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Wabbajack/Wabbajack.csproj
+++ b/Wabbajack/Wabbajack.csproj
@@ -57,9 +57,13 @@
   <ItemGroup>
     <PackageReference Include="cef.redist.x64" Version="89.0.17" />
       <PackageReference Include="CefSharp.Common" Version="89.0.170" />
-      <PackageReference Include="CefSharp.Wpf" Version="89.0.170" />
+      <PackageReference Include="CefSharp.Wpf" Version="89.0.170">
+        <NoWarn>NU1701</NoWarn>
+      </PackageReference>
     <PackageReference Include="DynamicData" Version="7.1.1" />
-    <PackageReference Include="Extended.Wpf.Toolkit" Version="4.0.2" />
+    <PackageReference Include="Extended.Wpf.Toolkit" Version="4.0.2">
+      <NoWarn>NU1701</NoWarn>
+    </PackageReference>
     <PackageReference Include="Fody" Version="6.5.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
- Ignore "This package was restored using [...]" compatibility warning [NU1701](https://docs.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu1701) for:
Wabbajack: CefSharp.Wpf, Extended.Wpf.Toolkit
Wabbajack.Lib: CefSharp.OffScreen

- Fix UTF-7 ignore in Compression.BSA, the warning code was changed in .NET 5.0: [SYSLIB0001](https://docs.microsoft.com/en-au/dotnet/core/compatibility/syslib-warnings/syslib0001).

- Added Run Configurations for Wabbajack.App.Test because my Visual Studio keeps wanting to for some reason.