### PR TITLE
Fix AbstractIPS4OAuthDownloader's CriticalFailureIntervention

### DIFF
--- a/Wabbajack.Lib/Downloaders/AbstractIPS4OAuthDownloader.cs
+++ b/Wabbajack.Lib/Downloaders/AbstractIPS4OAuthDownloader.cs
@@ -350,9 +350,9 @@ namespace Wabbajack.Lib.Downloaders
             {
                 if (ex.Code == 400)
                 {
-                    throw new CriticalFailureIntervention(
-                        $"You have been logged out of {siteName} for reasons out of our control, please log back in via the settings panel",
-                        $"Logged out of {siteName}");
+                    Utils.ErrorThrow(new CriticalFailureIntervention(
+                        $"You have been logged out of {siteName} for reasons out of our control, please re-login via the settings panel.",
+                        $"Bad Request: Logged Out - {siteName}"));
                 }
             }
 


### PR DESCRIPTION
`CriticalFailureIntervention`'s need to be logged to be handled by `UserInterventionHandlers.Handle`, otherwise they just count as a standard Exception.

Also reworded the error to make it clearer that a user may need to click "Logout".