### PR TITLE
Null check SourceModList

### DIFF
--- a/Wabbajack/View Models/Installers/MO2InstallerVM.cs
+++ b/Wabbajack/View Models/Installers/MO2InstallerVM.cs
@@ -63,7 +63,7 @@ namespace Wabbajack
                     this.WhenAny(x => x.DownloadLocation.TargetPath),
                     resultSelector: (target, download) => (target, download))
                 .ObserveOn(RxApp.TaskpoolScheduler)
-                .Select(i => MO2Installer.CheckValidInstallPath(i.target, i.download, Parent.ModList?.SourceModList.GameType.MetaData()))
+                .Select(i => MO2Installer.CheckValidInstallPath(i.target, i.download, Parent.ModList?.SourceModList?.GameType.MetaData()))
                 .ObserveOnGuiThread();
 
             _CanInstall = Observable.CombineLatest(


### PR DESCRIPTION
Fixes null exception when returning to MO2InstallerVM after a UserIntervention (such as manually downloading a Nexus file).