### PR TITLE
Fix missing KnownFolders

### DIFF
--- a/Wabbajack.Common/KnownFolders/KnownFolder.cs
+++ b/Wabbajack.Common/KnownFolders/KnownFolder.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
-#nullable disable
 
 namespace Wabbajack.Common.IO
 {
@@ -48,7 +47,7 @@ namespace Wabbajack.Common.IO
         /// Gets the default path of the folder. This does not require the folder to be existent.
         /// </summary>
         /// <exception cref="ExternalException">The known folder could not be retrieved.</exception>
-        public string DefaultPath
+        public string? DefaultPath
         {
             get => GetPath(KnownFolderFlags.DontVerify | KnownFolderFlags.DefaultPath);
         }
@@ -57,10 +56,14 @@ namespace Wabbajack.Common.IO
         /// Gets or sets the path as currently configured. This does not require the folder to be existent.
         /// </summary>
         /// <exception cref="ExternalException">The known folder could not be retrieved.</exception>
-        public string Path
+        public string? Path
         {
             get => GetPath(KnownFolderFlags.DontVerify);
-            set => SetPath(KnownFolderFlags.None, value);
+            set
+            {
+                if (value != null)
+                    SetPath(KnownFolderFlags.None, value);
+            }
         }
 
         /// <summary>
@@ -68,10 +71,14 @@ namespace Wabbajack.Common.IO
         /// This does not require the folder to be existent.
         /// </summary>
         /// <exception cref="ExternalException">The known folder could not be retrieved.</exception>
-        public string ExpandedPath
+        public string? ExpandedPath
         {
             get => GetPath(KnownFolderFlags.DontVerify | KnownFolderFlags.NoAlias);
-            set => SetPath(KnownFolderFlags.DontUnexpand, value);
+            set
+            {
+                if (value != null)
+                    SetPath(KnownFolderFlags.DontUnexpand, value);
+            }
         }
 
         // ---- METHODS (PUBLIC) ---------------------------------------------------------------------------------------
@@ -87,20 +94,17 @@ namespace Wabbajack.Common.IO
 
         // ---- METHODS (PRIVATE) --------------------------------------------------------------------------------------
 
-        private string GetPath(KnownFolderFlags flags)
+        private string? GetPath(KnownFolderFlags flags)
         {
             int result = SHGetKnownFolderPath(Type.GetGuid(), (uint)flags, Identity.Token, out IntPtr outPath);
-            if (result >= 0)
-            {
-                string path = Marshal.PtrToStringUni(outPath);
-                Marshal.FreeCoTaskMem(outPath);
-                return path;
-            }
-            else
-            {
-                throw new ExternalException("Cannot get the known folder path. It may not be available on this system.",
-                    result);
-            }
+            if (result < 0)
+                return null;
+
+            var path = Marshal.PtrToStringUni(outPath);
+            Marshal.FreeCoTaskMem(outPath);
+            return path;
+
+            //throw new ExternalException("Cannot get the known folder path. It may not be available on this system." result);
         }
 
         private void SetPath(KnownFolderFlags flags, string path)

--- a/Wabbajack.Common/Paths/AbsolutePath.cs
+++ b/Wabbajack.Common/Paths/AbsolutePath.cs
@@ -176,7 +176,16 @@ namespace Wabbajack.Common
         /// <summary>
         /// Returns the path to the Windows folder, most often c:\Windows
         /// </summary>
-        public static AbsolutePath WindowsFolder => (AbsolutePath)KnownFolders.Windows.Path;
+        public static AbsolutePath WindowsFolder
+        {
+            get
+            {
+                var path = KnownFolders.Windows.Path;
+                if (path == null)
+                    throw new ArgumentNullException(nameof(path), "Unable to find path to the Windows folder!");
+                return new AbsolutePath(path);
+            }
+        }
 
         public AbsolutePath Root => (AbsolutePath)Path.GetPathRoot(_path);
 

--- a/Wabbajack.Common/Paths/FileCompaction.cs
+++ b/Wabbajack.Common/Paths/FileCompaction.cs
@@ -13,7 +13,12 @@ namespace Wabbajack.Common
         {
             if (_haveCompact != null && _haveCompact.Value) return _compactExecutable;
             if (_haveCompact != null) return null;
-            _compactExecutable = ((AbsolutePath)KnownFolders.SystemX86.Path).Combine("compact.exe");
+
+            var x86Path = KnownFolders.SystemX86.Path;
+            if (x86Path == null)
+                return null;
+            
+            _compactExecutable = ((AbsolutePath)x86Path).Combine("compact.exe");
             
             if (!_compactExecutable.Exists) return null;
 

--- a/Wabbajack.Lib/MO2Installer.cs
+++ b/Wabbajack.Lib/MO2Installer.cs
@@ -511,7 +511,11 @@ namespace Wabbajack.Lib
             if (game?.TryGetGameLocation() != null && path.IsChildOf(game.TryGetGameLocation())) return ErrorResponse.Fail("Cannot install to game directory.");
 
             // Check if child of Program Files
-            if (path.IsChildOf(new AbsolutePath(KnownFolders.ProgramFiles.Path))) return ErrorResponse.Fail("Cannot install to Program Files directory.");
+            var programFilesPath = KnownFolders.ProgramFiles.Path;
+            if (programFilesPath != null)
+            {
+                if (path.IsChildOf(new AbsolutePath(programFilesPath))) return ErrorResponse.Fail("Cannot install to Program Files directory.");
+            }
 
             // If the folder doesn't exist, it's empty so we don't need to check further
             if (!path.Exists) return ErrorResponse.Success;

--- a/Wabbajack/View Models/Installers/InstallerVM.cs
+++ b/Wabbajack/View Models/Installers/InstallerVM.cs
@@ -97,17 +97,21 @@ namespace Wabbajack
 
         public InstallerVM(MainWindowVM mainWindowVM) : base(mainWindowVM)
         {
-            if (AbsolutePath.EntryPoint.IsChildOf(new AbsolutePath(KnownFolders.Downloads.Path)))
+            var downloadsPath = KnownFolders.Downloads.Path;
+            var skyDrivePath = KnownFolders.SkyDrive.Path;
+
+            if (downloadsPath != null && AbsolutePath.EntryPoint.IsChildOf(new AbsolutePath(downloadsPath)))
             {
                 Utils.Error(new CriticalFailureIntervention(
                     "Wabbajack is running inside your Downloads folder. This folder is often highly monitored by antivirus software and these can often " +
                     "conflict with the operations Wabbajack needs to perform. Please move Wabbajack outside of your Downloads folder and then restart the app.",
                     "Cannot run inside Downloads", true));
             }
-            else if (AbsolutePath.EntryPoint.IsChildOf(new AbsolutePath(KnownFolders.SkyDrive.Path)))
+
+            if (skyDrivePath != null && AbsolutePath.EntryPoint.IsChildOf(new AbsolutePath(skyDrivePath)))
             {
                 Utils.Error(new CriticalFailureIntervention(
-                    $"Wabbajack is running inside a OneDrive folder \"{new AbsolutePath(KnownFolders.SkyDrive.Path)}\". This folder is known to cause issues with Wabbajack. " +
+                    $"Wabbajack is running inside a OneDrive folder \"{skyDrivePath}\". This folder is known to cause issues with Wabbajack. " +
                     "Please move Wabbajack outside of your OneDrive folder and then restart the app.",
                     "Cannot run inside OneDrive", true));
             }


### PR DESCRIPTION
Makes KnownFolder Paths nullable so we don't throw an exception when a specific folder does not exist. Some users had a Windows build without SkyDrive which is why Wabbajack crashed.