### PR TITLE
Logging Quality of Life updates

### DIFF
--- a/Wabbajack.Common/CircuitBreaker/WithAutoRetry.cs
+++ b/Wabbajack.Common/CircuitBreaker/WithAutoRetry.cs
@@ -27,7 +27,7 @@ namespace Wabbajack.Common
                 retries += 1;
                 if (retries > maxRetries)
                     throw;
-                Utils.Log($"(Retry {retries} of {maxRetries}), got exception {ex.Message}, waiting {delay!.Value.TotalMilliseconds}ms");
+                Utils.Warn($"(Retry {retries} of {maxRetries}), got exception {ex.Message}, waiting {delay!.Value.TotalMilliseconds}ms");
                 await Task.Delay(delay.Value);
                 delay = delay * multipler;
                 goto TOP;
@@ -51,7 +51,7 @@ namespace Wabbajack.Common
                 retries += 1;
                 if (retries > maxRetries)
                     throw;
-                Utils.Log($"(Retry {retries} of {maxRetries}), got exception {ex.Message}, waiting {delay!.Value.TotalMilliseconds}ms");
+                Utils.Warn($"(Retry {retries} of {maxRetries}), got exception {ex.Message}, waiting {delay!.Value.TotalMilliseconds}ms");
                 await Task.Delay(delay.Value);
                 delay = delay * multipler;
                 goto TOP;
@@ -76,7 +76,7 @@ namespace Wabbajack.Common
                 retries += 1;
                 if (retries > maxRetries)
                     throw;
-                Utils.Log($"(Retry {retries} of {maxRetries}), got exception {ex.Message}, waiting {delay!.Value.TotalMilliseconds}ms");
+                Utils.Warn($"(Retry {retries} of {maxRetries}), got exception {ex.Message}, waiting {delay!.Value.TotalMilliseconds}ms");
                 await Task.Delay(delay.Value);
                 delay = delay * multipler;
                 goto TOP;
@@ -99,7 +99,7 @@ namespace Wabbajack.Common
                 retries += 1;
                 if (retries > maxRetries)
                     throw;
-                Utils.Log($"(Retry {retries} of {maxRetries}), got exception {ex.Message}, waiting {delay!.Value.TotalMilliseconds}ms");
+                Utils.Warn($"(Retry {retries} of {maxRetries}), got exception {ex.Message}, waiting {delay!.Value.TotalMilliseconds}ms");
                 await Task.Delay(delay.Value);
                 delay = delay * multipler;
                 goto TOP;
@@ -123,7 +123,7 @@ namespace Wabbajack.Common
                 retries += 1;
                 if (retries > maxRetries)
                     throw;
-                Utils.Log($"(Retry {retries} of {maxRetries}), got exception {ex.Message}, waiting {delay!.Value.TotalMilliseconds}ms");
+                Utils.Warn($"(Retry {retries} of {maxRetries}), got exception {ex.Message}, waiting {delay!.Value.TotalMilliseconds}ms");
                 Thread.Sleep(delay.Value);
                 delay = delay * multipler;
                 goto TOP;

--- a/Wabbajack.Common/ProcessHelper.cs
+++ b/Wabbajack.Common/ProcessHelper.cs
@@ -75,8 +75,7 @@ namespace Wabbajack.Common
             {
                 if (string.IsNullOrEmpty(data.Data)) return;
                 Output.OnNext((StreamType.Error, data.Data));
-                if (LogError)
-                    Utils.Log($"{Path.FileName} ({p.Id}) StdErr: {data.Data}");
+                if (LogError) Utils.Error($"{Path.FileName} ({p.Id}) StdErr: {data.Data}");
             };
             p.ErrorDataReceived += ErrorEventHandler;
 

--- a/Wabbajack.Common/StatusFeed/Errors/7zipReturnError.cs
+++ b/Wabbajack.Common/StatusFeed/Errors/7zipReturnError.cs
@@ -11,23 +11,18 @@ namespace Wabbajack.Common.StatusFeed.Errors
         public AbsolutePath Destination { get; }
         public AbsolutePath Filename { get; }
         public int Code;
-        public string _7zip_output;
         public override string ShortDescription => $"7Zip returned an error while executing";
 
         public override string ExtendedDescription =>
             $@"7Zip.exe should always return 0 when it finishes executing. While extracting {(string)Filename} 7Zip encountered some error and
-instead returned {Code} which indicates there was an error. The archive might be corrupt or in a format that 7Zip cannot handle. Please verify the file is valid and that you
-haven't run out of disk space in the {(string)Destination} folder.
+            instead returned {Code} which indicates there was an error. The archive might be corrupt or in a format that 7Zip cannot handle. Please verify the file is valid and that you
+            haven't run out of disk space on your {Destination.DriveInfo().Name} drive.";
 
-7Zip Output:
-{_7zip_output}";
-
-        public _7zipReturnError(int code, AbsolutePath filename, AbsolutePath destination, string output)
+        public _7zipReturnError(int code, AbsolutePath filename, AbsolutePath destination)
         {
             Code = code;
             Filename = filename;
             Destination = destination;
-            _7zip_output = output;
         }
     }
 }

--- a/Wabbajack.Common/StoreHandlers/EpicGameStoreHandler.cs
+++ b/Wabbajack.Common/StoreHandlers/EpicGameStoreHandler.cs
@@ -28,7 +28,7 @@ namespace Wabbajack.Common.StoreHandlers
                 var name = eosKey.GetValue("ModSdkMetadataDir");
                 if (name == null)
                 {
-                    Utils.Log("Registry key entry does not exist for Epic Game store");
+                    Utils.Warn("Registry key entry does not exist for Epic Game store");
                     return false;
                 }
 
@@ -42,23 +42,26 @@ namespace Wabbajack.Common.StoreHandlers
                     try
                     {
                         var item = itm.FromJson<EpicGameItem>();
-                        Utils.Log($"Found Epic Game Store Game: {item.DisplayName} at {item.InstallLocation}");
-
                         if (byID.TryGetValue(item.CatalogItemId, out var game))
                         {
+                            Utils.Log($"Found Epic Game Store Game: \"{item.DisplayName}\" ({item.CatalogItemId}) at {item.InstallLocation}");
                             Games.Add(new EpicStoreGame(game, item));
+                        }
+                        else
+                        {
+                            Utils.Trace($"Epic Game Store Game \"{item.DisplayName}\" ({item.CatalogItemId}) is not supported");
                         }
                     }
                     catch (Newtonsoft.Json.JsonReaderException)
                     {
-                        Utils.Log($"Failure parsing Epic Game Store manifest: {itm}");
+                        Utils.Error($"Failure parsing Epic Game Store manifest: {itm}");
                     }
 
                 }
             }
             catch (NullReferenceException)
             {
-                Utils.Log("Epic Game Store is does not appear to be installed");
+                Utils.Log("Epic Game Store does not appear to be installed");
                 return false;
             }
 

--- a/Wabbajack.Common/StoreHandlers/GOGHandler.cs
+++ b/Wabbajack.Common/StoreHandlers/GOGHandler.cs
@@ -104,7 +104,7 @@ namespace Wabbajack.Common.StoreHandlers
                     
                     if (gameMeta == null)
                     {
-                        Utils.Log($"GOG Game \"{gameName}\" ({gameID}) is not supported, skipping");
+                        Utils.Trace($"GOG Game \"{gameName}\" ({gameID}) is not supported");
                         return;
                     }
 
@@ -125,7 +125,7 @@ namespace Wabbajack.Common.StoreHandlers
             }
             catch (Exception e)
             {
-                Utils.ErrorThrow(e);
+                Utils.Fatal(e);
             }
 
             Utils.Log($"Total number of GOG Games found: {Games.Count}");

--- a/Wabbajack.Common/StoreHandlers/OriginHandler.cs
+++ b/Wabbajack.Common/StoreHandlers/OriginHandler.cs
@@ -49,7 +49,7 @@ namespace Wabbajack.Common.StoreHandlers
                     }
                     catch (Exception ex)
                     {
-                        Utils.Log($"Origin got {ex.Message} when loading info for {known}");
+                        Utils.Warn($"Origin got {ex.Message} when loading info for {known}");
                         continue;
                     }
 
@@ -84,7 +84,7 @@ namespace Wabbajack.Common.StoreHandlers
             }
             catch (Exception ex)
             {
-                Utils.Log(ex.ToString());
+                Utils.Error(ex.ToString());
                 return false;
             }
         }
@@ -137,7 +137,7 @@ namespace Wabbajack.Common.StoreHandlers
             var matchPath = Regex.Match(path, @"\[(.*?)\\(.*)\\(.*)\](.*)");
             if (!matchPath.Success)
             {
-                Utils.Log("Unknown path format " + path);
+                Utils.Warn("Unknown path format " + path);
                 return default;
             }
 

--- a/Wabbajack.Common/StoreHandlers/SteamHandler.cs
+++ b/Wabbajack.Common/StoreHandlers/SteamHandler.cs
@@ -100,7 +100,7 @@ namespace Wabbajack.Common.StoreHandlers
 
                 if (!path.Exists)
                 {
-                    Utils.Log($"Directory {path} does not exist, skipping");
+                    Utils.Trace($"Directory {path} does not exist, skipping");
                     return;
                 }
 
@@ -124,7 +124,7 @@ namespace Wabbajack.Common.StoreHandlers
 
             if (SteamUniverses.Count == 0)
             {
-                Utils.Log("Could not find any Steam Libraries");
+                Utils.Warn("Could not find any Steam Libraries");
                 return false;
             }
 
@@ -179,7 +179,7 @@ namespace Wabbajack.Common.StoreHandlers
 
                     if (gameMeta == null)
                     {
-                        Utils.Log($"Steam Game \"{game.Name}\" ({game.ID}) is not supported, skipping");
+                        Utils.Trace($"Steam Game \"{game.Name}\" ({game.ID}) is not supported");
                         return;
                     }
 

--- a/Wabbajack.Common/Util/PhysicalDisk.cs
+++ b/Wabbajack.Common/Util/PhysicalDisk.cs
@@ -38,7 +38,7 @@ namespace Wabbajack.Common
             } 
             catch (Exception ex)
             {
-                Utils.Log($"Caught error getting disk info: {ex.Message}. Treating disk as Unspecified.");
+                Utils.Warn($"Caught error getting disk info: {ex.Message}. Treating disk as Unspecified.");
             }
         }
 

--- a/Wabbajack.Common/Utils.cs
+++ b/Wabbajack.Common/Utils.cs
@@ -789,7 +789,7 @@ namespace Wabbajack.Common
             }
             catch (Exception ex)
             {
-                Log($"Error encrypting data {key} {ex}");
+                Error($"Error encrypting data {key} {ex}");
                 throw;
             }
         }

--- a/Wabbajack.Lib/ClientAPI.cs
+++ b/Wabbajack.Lib/ClientAPI.cs
@@ -205,8 +205,8 @@ using Wabbajack.Lib.Downloaders;
                 }
                 catch (Exception ex)
                 {
-                    Utils.Log($"Verification error for failed for inferenced archive {result.State.PrimaryKeyString}");
-                    Utils.Log(ex.ToString());
+                    Utils.Error($"Verification error for failed for inferenced archive {result.State.PrimaryKeyString}");
+                    Utils.Error(ex.ToString());
                 }
             }
             return null;
@@ -224,7 +224,7 @@ using Wabbajack.Lib.Downloaders;
         public static async Task<Archive[]> GetModUpgrades(Hash src)
         {
             var client = await GetClient();
-            Utils.Log($"Looking for generic upgrade for {src} ({(long)src})");
+            Utils.Trace($"Looking for generic upgrade for {src} ({(long)src})");
             var results = await client.GetJsonAsync<Archive[]>($"{Consts.WabbajackBuildServerUri}mod_upgrade/find/{src.ToHex()}");
             return results;
         }

--- a/Wabbajack.Lib/CompilationSteps/DeconstructBSAs.cs
+++ b/Wabbajack.Lib/CompilationSteps/DeconstructBSAs.cs
@@ -85,7 +85,7 @@ namespace Wabbajack.Lib.CompilationSteps
             foreach (var match in matches)
             {
                 if (match is IgnoredDirectly)
-                    Utils.ErrorThrow(new UnconvertedError($"File required for BSA {source.Path} creation doesn't exist: {match.To}"));
+                    Utils.Fatal(new UnconvertedError($"File required for BSA {source.Path} creation doesn't exist: {match.To}"));
                 _mo2Compiler.ExtraFiles.Add(match);
             }
 

--- a/Wabbajack.Lib/CompilationSteps/IncludePatches.cs
+++ b/Wabbajack.Lib/CompilationSteps/IncludePatches.cs
@@ -121,7 +121,7 @@ namespace Wabbajack.Lib.CompilationSteps
             {
                 if (await ClientAPI.GetVirusScanResult(source.File.AbsoluteName) == VirusScanner.Result.Malware)
                 {
-                    Utils.ErrorThrow(new Exception($"Executable file {source.File.AbsoluteName} ({source.File}) has been marked as malware."));
+                    Utils.Fatal(new Exception($"Executable file {source.File.AbsoluteName} ({source.File}) has been marked as malware."));
                 }
             }
             

--- a/Wabbajack.Lib/DiskSpaceWatcher.cs
+++ b/Wabbajack.Lib/DiskSpaceWatcher.cs
@@ -26,12 +26,10 @@ namespace Wabbajack.Lib
 
         public async Task Start()
         {
-            Utils.Log(
-                $"Drive watcher is starting. Will warn at {(_minSpace * 2).ToFileSizeString()} and error at {_minSpace.ToFileSizeString()}");
+            Utils.Trace($"Drive watcher is starting. Will warn at {(_minSpace * 2).ToFileSizeString()} and error at {_minSpace.ToFileSizeString()}");
             foreach (var drive in _drives)
             {
-                Utils.Log(
-                    $"Starting Drive watcher on {drive.Name} currently {drive.AvailableFreeSpace.ToFileSizeString()} free out of {drive.TotalSize.ToFileSizeString()}");
+                Utils.Log($"Starting Drive watcher on {drive.Name} currently {drive.AvailableFreeSpace.ToFileSizeString()} free out of {drive.TotalSize.ToFileSizeString()}");
             }
 
             
@@ -43,13 +41,12 @@ namespace Wabbajack.Lib
                     if (used < _minSpace)
                     {
                         _onFailure(drive);
-                        Utils.ErrorThrow(new Exception($"Out of space on drive {drive.Name}"));
+                        Utils.Fatal(new Exception($"Out of space on drive {drive.Name}"));
                     }
 
                     if (used < _minSpace * 2)
                     {
-                        Utils.Log(
-                            $"Warning! Drive {drive.Name} only has {used.ToFileSizeString()} of free space left, processing will stop when you only have {used.ToFileSizeString()}");
+                        Utils.Warn($"Warning! Drive {drive.Name} only has {used.ToFileSizeString()} of free space left, processing will stop when you only have {used.ToFileSizeString()}");
                     }
                 }
 

--- a/Wabbajack.Lib/Downloaders/AbstractDownloadState.cs
+++ b/Wabbajack.Lib/Downloaders/AbstractDownloadState.cs
@@ -122,8 +122,8 @@ namespace Wabbajack.Lib.Downloaders
                 }
                 catch (Exception ex)
                 {
-                    Utils.Log($"Verification error for failed for possible upgrade {result.State.PrimaryKeyString}");
-                    Utils.Log(ex.ToString());
+                    Utils.Error($"Verification error for failed for possible upgrade {result.State.PrimaryKeyString}");
+                    Utils.Error(ex.ToString());
                 }
             }
 

--- a/Wabbajack.Lib/Downloaders/AbstractIPS4Downloader.cs
+++ b/Wabbajack.Lib/Downloaders/AbstractIPS4Downloader.cs
@@ -203,7 +203,7 @@ namespace Wabbajack.Lib.Downloaders
 
                     if (!Downloader.IsCloudFlareProtected && csrfKey == null)
                     {
-                        Utils.Log($"Returning null from IPS4 Downloader because no csrfKey was found");
+                        Utils.Error($"Returning null from IPS4 Downloader because no csrfKey was found");
                         return false;
                     }
 
@@ -220,7 +220,7 @@ namespace Wabbajack.Lib.Downloaders
 
                     if (a.Size == 0 || size == 0 || a.Size == size) return true;
 
-                    Utils.Log($"Bad Header Content sizes {a.Size} vs {size}");
+                    Utils.Error($"Bad Header Content sizes {a.Size} vs {size}");
                     return false;
 
                 }
@@ -228,7 +228,7 @@ namespace Wabbajack.Lib.Downloaders
                 var streamResult = await GetDownloadAsync(new Uri(url));
                 if (streamResult.StatusCode != HttpStatusCode.OK)
                 {
-                    Utils.ErrorThrow(new InvalidOperationException(), $"{Downloader.SiteName} servers reported an error for file: {FileID}");
+                    Utils.Fatal(new InvalidOperationException(), $"{Downloader.SiteName} servers reported an error for file: {FileID}");
                 }
 
                 var contentType = streamResult.Content.Headers.ContentType;
@@ -246,7 +246,7 @@ namespace Wabbajack.Lib.Downloaders
                     
                     if (a.Size != 0 && headerContentSize != 0 && a.Size != headerContentSize)
                     {
-                        Utils.Log($"Bad Header Content sizes {a.Size} vs {headerContentSize}");
+                        Utils.Error($"Bad Header Content sizes {a.Size} vs {headerContentSize}");
                         return false;
                     }
 
@@ -372,7 +372,7 @@ namespace Wabbajack.Lib.Downloaders
                 var csrfKey = await GetCsrfKey(token.Token);
                 if (csrfKey == null)
                 {
-                    Utils.Log($"Could not load CRSF key");
+                    Utils.Error($"Could not load CRSF key");
                     return new List<Archive>();
                 }
                 

--- a/Wabbajack.Lib/Downloaders/DownloadDispatcher.cs
+++ b/Wabbajack.Lib/Downloaders/DownloadDispatcher.cs
@@ -118,7 +118,7 @@ namespace Wabbajack.Lib.Downloaders
 
             if (!(archive.State is IUpgradingState))
             {
-                Utils.Log($"Download failed for {archive.Name} and no upgrade from this download source is possible");
+                Utils.Error($"Download failed for {archive.Name} and no upgrade from this download source is possible");
                 return DownloadResult.Failure;
             }
 
@@ -130,8 +130,7 @@ namespace Wabbajack.Lib.Downloaders
                 result = await AbstractDownloadState.ServerFindUpgrade(archive);
                 if (result == default)
                 {
-                    Utils.Log(
-                        $"No solution for broken download {archive.Name} {archive.State.PrimaryKeyString} could be found");
+                    Utils.Error($"No solution for broken download {archive.Name} ({archive.State.PrimaryKeyString}) could be found");
                     return DownloadResult.Failure;
                 }
             }
@@ -164,7 +163,7 @@ namespace Wabbajack.Lib.Downloaders
             var hash = await destination.FileHashCachedAsync();
             if (hash != archive.Hash && archive.Hash != default)
             {
-                Utils.Log("Archive hash didn't match after patching");
+                Utils.Error("Archive hash didn't match after patching");
                 return DownloadResult.Failure;
             }
 
@@ -210,12 +209,13 @@ namespace Wabbajack.Lib.Downloaders
                 var hash = await destination.FileHashCachedAsync();
                 if (hash == archive.Hash) return true;
 
-                Utils.Log($"Hashed download is incorrect");
+                Utils.Error($"Hashed download is incorrect");
                 return false;
 
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                Utils.Error($"Exception during download dispatch for \"{archive.Name}\": {ex.Message}", showInLog: false);
                 return false;
             }
         }

--- a/Wabbajack.Lib/Downloaders/HTTPDownloader.cs
+++ b/Wabbajack.Lib/Downloaders/HTTPDownloader.cs
@@ -104,6 +104,7 @@ namespace Wabbajack.Lib.Downloaders
                 if (!response.IsSuccessStatusCode) 
                 {
                     response.Dispose();
+                    Utils.Error($"\"{a.Name}\" responded with code {(int)response.StatusCode} while downloading!");
                     return false;
                 }
 
@@ -171,8 +172,7 @@ namespace Wabbajack.Lib.Downloaders
                                     throw;
                                 }
 
-                                Utils.Log(
-                                    $"Abort during download, trying to resume {Url} from {totalRead.ToFileSizeString()}");
+                                Utils.Error($"Abort during download, trying to resume {Url} from {totalRead.ToFileSizeString()}");
 
                                 var msg = new HttpRequestMessage(HttpMethod.Get, Url);
                                 msg.Headers.Range = new RangeHeaderValue(totalRead, null);
@@ -238,7 +238,7 @@ namespace Wabbajack.Lib.Downloaders
                 }
                 catch (HttpException ex)
                 {
-                    Utils.Log($"Error finding upgrade via HTTP to find Upgrade for {Url} {ex}");
+                    Utils.Error($"Error finding upgrade via HTTP to find Upgrade for {Url} {ex}");
                     return default;
                 }
 

--- a/Wabbajack.Lib/Downloaders/ModDBDownloader.cs
+++ b/Wabbajack.Lib/Downloaders/ModDBDownloader.cs
@@ -66,7 +66,7 @@ namespace Wabbajack.Lib.Downloaders
                     {
                         if (idx == urls.Length - 1)
                             throw;
-                        Utils.Log($"Download from {url} failed, trying next mirror");
+                        Utils.Error($"Download from {url} failed, trying next mirror");
                     }
                 }
                 return false;

--- a/Wabbajack.Lib/Downloaders/NexusDownloader.cs
+++ b/Wabbajack.Lib/Downloaders/NexusDownloader.cs
@@ -95,8 +95,7 @@ namespace Wabbajack.Lib.Downloaders
                 }
                 catch (FormatException)
                 {
-                    Utils.Log(
-                        $"Cannot parse ModID/FileID from {(string)general.gameName} {(string)general.modID} {(string)general.fileID}");
+                    Utils.Error($"Cannot parse ModID/FileID from {(string)general.gameName} {(string)general.modID} {(string)general.fileID}");
                     throw;
                 }
             }
@@ -121,7 +120,7 @@ namespace Wabbajack.Lib.Downloaders
                     _status = await Client.GetUserStatus();
                     if (!Client.IsAuthenticated)
                     {
-                        Utils.ErrorThrow(new UnconvertedError(
+                        Utils.Fatal(new UnconvertedError(
                             $"Authenticating for the Nexus failed. A nexus account is required to automatically download mods."));
                         return;
                     }
@@ -202,7 +201,7 @@ namespace Wabbajack.Lib.Downloaders
                 }
                 catch (NexusAPIQuotaExceeded ex)
                 {
-                    Utils.Log(ex.ExtendedDescription);
+                    Utils.Error(ex.ExtendedDescription);
                     throw;
                 }
                 catch (Exception)
@@ -232,7 +231,7 @@ namespace Wabbajack.Lib.Downloaders
                 }
                 catch (Exception ex)
                 {
-                    Utils.Log($"{Name} - {Game} - {ModID} - {FileID} - Error getting Nexus download URL - {ex}");
+                    Utils.Error($"{Name} - {Game} - {ModID} - {FileID} - Error getting Nexus download URL - {ex}");
                     return false;
                 }
 

--- a/Wabbajack.Lib/Downloaders/WabbajackCDNDownloader.cs
+++ b/Wabbajack.Lib/Downloaders/WabbajackCDNDownloader.cs
@@ -138,8 +138,8 @@ namespace Wabbajack.Lib.Downloaders
                         return await client.GetAsync(remap, retry: false, token: token);
                     }
                     retries += 1;
-                    Utils.Log($"Error reading {url} retrying [{retries}]");
-                    Utils.Log(ex.ToString());
+                    Utils.Error($"Error reading {url} retrying [{retries}]");
+                    Utils.Error(ex.ToString());
                     goto TOP;
                 }
             }

--- a/Wabbajack.Lib/Http/Client.cs
+++ b/Wabbajack.Lib/Http/Client.cs
@@ -65,10 +65,10 @@ namespace Wabbajack.Lib.Http
             using var result = await SendAsync(request, token: token);
             if (!result.IsSuccessStatusCode)
             {
-                Utils.Log("Internal Error");
-                Utils.Log(await result.Content.ReadAsStringAsync());
-                throw new Exception(
-                    $"Bad HTTP request {result.StatusCode} {result.ReasonPhrase} - {request.RequestUri}");
+                Utils.Error("Internal Error");
+                Utils.Error(await result.Content.ReadAsStringAsync());
+                Utils.Error(new Exception(
+                    $"Bad HTTP request {result.StatusCode} {result.ReasonPhrase} - {request.RequestUri}"));
             }
             return await result.Content.ReadAsStringAsync();
         }
@@ -111,7 +111,7 @@ namespace Wabbajack.Lib.Http
 
                     retries++;
                     var ms = Utils.NextRandom(100, 1000);
-                    Utils.Log($"Got a {http.Code} from {msg.RequestUri} retrying in {ms}ms");
+                    Utils.Warn($"Got a {http.Code} from {msg.RequestUri} retrying in {ms}ms");
 
                     await Task.Delay(ms, token ?? CancellationToken.None);
                     msg = CloneMessage(msg);
@@ -120,14 +120,12 @@ namespace Wabbajack.Lib.Http
                 if (retries > Consts.MaxHTTPRetries) throw;
 
                 retries++;
-                Utils.LogStraightToFile(ex.ToString());
-                Utils.Log($"Http Connect error to {msg.RequestUri} retry {retries}");
+                Utils.Error(ex, showInLog: false);
+                Utils.Error($"Http Connect error to {msg.RequestUri} retry {retries}");
                 await Task.Delay(100 * retries, token ?? CancellationToken.None);
                 msg = CloneMessage(msg);
                 goto TOP;
-
             }
-
         }
 
         private Dictionary<string, Func<(string Ip, string Host)>> _workaroundMappings = new()

--- a/Wabbajack.Lib/Http/ClientFactory.cs
+++ b/Wabbajack.Lib/Http/ClientFactory.cs
@@ -25,7 +25,7 @@ namespace Wabbajack.Lib.Http
                 AutomaticDecompression = DecompressionMethods.All,
 
             };
-            Utils.Log($"Configuring with SSL {_socketsHandler.SslOptions.EnabledSslProtocols}");
+            Utils.Trace($"Configuring with SSL {_socketsHandler.SslOptions.EnabledSslProtocols}");
 
             ServicePointManager.ServerCertificateValidationCallback +=
                 (sender, certificate, chain, errors) =>

--- a/Wabbajack.Lib/LauncherUpdater.cs
+++ b/Wabbajack.Lib/LauncherUpdater.cs
@@ -34,7 +34,7 @@ namespace Wabbajack.Lib
 
             if (CommonFolder.Value == AbsolutePath.EntryPoint)
             {
-                Utils.Log("Outside of standard install folder, not updating");
+                Utils.Trace("Outside of standard install folder, not updating");
                 return;
             }
 
@@ -52,7 +52,7 @@ namespace Wabbajack.Lib
 
             foreach (var (_, path) in oldVersions)
             {
-                Utils.Log($"Deleting old Wabbajack version at: {path}");
+                Utils.Trace($"Deleting old Wabbajack version at: {path}");
                 await path.DeleteDirectory();
             }
 
@@ -83,8 +83,7 @@ namespace Wabbajack.Lib
 
                 if (tempPath.Size != release.asset.Size)
                 {
-                    Utils.Log(
-                        $"Downloaded launcher did not match expected size: {tempPath.Size} expected {release.asset.Size}");
+                    Utils.Error($"Downloaded launcher did not match expected size: {tempPath.Size} expected {release.asset.Size}");
                     return;
                 }
 

--- a/Wabbajack.Lib/Metrics.cs
+++ b/Wabbajack.Lib/Metrics.cs
@@ -75,7 +75,7 @@ namespace Wabbajack.Lib
                 return;
 
             var key = await GetMetricsKey();
-            Utils.Log($"File hash check (-42) {key}");
+            Utils.Trace($"File hash check (-42) {key}", "");
             var client = new Http.Client();
             client.Headers.Add((Consts.MetricsKeyHeader, key));
             await client.GetAsync($"{Consts.WabbajackBuildServerUri}metrics/{action}/{subject}");

--- a/Wabbajack.Lib/NativeCompiler.cs
+++ b/Wabbajack.Lib/NativeCompiler.cs
@@ -52,7 +52,7 @@ namespace Wabbajack.Lib
                 new[] {SourcePath, DownloadsPath, GamePath, AbsolutePath.EntryPoint}, (long)2 << 31,
                 drive =>
                 {
-                    Utils.Log($"Aborting due to low space on {drive.Name}");
+                    Utils.Error($"Aborting due to low space on {drive.Name}");
                     Abort();
                 });
             var watcherTask = watcher.Start();
@@ -128,7 +128,7 @@ namespace Wabbajack.Lib
                 {
                     if (!VFS.Index.ByRootPath.ContainsKey(p))
                     {
-                        Utils.Log($"WELL THERE'S YOUR PROBLEM: {p} {VFS.Index.ByRootPath.Count}");
+                        Utils.Error($"WELL THERE'S YOUR PROBLEM: {p} {VFS.Index.ByRootPath.Count}");
                     }
 
                     return new RawSourceFile(VFS.Index.ByRootPath[p], p.RelativeTo(SourcePath));
@@ -143,7 +143,7 @@ namespace Wabbajack.Lib
             AllFiles.SetTo(mo2Files
                 .DistinctBy(f => f.Path));
 
-            Info($"Found {AllFiles.Count} files to build into mod list");
+            Utils.Log($"Found {AllFiles.Count} files to build into mod list");
 
             if (cancel.IsCancellationRequested)
             {
@@ -156,14 +156,13 @@ namespace Wabbajack.Lib
                 .Where(fs => fs.Count() > 1)
                 .Select(fs =>
                 {
-                    Utils.Log(
-                        $"Duplicate files installed to {fs.Key} from : {String.Join(", ", fs.Select(f => f.AbsolutePath))}");
+                    Utils.Error($"Duplicate files installed to {fs.Key} from : {String.Join(", ", fs.Select(f => f.AbsolutePath))}");
                     return fs;
                 }).ToList();
 
             if (dups.Count > 0)
             {
-                Error($"Found {dups.Count} duplicates, exiting");
+                Utils.Fatal(new Exception($"Found {dups.Count} duplicates, exiting"));
             }
 
             if (cancel.IsCancellationRequested)
@@ -203,7 +202,7 @@ namespace Wabbajack.Lib
 
             InstallDirectives.SetTo(results.Where(i => !(i is IgnoredDirectly)));
 
-            Info("Getting Nexus api_key, please click authorize if a browser window appears");
+            Utils.Log("Getting Nexus api_key, please click authorize if a browser window appears");
 
             UpdateTracker.NextStep("Building Patches");
             await BuildPatches();

--- a/Wabbajack.Lib/NexusApi/NexusApi.cs
+++ b/Wabbajack.Lib/NexusApi/NexusApi.cs
@@ -269,7 +269,7 @@ namespace Wabbajack.Lib.NexusApi
                 await UpdateRemaining(response);
                 if (!response.IsSuccessStatusCode)
                 {
-                    Utils.Log($"Nexus call failed: {response.RequestMessage!.RequestUri}");
+                    Utils.Error($"Nexus call failed: {response.RequestMessage!.RequestUri}");
                     throw new HttpException(response);
                 }
 
@@ -280,13 +280,13 @@ namespace Wabbajack.Lib.NexusApi
             {
                 if (retries == Consts.MaxHTTPRetries)
                     throw;
-                Utils.Log($"Nexus call to {url} failed, retrying {retries} of {Consts.MaxHTTPRetries}");
+                Utils.Error($"Nexus call to {url} failed, retrying {retries} of {Consts.MaxHTTPRetries}");
                 retries++;
                 goto TOP;
             }
             catch (Exception e)
             {
-                Utils.Log($"Nexus call failed `{url}`: " + e);
+                Utils.Error($"Nexus call failed `{url}`: " + e);
                 throw;
             }
         }
@@ -333,7 +333,7 @@ namespace Wabbajack.Lib.NexusApi
                 using var _ = await ManualDownloadLock.WaitAsync();
                 await Task.Delay(1000);
                 Utils.Log($"Requesting manual download for {archive.Name} {archive.PrimaryKeyString}");
-                return (await Utils.Log(await ManuallyDownloadNexusFile.Create(archive)).Task).ToString();
+                return (await Utils.Log(await ManuallyDownloadNexusFile.Create(archive), writeToFile: false).Task).ToString();
             }
             catch (TaskCanceledException ex)
             {

--- a/Wabbajack.Lib/Tasks/MigrateGameFolder.cs
+++ b/Wabbajack.Lib/Tasks/MigrateGameFolder.cs
@@ -10,7 +10,7 @@ namespace Wabbajack.Lib.Tasks
             var iniPath = mo2Folder.Combine(Consts.ModOrganizer2Ini);
             if (!iniPath.Exists)
             {
-                Utils.Log($"Game folder conversion failed, {Consts.ModOrganizer2Ini} does not exist in {mo2Folder}");
+                Utils.Error($"Game folder conversion failed, {Consts.ModOrganizer2Ini} does not exist in {mo2Folder}");
                 return false;
             }
 
@@ -20,7 +20,7 @@ namespace Wabbajack.Lib.Tasks
 
             if (!GameRegistry.TryGetByFuzzyName((string)gameIni.General.gameName, out var gameMeta))
             {
-                Utils.Log($"Could not locate game for {gameIni.General.gameName}");
+                Utils.Error($"Could not locate game for {gameIni.General.gameName}");
                 return false;
             }
 

--- a/Wabbajack.Lib/Validation/ValidateModlist.cs
+++ b/Wabbajack.Lib/Validation/ValidateModlist.cs
@@ -44,7 +44,7 @@ namespace Wabbajack.Lib.Validation
 
             Utils.Log("Running validation checks");
             var errors = await validator.Validate(modlist);
-            errors.Do(e => Utils.Log(e));
+            errors.Do(e => Utils.Error(e));
             if (errors.Count() > 0)
             {
                 throw new Exception($"{errors.Count()} validation errors found, cannot continue.");

--- a/Wabbajack.Lib/zEditIntegration.cs
+++ b/Wabbajack.Lib/zEditIntegration.cs
@@ -46,25 +46,25 @@ namespace Wabbajack.Lib
 
                         if (settings.modManager != "Mod Organizer 2")
                         {
-                            Utils.Log($"zEdit settings file {f}: modManager is not Mod Organizer 2 but {settings.modManager}!");
+                            Utils.Error($"zEdit settings file {f}: modManager is not Mod Organizer 2 but {settings.modManager}!");
                             return false;
                         }
 
                         if (settings.managerPath != _mo2Compiler.SourcePath)
                         {
-                            Utils.Log($"zEdit settings file {f}: managerPath is not {_mo2Compiler.SourcePath} but {settings.managerPath}!");
+                            Utils.Error($"zEdit settings file {f}: managerPath is not {_mo2Compiler.SourcePath} but {settings.managerPath}!");
                             return false;
                         }
 
                         if (settings.modsPath != _mo2Compiler.SourcePath.Combine(Consts.MO2ModFolderName))
                         {
-                            Utils.Log($"zEdit settings file {f}: modsPath is not {_mo2Compiler.SourcePath}\\{Consts.MO2ModFolderName} but {settings.modsPath}!");
+                            Utils.Error($"zEdit settings file {f}: modsPath is not {_mo2Compiler.SourcePath}\\{Consts.MO2ModFolderName} but {settings.modsPath}!");
                             return false;
                         }
 
                         if (settings.mergePath != _mo2Compiler.SourcePath.Combine(Consts.MO2ModFolderName))
                         {
-                            Utils.Log($"zEdit settings file {f}: modsPath is not {_mo2Compiler.SourcePath}\\{Consts.MO2ModFolderName} but {settings.modsPath}!");
+                            Utils.Error($"zEdit settings file {f}: modsPath is not {_mo2Compiler.SourcePath}\\{Consts.MO2ModFolderName} but {settings.modsPath}!");
                             return false;
                         }
 
@@ -73,7 +73,7 @@ namespace Wabbajack.Lib
 
                 if (!settingsFiles.Any())
                 {
-                    Utils.Log($"Found not acceptable settings.json file for zEdit!");
+                    Utils.Error($"Found not acceptable settings.json file for zEdit!");
                     return;
                 }
                 
@@ -84,7 +84,7 @@ namespace Wabbajack.Lib
 
                 if (profileFolder == default)
                 {
-                    Utils.Log("Found no acceptable profiles folder for zEdit!");
+                    Utils.Error("Found no acceptable profiles folder for zEdit!");
                     return;
                 }
 
@@ -97,8 +97,7 @@ namespace Wabbajack.Lib
                 merges.Where(m => m.Count() > 1)
                     .Do(m =>
                     {
-                        Utils.Log(
-                            $"WARNING, you have two patches named {m.Key.name}\\{m.Key.filename} in your zEdit profiles. We'll pick one at random, this probably isn't what you want.");
+                        Utils.Warn($"WARNING, you have two patches named {m.Key.name}\\{m.Key.filename} in your zEdit profiles. We'll pick one at random, this probably isn't what you want.");
                     });
 
                 _mergesIndexed =

--- a/Wabbajack.Server/Services/AbstractService.cs
+++ b/Wabbajack.Server/Services/AbstractService.cs
@@ -74,7 +74,7 @@ namespace Wabbajack.Server.Services
                         catch (Exception ex)
                         {
                             _logger.LogError(ex, "Running Service Loop");
-                            Utils.Log($"Error in service {this.GetType()} : {ex}");
+                            Utils.Error($"Error in service {this.GetType()} : {ex}");
                         }
 
                         var token = await _quickSync.GetToken<TP>();

--- a/Wabbajack.Server/Services/ListValidator.cs
+++ b/Wabbajack.Server/Services/ListValidator.cs
@@ -111,7 +111,7 @@ namespace Wabbajack.Server.Services
                     catch (Exception ex)
                     {
                         _logger.LogError(ex, $"During Validation of {archive.Hash} {archive.State.PrimaryKeyString}");
-                        Utils.Log($"Exception in validation of {archive.Hash} {archive.State.PrimaryKeyString} " + ex);
+                        Utils.Error($"Exception in validation of {archive.Hash} {archive.State.PrimaryKeyString} " + ex);
                         return (archive, ArchiveStatus.InValid);
                     }
                     finally
@@ -410,7 +410,7 @@ namespace Wabbajack.Server.Services
                             }
                             catch (Exception ex)
                             {
-                                Utils.Log("Exception in Nexus Validation " + ex);
+                                Utils.Error("Exception in Nexus Validation " + ex);
                                 mod = new ModInfo
                                 {
                                     mod_id = ns.ModID.ToString(),

--- a/Wabbajack.Server/Services/NexusKeyMaintainance.cs
+++ b/Wabbajack.Server/Services/NexusKeyMaintainance.cs
@@ -38,7 +38,7 @@ namespace Wabbajack.Server.Services
                 }
                 catch (Exception ex)
                 {
-                    Utils.Log($"Error getting tracking client: {ex}");
+                    Utils.Error($"Error getting tracking client: {ex}");
                 }
 
             }

--- a/Wabbajack.VirtualFileSystem/FileExtractor2/FileExtractor.cs
+++ b/Wabbajack.VirtualFileSystem/FileExtractor2/FileExtractor.cs
@@ -186,8 +186,8 @@ namespace Wabbajack.VirtualFileSystem
                     source = spoolFile.Path;
                 }
 
-                Utils.Log(new GenericInfo($"Extracting {(string)source.FileName}",
-                    $"The contents of {(string)source.FileName} are being extracted to {(string)source.FileName} using 7zip.exe"));
+                Utils.Log($"Extracting {(string)source.FileName}", writeToFile: false);
+                Utils.Log($"The contents of {(string)source.FileName} are being extracted to {(string)source.FileName} using 7zip.exe", showInLog: false);
 
                 var process = new ProcessHelper {Path = @"Extractors\7z.exe".RelativeTo(AbsolutePath.EntryPoint),};
 
@@ -232,7 +232,7 @@ namespace Wabbajack.VirtualFileSystem
 
                 if (exitCode != 0)
                 {
-                    Utils.ErrorThrow(new _7zipReturnError(exitCode, source, dest, ""));
+                    Utils.Fatal(new _7zipReturnError(exitCode, source, dest));
                 }
                 else
                 {

--- a/Wabbajack.VirtualFileSystem/VirtualFile.cs
+++ b/Wabbajack.VirtualFileSystem/VirtualFile.cs
@@ -245,7 +245,7 @@ namespace Wabbajack.VirtualFileSystem
             }
             catch (Exception)
             {
-                Utils.Log($"Error while examining the contents of {relPath.FileName}");
+                Utils.Error($"Error while examining the contents of {relPath.FileName}");
                 throw;
             }
 

--- a/Wabbajack/View Models/Gallery/ModListMetadataVM.cs
+++ b/Wabbajack/View Models/Gallery/ModListMetadataVM.cs
@@ -191,7 +191,7 @@ namespace Wabbajack
                 .ToGuiProperty(this, nameof(Exists));
 
             var imageObs = Observable.Return(Metadata.Links.ImageUri)
-                .DownloadBitmapImage((ex) => Utils.Log($"Error downloading modlist image {Metadata.Title}"));
+                .DownloadBitmapImage((ex) => Utils.Error($"Error downloading modlist image {Metadata.Title}"));
 
             _Image = imageObs
                 .ToGuiProperty(this, nameof(Image));

--- a/Wabbajack/Views/MainWindow.xaml.cs
+++ b/Wabbajack/Views/MainWindow.xaml.cs
@@ -31,12 +31,13 @@ namespace Wabbajack
                 AppDomain.CurrentDomain.UnhandledException += (sender, e) =>
                 {
                     // Don't do any special logging side effects
-                    Utils.LogStraightToFile("Error.");
-                    Utils.LogStraightToFile(((Exception)e.ExceptionObject).ToString());
+                    Utils.Error("Error.", showInLog: false);
+                    Utils.Error(((Exception)e.ExceptionObject).ToString(), showInLog: false);
                     Environment.Exit(-1);
                 };
 
                 Utils.Log($"Wabbajack Build - {ThisAssembly.Git.Sha}");
+                Utils.Log($"Time started: {DateTime.Now:o}");
                 Utils.Log($"Running in {AbsolutePath.EntryPoint}");
 
                 var p = SystemParametersConstructor.Create();
@@ -44,16 +45,14 @@ namespace Wabbajack
                 Utils.Log($"Detected Windows Version: {p.WindowsVersion}");
 
                 if (!(p.WindowsVersion.Major >= 10 && p.WindowsVersion.Minor >= 0))
-                    Utils.Log(
-                        $"You are not running a recent version of Windows (version 10 or greater), Wabbajack is not supported on OS versions older than Windows 10.");
+                    Utils.Error($"You are not running a recent version of Windows (version 10 or greater), Wabbajack is not supported on OS versions older than Windows 10.");
 
-                Utils.Log(
-                    $"System settings - ({p.SystemMemorySize.ToFileSizeString()} RAM) ({p.SystemPageSize.ToFileSizeString()} Page), Display: {p.ScreenWidth} x {p.ScreenHeight} ({p.VideoMemorySize.ToFileSizeString()} VRAM - VideoMemorySizeMb={p.EnbLEVRAMSize})");
+                Utils.Log($"System settings - ({p.SystemMemorySize.ToFileSizeString()} RAM) ({p.SystemPageSize.ToFileSizeString()} Page), Display: {p.ScreenWidth} x {p.ScreenHeight} ({p.VideoMemorySize.ToFileSizeString()} VRAM - VideoMemorySizeMb={p.EnbLEVRAMSize})");
 
                 if (p.SystemPageSize == 0)
-                    Utils.Log("Pagefile is disabled! Consider increasing to 20000MB. A disabled pagefile can cause crashes and poor in-game performance.");
+                    Utils.Warn("Pagefile is disabled! Consider increasing to 20000MB. A disabled pagefile can cause crashes and poor in-game performance.");
                 else if (p.SystemPageSize < 2e+10)
-                    Utils.Log("Pagefile below recommended! Consider increasing to 20000MB. A suboptimal pagefile can cause crashes and poor in-game performance.");
+                    Utils.Warn("Pagefile below recommended! Consider increasing to 20000MB. A suboptimal pagefile can cause crashes and poor in-game performance.");
 
                 Warmup();
                 
@@ -90,8 +89,8 @@ namespace Wabbajack
             }
             catch (Exception ex)
             {
-                Utils.LogStraightToFile("Error");
-                Utils.LogStraightToFile(ex.ToString());
+                Utils.Error("Error", showInLog: false);
+                Utils.Error(ex.ToString(), showInLog: false);
                 Environment.Exit(-1);
             }
         }
@@ -133,7 +132,7 @@ namespace Wabbajack
             }
             catch (Exception e)
             {
-                Utils.Log($"ExtensionManager had an exception:\n{e}");
+                Utils.Warn($"ExtensionManager had an exception:\n{e}");
             }
         }
 


### PR DESCRIPTION
This PR focuses on making the log files generated by Wabbajack easier to debug [read: prettier].
I've set this PR as a Draft to garner feedback and reviews.

There are now multiple logging levels, each with it's own function instead of one function with a level parameter.
\- `Utils.Trace("msg");` instead of `Utils.Log(Level.Trace, "msg");`
(The Info level function has remained `Utils.Log()` to reduce unnecessary refactoring)

The functions utilise `System.Runtime.CompilerService` to receive the CallerFilePath, which we then parse to get the calling file.

There are five levels currently specified:
- `Trace` receives a string and logs to file only.
- `Info` receives a string and logs to file and display. (Can specify to not write to an output.)
- `Warn` similar to Info.
- `Error` has two functions, one receives a string, the other an exception. Otherwise similar to Info.
- `Fatal` receives an exception, will throw after logging. (Can specify to not throw.)

I've done my best to accurately label logging with the correct levels, but there may be room for improvement and/or changes. There's quite a few files to go through but it should be pretty easy to cruise through since it's mostly renaming a single function. (`Utils.Log` -> `Utils.Error`, etc)

Other changes:
1. Log the time the program was started.
2. Removed the output string from 7zipReturnError as it was redundant and unused. (The StdErr stream is always logged.) and added the drive name to the description.
3. `MO2Installer.cs` now prints the failed download archive URL alongside the name.
4. Added additional error logging to `EpicGameStoreHandler.cs`, `DownloadDispatcher.cs`, `HTTPDownloader.cs`