### PR TITLE
Fix IPS4 verification and MEGA status percentage.

### DIFF
--- a/Wabbajack.Lib/Downloaders/AbstractIPS4Downloader.cs
+++ b/Wabbajack.Lib/Downloaders/AbstractIPS4Downloader.cs
@@ -250,10 +250,15 @@ namespace Wabbajack.Lib.Downloaders
                         return false;
                     }
 
+                    if (quickMode)
+                    {
+                        streamResult.Dispose();
+                        return true;
+                    }
+
                     await using (var os = await path.Create())
                     await using (var ins = await streamResult.Content.ReadAsStreamAsync())
                     {
-                        if (quickMode) return true;
                         if (a.Size == 0)
                         {
                             Utils.Status($"Downloading {a.Name}");

--- a/Wabbajack.Lib/Downloaders/AbstractIPS4Downloader.cs
+++ b/Wabbajack.Lib/Downloaders/AbstractIPS4Downloader.cs
@@ -253,6 +253,7 @@ namespace Wabbajack.Lib.Downloaders
                     await using (var os = await path.Create())
                     await using (var ins = await streamResult.Content.ReadAsStreamAsync())
                     {
+                        if (quickMode) return true;
                         if (a.Size == 0)
                         {
                             Utils.Status($"Downloading {a.Name}");

--- a/Wabbajack.Lib/Downloaders/MEGADownloader.cs
+++ b/Wabbajack.Lib/Downloaders/MEGADownloader.cs
@@ -175,7 +175,9 @@ namespace Wabbajack.Lib.Downloaders
 
                 var fileLink = new Uri(Url);
                 Utils.Status($"Downloading MEGA file: {a.Name}");
-                await MegaApiClient.DownloadFileAsync(fileLink, (string)destination, new Progress<double>(p => Utils.Status($"Downloading MEGA File: {a.Name}", Percent.FactoryPutInRange(p))));
+                await MegaApiClient.DownloadFileAsync(fileLink, (string)destination, new Progress<double>(p => 
+                    Utils.Status($"Downloading MEGA File: {a.Name}", Percent.FactoryPutInRange(p / 100d))
+                ));
                 return true;
             }
 


### PR DESCRIPTION
- Makes IPS4 downloader (non-Cloudflare) return before download if quickMode is true.

- Fixes MEGA's status percentage (MEGA reports 0-100, WJ 0-1).