### PR TITLE
Miscellaneous fixes and improvements.

### DIFF
--- a/Wabbajack.CLI/Verbs/Changelog.cs
+++ b/Wabbajack.CLI/Verbs/Changelog.cs
@@ -75,7 +75,7 @@ namespace Wabbajack.CLI.Verbs
 
             var mdText =
                 $"## {update.Version}\n\n" +
-                $"**Build at:** `{File.GetCreationTime(Update)}`\n\n" +
+                $"**Build at:** `{File.GetLastWriteTime(Update)}`\n\n" +
                 "**Info**:\n\n" +
                 $"- Download Size change: {downloadSizeChanges.ToFileSizeString()} (Total: {update.DownloadSize.ToFileSizeString()})\n" +
                 $"- Install Size change: {installSizeChanges.ToFileSizeString()} (Total: {update.InstallSize.ToFileSizeString()})\n\n";

--- a/Wabbajack.Common/Logging.cs
+++ b/Wabbajack.Common/Logging.cs
@@ -30,7 +30,7 @@ namespace Wabbajack.Common
         private static readonly Subject<IStatusMessage> LoggerSubj = new Subject<IStatusMessage>();
         public static IObservable<IStatusMessage> LogMessages => LoggerSubj;
 
-        public static async Task InitalizeLogging()
+        public static async Task InitializeLogging()
         {
             _startTime = DateTime.Now;
 

--- a/Wabbajack.Common/Logging.cs
+++ b/Wabbajack.Common/Logging.cs
@@ -126,7 +126,7 @@ namespace Wabbajack.Common
             if (!LoggingSettings.LogToFile || LogFile == default) return;
             lock (_logLock)
             {
-                File.AppendAllText(LogFile.ToString(), $"{(DateTime.Now - _startTime).TotalSeconds:0.##} - {msg}\r\n");
+                File.AppendAllText(LogFile.ToString(), $"{(DateTime.Now - _startTime).TotalSeconds:0.##} - {msg}\r\n", new UTF8Encoding(false, true));
             }
         }
 

--- a/Wabbajack.Common/Paths/AbsolutePath.cs
+++ b/Wabbajack.Common/Paths/AbsolutePath.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -209,6 +209,21 @@ namespace Wabbajack.Common
             return new RelativePath(relPath);
         }
 
+        public bool IsChildOf(AbsolutePath? parent)
+        {
+            if (parent is null) return false;
+            var child = this;
+            if (child == parent) return true;
+            while (child.Parent.Exists)
+            {
+                if (child.Parent == parent)
+                {
+                    return true;
+                }
+                child = child.Parent;
+            }
+            return false;
+        }
 
         public async Task<string> ReadAllTextAsync()
         {

--- a/Wabbajack.Common/Utils.cs
+++ b/Wabbajack.Common/Utils.cs
@@ -38,7 +38,7 @@ namespace Wabbajack.Common
 
         static Utils()
         {
-            InitalizeLogging().Wait();
+            InitializeLogging().Wait();
         }
 
         private static readonly string[] Suffix = {"B", "KB", "MB", "GB", "TB", "PB", "EB"}; // Longs run out around EB

--- a/Wabbajack.Lib/ABatchProcessor.cs
+++ b/Wabbajack.Lib/ABatchProcessor.cs
@@ -174,7 +174,12 @@ namespace Wabbajack.Lib
                 {
                     Utils.Log("Installation has Started");
                     _isRunning.OnNext(true);
-                    return await _Begin(_cancel.Token);
+                    var task = await _Begin(_cancel.Token);
+                    Utils.Log("Vacuuming databases");
+                    HashCache.VacuumDatabase();
+                    VirtualFile.VacuumDatabase();
+                    Utils.Log("Vacuuming completed");
+                    return task;
                 }
                 catch (Exception ex)
                 {
@@ -183,10 +188,6 @@ namespace Wabbajack.Lib
                 }
                 finally
                 {
-                    Utils.Log("Vacuuming databases");
-                    HashCache.VacuumDatabase();
-                    VirtualFile.VacuumDatabase();
-                    Utils.Log("Vacuuming completed");
                     _isRunning.OnNext(false);
                 }
             });

--- a/Wabbajack.Lib/MO2Installer.cs
+++ b/Wabbajack.Lib/MO2Installer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 using System.IO;
@@ -22,6 +22,7 @@ using File = Alphaleonis.Win32.Filesystem.File;
 using Path = Alphaleonis.Win32.Filesystem.Path;
 using SectionData = Wabbajack.Common.SectionData;
 using System.Collections.Generic;
+using Wabbajack.Common.IO;
 using Wabbajack.Lib.ModListRegistry;
 using Wabbajack.VirtualFileSystem;
 
@@ -503,14 +504,24 @@ namespace Wabbajack.Lib
             await OutputFolder.Combine(directive.To).WriteAllTextAsync(data);
         }
 
-        public static IErrorResponse CheckValidInstallPath(AbsolutePath path, AbsolutePath? downloadFolder)
+        public static IErrorResponse CheckValidInstallPath(AbsolutePath path, AbsolutePath? downloadFolder, GameMetaData? game)
         {
+            // Check if null path
+            if (string.IsNullOrEmpty(path.ToString())) return ErrorResponse.Fail("Please select an install directory.");
+
+            // Check if child of game folder
+            if (game?.TryGetGameLocation() != null && path.IsChildOf(game.TryGetGameLocation())) return ErrorResponse.Fail("Cannot install to game directory.");
+
+            // Check if child of Program Files
+            if (path.IsChildOf(new AbsolutePath(KnownFolders.ProgramFiles.Path))) return ErrorResponse.Fail("Cannot install to Program Files directory.");
+
+            // If the folder doesn't exist, it's empty so we don't need to check further
             if (!path.Exists) return ErrorResponse.Success;
 
             // Check folder does not have a Wabbajack ModList
             if (path.EnumerateFiles(false).Where(file => file.Exists).Any(file => file.Extension == Consts.ModListExtension))
             {
-                return ErrorResponse.Fail($"Cannot install into a folder with a Wabbajack ModList inside of it");
+                return ErrorResponse.Fail($"Cannot install into a folder with a Wabbajack ModList inside of it.");
             }
 
             // Check if folder is empty

--- a/Wabbajack.Lib/MO2Installer.cs
+++ b/Wabbajack.Lib/MO2Installer.cs
@@ -70,21 +70,19 @@ namespace Wabbajack.Lib
                 var otherGame = Game.CommonlyConfusedWith.Where(g => g.MetaData().IsInstalled).Select(g => g.MetaData()).FirstOrDefault();
                 if (otherGame != null)
                 {
-                    await Utils.Log(new CriticalFailureIntervention(
-                            $"In order to do a proper install Wabbajack needs to know where your {Game.HumanFriendlyGameName} folder resides. However this game doesn't seem to be installed, we did however find a installed " +
-                            $"copy of {otherGame.HumanFriendlyGameName}, did you install the wrong game?",
-                            $"Could not locate {Game.HumanFriendlyGameName}"))
-                        .Task;
+                    Utils.Error(new CriticalFailureIntervention(
+                        $"In order to do a proper install Wabbajack needs to know where your {Game.HumanFriendlyGameName} folder resides. However this game doesn't seem to be installed, we did however find an installed " +
+                        $"copy of {otherGame.HumanFriendlyGameName}, did you install the wrong game?",
+                        $"Could not locate {Game.HumanFriendlyGameName}"));
                 }
                 else
                 {
-                    await Utils.Log(new CriticalFailureIntervention(
-                            $"In order to do a proper install Wabbajack needs to know where your {Game.HumanFriendlyGameName} folder resides. However this game doesn't seem to be installed",
-                            $"Could not locate {Game.HumanFriendlyGameName}"))
-                        .Task;
+                    Utils.Error(new CriticalFailureIntervention(
+                        $"In order to do a proper install Wabbajack needs to know where your {Game.HumanFriendlyGameName} folder resides. However this game doesn't seem to be installed.",
+                        $"Could not locate {Game.HumanFriendlyGameName}"));
                 }
 
-                Utils.Log("Exiting because we couldn't find the game folder.");
+                Utils.Error("Exiting because we couldn't find the game folder.");
                 return false;
             }
 

--- a/Wabbajack.Lib/StatusMessages/CriticalFailureIntervention.cs
+++ b/Wabbajack.Lib/StatusMessages/CriticalFailureIntervention.cs
@@ -12,13 +12,17 @@ namespace Wabbajack.Lib
         private TaskCompletionSource<ConfirmationIntervention.Choice> _source = new TaskCompletionSource<ConfirmationIntervention.Choice>();
         public Task<ConfirmationIntervention.Choice> Task => _source.Task;
 
-        public CriticalFailureIntervention(string description, string title)
+        public CriticalFailureIntervention(string description, string title, bool exit = false)
         {
             ExtendedDescription = description;
             ShortDescription = title;
+            ExitApplication = exit;
         }
+
         public override string ShortDescription { get; }
         public override string ExtendedDescription { get; }
+        public bool ExitApplication { get; }
+
         public void Cancel()
         {
             _source.SetResult(ConfirmationIntervention.Choice.Abort);

--- a/Wabbajack.Test/MO2Tests.cs
+++ b/Wabbajack.Test/MO2Tests.cs
@@ -13,14 +13,14 @@ namespace Wabbajack.Test
         public async Task CheckValidInstallPath_Empty()
         {
             await using var tempDir = await TempFolder.Create();
-            Assert.True(MO2Installer.CheckValidInstallPath(tempDir.Dir, downloadFolder: null).Succeeded);
+            Assert.True(MO2Installer.CheckValidInstallPath(tempDir.Dir, null, null).Succeeded);
         }
 
         [Fact]
         public async Task CheckValidInstallPath_DoesNotExist()
         {
             await using var tempDir = await TempFolder.Create();
-            Assert.True(MO2Installer.CheckValidInstallPath(tempDir.Dir.Combine("Subfolder"), downloadFolder: null).Succeeded);
+            Assert.True(MO2Installer.CheckValidInstallPath(tempDir.Dir.Combine("Subfolder"), null, null).Succeeded);
         }
 
         [Fact]
@@ -29,7 +29,7 @@ namespace Wabbajack.Test
             await using var tempDir = await TempFolder.Create();
             await using var mo2 = await tempDir.Dir.Combine("ModOrganizer.exe").Create();
             await using var molist = await tempDir.Dir.Combine(((RelativePath)"modlist")).WithExtension(Consts.ModListExtension).Create();
-            Assert.False(MO2Installer.CheckValidInstallPath(tempDir.Dir, downloadFolder: null).Succeeded);
+            Assert.False(MO2Installer.CheckValidInstallPath(tempDir.Dir, null, null).Succeeded);
         }
 
         [Fact]
@@ -37,7 +37,7 @@ namespace Wabbajack.Test
         {
             await using var tempDir = await TempFolder.Create();
             await using var tmp = await tempDir.Dir.Combine(Consts.ModOrganizer2Exe).Create();
-            Assert.True(MO2Installer.CheckValidInstallPath(tempDir.Dir, downloadFolder: null).Succeeded);
+            Assert.True(MO2Installer.CheckValidInstallPath(tempDir.Dir, null, null).Succeeded);
         }
 
         [Fact]
@@ -47,7 +47,7 @@ namespace Wabbajack.Test
             await tempDir.Dir.DeleteDirectory();
             tempDir.Dir.CreateDirectory();
             await using var tmp = await tempDir.Dir.Combine($"someFile.txt").Create();
-            Assert.False(MO2Installer.CheckValidInstallPath(tempDir.Dir, downloadFolder: null).Succeeded);
+            Assert.False(MO2Installer.CheckValidInstallPath(tempDir.Dir, null, null).Succeeded);
         }
 
         [Fact]
@@ -57,7 +57,14 @@ namespace Wabbajack.Test
             var downloadsFolder = tempDir.Dir.Combine("downloads");
             downloadsFolder.CreateDirectory();
             await using var tmp = await tempDir.Dir.Combine($"downloads/someFile.txt").Create();
-            Assert.True(MO2Installer.CheckValidInstallPath(tempDir.Dir, downloadFolder: downloadsFolder).Succeeded);
+            Assert.True(MO2Installer.CheckValidInstallPath(tempDir.Dir, downloadsFolder, null).Succeeded);
+        }
+
+        [Fact]
+        public async Task CheckValidInstallPath_NullPath()
+        {
+            var tempDir = new AbsolutePath("", true);
+            Assert.True(MO2Installer.CheckValidInstallPath(tempDir, null, null).Succeeded == false);
         }
         #endregion
     }

--- a/Wabbajack/App.xaml.cs
+++ b/Wabbajack/App.xaml.cs
@@ -16,7 +16,7 @@ namespace Wabbajack
             Consts.LogsFolder.CreateDirectory();
 
             LoggingSettings.LogToFile = true;
-            Utils.InitalizeLogging().Wait();
+            Utils.InitializeLogging().Wait();
 
             CLIOld.ParseOptions(Environment.GetCommandLineArgs());
             if (CLIArguments.Help)

--- a/Wabbajack/View Models/Installers/InstallerVM.cs
+++ b/Wabbajack/View Models/Installers/InstallerVM.cs
@@ -97,13 +97,19 @@ namespace Wabbajack
 
         public InstallerVM(MainWindowVM mainWindowVM) : base(mainWindowVM)
         {
-           
-            if (Path.GetDirectoryName(Assembly.GetEntryAssembly().Location.ToLower()) == KnownFolders.Downloads.Path.ToLower())
+            if (AbsolutePath.EntryPoint.IsChildOf(new AbsolutePath(KnownFolders.Downloads.Path)))
             {
                 Utils.Error(new CriticalFailureIntervention(
                     "Wabbajack is running inside your Downloads folder. This folder is often highly monitored by antivirus software and these can often " +
-                    "conflict with the operations Wabbajack needs to perform. Please move this executable outside of your Downloads folder and then restart the app.",
-                    "Cannot run inside Downloads"));
+                    "conflict with the operations Wabbajack needs to perform. Please move Wabbajack outside of your Downloads folder and then restart the app.",
+                    "Cannot run inside Downloads", true));
+            }
+            else if (AbsolutePath.EntryPoint.IsChildOf(new AbsolutePath(KnownFolders.SkyDrive.Path)))
+            {
+                Utils.Error(new CriticalFailureIntervention(
+                    $"Wabbajack is running inside a OneDrive folder \"{new AbsolutePath(KnownFolders.SkyDrive.Path)}\". This folder is known to cause issues with Wabbajack. " +
+                    "Please move Wabbajack outside of your OneDrive folder and then restart the app.",
+                    "Cannot run inside OneDrive", true));
             }
 
             MWVM = mainWindowVM;

--- a/Wabbajack/View Models/Installers/MO2InstallerVM.cs
+++ b/Wabbajack/View Models/Installers/MO2InstallerVM.cs
@@ -63,7 +63,7 @@ namespace Wabbajack
                     this.WhenAny(x => x.DownloadLocation.TargetPath),
                     resultSelector: (target, download) => (target, download))
                 .ObserveOn(RxApp.TaskpoolScheduler)
-                .Select(i => MO2Installer.CheckValidInstallPath(i.target, i.download, Parent.ModList.SourceModList.GameType.MetaData()))
+                .Select(i => MO2Installer.CheckValidInstallPath(i.target, i.download, Parent.ModList?.SourceModList.GameType.MetaData()))
                 .ObserveOnGuiThread();
 
             _CanInstall = Observable.CombineLatest(

--- a/Wabbajack/View Models/Installers/MO2InstallerVM.cs
+++ b/Wabbajack/View Models/Installers/MO2InstallerVM.cs
@@ -63,7 +63,7 @@ namespace Wabbajack
                     this.WhenAny(x => x.DownloadLocation.TargetPath),
                     resultSelector: (target, download) => (target, download))
                 .ObserveOn(RxApp.TaskpoolScheduler)
-                .Select(i => MO2Installer.CheckValidInstallPath(i.target, i.download))
+                .Select(i => MO2Installer.CheckValidInstallPath(i.target, i.download, Parent.ModList.SourceModList.GameType.MetaData()))
                 .ObserveOnGuiThread();
 
             _CanInstall = Observable.CombineLatest(
@@ -83,7 +83,7 @@ namespace Wabbajack
                 {
                     if (DownloadLocation.TargetPath == default || DownloadLocation.TargetPath == installPath)
                     {
-                        DownloadLocation.TargetPath = installPath.Combine("downloads");
+                        if (installPath.Exists) DownloadLocation.TargetPath = installPath.Combine("downloads");
                     }
                 })
                 .DisposeWith(CompositeDisposable);

--- a/Wabbajack/View Models/MainWindowVM.cs
+++ b/Wabbajack/View Models/MainWindowVM.cs
@@ -77,9 +77,9 @@ namespace Wabbajack
                 .Bind(Log)
                 .Subscribe()
                 .DisposeWith(CompositeDisposable);
-            
+
             Utils.LogMessages
-                .OfType<IUserIntervention>()
+                .Where(a => a is IUserIntervention or CriticalFailureIntervention)
                 .ObserveOnGuiThread()
                 .SelectTask(async msg =>
                 {
@@ -93,9 +93,9 @@ namespace Wabbajack
                         Utils.Error(ex, $"Error while handling user intervention of type {msg?.GetType()}");
                         try
                         {
-                            if (!msg.Handled)
+                            if (msg is IUserIntervention {Handled: false} intervention)
                             {
-                                msg.Cancel();
+                                intervention.Cancel();
                             }
                         }
                         catch (Exception cancelEx)


### PR DESCRIPTION
While working on other things, I've made some small changes I figured I should split into their own PR, an Omni-PR if you will.

While I can't find any immediate problems in my testing, a few people to test would be appreciated.

1. Specify UTF-8 without BOM in logging so Discord can show previews.
2. Make the changelog generated use LastWriteTime to avoid incorrect time if a list with the same file name is compiled.
3. Added an IsChildOf function to AbsolutePath, returns if the path is a child of a given path.
4. Fixed typo `InitalizeLogging -> InitializeLogging`
5. Fix and improve valid install path checks:
+ Fail if child of game folder.
+ Fail if child of Program Files.
+ Add test for null path.
+ Fix success if path null.
+ Check if install path exists before updating download path.
6. Vacuum databases after task completes rather than in the finally clause.
7. Fix CriticalFailureIntervention never being handled. (Can also specify if application should exit.)
+ **With these changes, on installing a list, if Wabbajack is run from Downloads or OneDrive, it will show a message to the user and then exit when they click OK.**
I tried implementing a better error that would prevent a user from progressing, but couldn't immediately figure it out, so I settled for this, but can remove it if needed.