### PR TITLE
fixed .txt based tagfiles

### DIFF
--- a/Wabbajack.Lib/CompilationSteps/IgnoreTaggedFiles.cs
+++ b/Wabbajack.Lib/CompilationSteps/IgnoreTaggedFiles.cs
@@ -10,7 +10,7 @@ namespace Wabbajack.Lib.CompilationSteps
 {
     public class IgnoreTaggedFiles : ACompilationStep
     {
-        private readonly List<AbsolutePath> _ignoreList = new List<AbsolutePath>();
+        private List<AbsolutePath> _ignoreList = new List<AbsolutePath>();
         private List<AbsolutePath> _tagFiles;
         private readonly string _tag;
         private readonly ACompiler _aCompiler;
@@ -18,13 +18,13 @@ namespace Wabbajack.Lib.CompilationSteps
         private readonly string _reason;
 
         public IgnoreTaggedFiles(ACompiler compiler, string tag) : base(compiler)
-        {   
+        {
             _aCompiler = (ACompiler)compiler;
             _sourcePath = _aCompiler.SourcePath;
             _tag = tag;
             string rootDirectory = (string)_sourcePath;
 
-            _reason = $"Ignored because folder was tagged with {_tag}";
+            _reason = $"Ignored because folder/file was tagged with {_tag}";
 
             _tagFiles = Directory.EnumerateFiles(rootDirectory, _tag, SearchOption.AllDirectories)
                 .Select(str => (AbsolutePath)str)
@@ -48,7 +48,7 @@ namespace Wabbajack.Lib.CompilationSteps
         {
             foreach (var folderpath in _ignoreList)
             {
-                if (!source.AbsolutePath.InFolder(folderpath)) continue;
+                if (!source.AbsolutePath.Equals(folderpath) || !source.AbsolutePath.InFolder(folderpath)) continue;
                 var result = source.EvolveTo<IgnoredDirectly>();
                 result.Reason = _reason;
                 return result;

--- a/Wabbajack.Lib/CompilationSteps/IncludeTaggedFiles.cs
+++ b/Wabbajack.Lib/CompilationSteps/IncludeTaggedFiles.cs
@@ -10,7 +10,7 @@ namespace Wabbajack.Lib.CompilationSteps
 {
     public class IncludeTaggedFiles : ACompilationStep
     {
-        private readonly List<AbsolutePath> _includeDirectly = new List<AbsolutePath>();
+        private List<AbsolutePath> _includeDirectly = new List<AbsolutePath>();
         private List<AbsolutePath> _tagFiles;
         private readonly string _tag;
         private readonly ACompiler _aCompiler;
@@ -45,7 +45,7 @@ namespace Wabbajack.Lib.CompilationSteps
         {
             foreach (var folderpath in _includeDirectly)
             {
-                if (!source.AbsolutePath.InFolder(folderpath)) continue;
+                if (!source.AbsolutePath.Equals(folderpath) || !source.AbsolutePath.InFolder(folderpath)) continue;
                 var result = source.EvolveTo<InlineFile>();
                 result.SourceDataID = await _compiler.IncludeFile(source.AbsolutePath);
                 return result;

--- a/Wabbajack.Lib/MO2Compiler.cs
+++ b/Wabbajack.Lib/MO2Compiler.cs
@@ -461,8 +461,7 @@ namespace Wabbajack.Lib
 
                 // There are some types of files that will error the compilation, because they're created on-the-fly via tools
                 // so if we don't have a match by this point, just drop them.
-                new IgnoreEndsWith(this, ".html"),
-                new IgnoreEndsWith(this, ".txt"),
+                new IgnoreEndsWith(this, ".html"),                
                 // Don't know why, but this seems to get copied around a bit
                 new IgnoreEndsWith(this, "HavokBehaviorPostProcess.exe"),
                 // Theme file MO2 downloads somehow
@@ -482,6 +481,7 @@ namespace Wabbajack.Lib
                 new IncludeTaggedMods(this, Consts.WABBAJACK_NOMATCH_INCLUDE),
                 new IncludeTaggedFolders(this,Consts.WABBAJACK_NOMATCH_INCLUDE),
                 new IncludeTaggedFiles(this,Consts.WABBAJACK_NOMATCH_INCLUDE_FILES),
+                new IncludeRegex(this, ".*\\.txt"),
                 new IgnorePathContains(this,@"\Edit Scripts\Export\"),
                 new IgnoreExtension(this, new Extension(".CACHE")),
                 new DropAll(this)


### PR DESCRIPTION
the .txt tag files that should contain a list of folders and files
only worked on folders cause I was big dumb, now it works for files AND folders.