### PR TITLE
version info in mouse hover text in gallery view

### DIFF
--- a/Wabbajack.Lib/ModListRegistry/ModListMetadata.cs
+++ b/Wabbajack.Lib/ModListRegistry/ModListMetadata.cs
@@ -49,6 +49,9 @@ namespace Wabbajack.Lib.ModListRegistry
 
         [JsonProperty("download_metadata")]
         public DownloadMetadata? DownloadMetadata { get; set; }
+        
+        [JsonProperty("version")]
+        public Version? Version { get; set; }
 
         [JsonIgnore]
         public ModListSummary ValidationSummary { get; set; } = new ModListSummary();

--- a/Wabbajack/View Models/Gallery/ModListMetadataVM.cs
+++ b/Wabbajack/View Models/Gallery/ModListMetadataVM.cs
@@ -65,6 +65,9 @@ namespace Wabbajack
 
         [Reactive]
         public string InstallSizeText { get; private set; }
+        
+        [Reactive]
+        public string VersionText { get; private set; }
 
         [Reactive]
         public IErrorResponse Error { get; private set; }
@@ -78,7 +81,7 @@ namespace Wabbajack
         private Subject<bool> IsLoadingIdle;
 
         public ModListMetadataVM(ModListGalleryVM parent, ModlistMetadata metadata)
-        {            
+        {
             _parent = parent;
             Metadata = metadata;
             Location = LauncherUpdater.CommonFolder.Value.Combine("downloaded_mod_lists", Metadata.Links.MachineURL + (string)Consts.ModListExtension);
@@ -92,6 +95,7 @@ namespace Wabbajack
 
             DownloadSizeText = "Download size : " + UIUtils.FormatBytes(Metadata.DownloadMetadata.SizeOfArchives);
             InstallSizeText = "Installation size : " + UIUtils.FormatBytes(Metadata.DownloadMetadata.SizeOfInstalledFiles);
+            VersionText = "Modlist version : " + Metadata.Version;
             IsBroken = metadata.ValidationSummary.HasFailures || metadata.ForceDown;
             //https://www.wabbajack.org/#/modlists/info?machineURL=eldersouls
             OpenWebsiteCommand = ReactiveCommand.Create(() => Utils.OpenWebsite(new Uri($"https://www.wabbajack.org/#/modlists/info?machineURL={Metadata.Links.MachineURL}")));
@@ -117,7 +121,7 @@ namespace Wabbajack
             }, IsLoadingIdle.StartWith(true));
             ExecuteCommand = ReactiveCommand.CreateFromObservable<Unit, Unit>(
                 canExecute: this.WhenAny(x => x.IsBroken).Select(x => !x),
-                execute: (unit) => 
+                execute: (unit) =>
                 Observable.Return(unit)
                 .WithLatestFrom(
                     this.WhenAny(x => x.Exists),

--- a/Wabbajack/Views/ModListTileView.xaml
+++ b/Wabbajack/Views/ModListTileView.xaml
@@ -145,6 +145,41 @@
                         </Ellipse.Style>
                     </Ellipse>
                     <Label
+                        Margin="10,242,0,0"
+                        HorizontalAlignment="Left"
+                        VerticalAlignment="Top"
+                        Content="{Binding VersionText}"
+                        Opacity="0">
+                        <Label.Style>
+                            <Style TargetType="Label">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding IsMouseOver, ElementName=ModListTile}" Value="True">
+                                        <DataTrigger.EnterActions>
+                                            <BeginStoryboard>
+                                                <Storyboard>
+                                                    <DoubleAnimation
+                                                        Storyboard.TargetProperty="Opacity"
+                                                        To="1"
+                                                        Duration="0:0:0.08" />
+                                                </Storyboard>
+                                            </BeginStoryboard>
+                                        </DataTrigger.EnterActions>
+                                        <DataTrigger.ExitActions>
+                                            <BeginStoryboard>
+                                                <Storyboard>
+                                                    <DoubleAnimation
+                                                        Storyboard.TargetProperty="Opacity"
+                                                        To="0"
+                                                        Duration="0:0:0.08" />
+                                                </Storyboard>
+                                            </BeginStoryboard>
+                                        </DataTrigger.ExitActions>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Label.Style>
+                    </Label>
+                    <Label
                         Margin="10,257,0,0"
                         HorizontalAlignment="Left"
                         VerticalAlignment="Top"
@@ -255,7 +290,7 @@
                 Maximum="1"
                 Visibility="{Binding IsEnabled, ElementName=ExecuteButton, Converter={StaticResource bool2VisibilityHiddenConverter}, ConverterParameter=False}" />
             <ScrollViewer Grid.Row="1" Grid.Column="0" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
-            <TextBlock 
+            <TextBlock
                        x:Name="MetadataDescription"
                        Margin="8,5"
                        VerticalAlignment="Center"


### PR DESCRIPTION
partially addresses #1403 

Adds the version number of the modlist to the hover-text alongside installation size, in the gallery view.

Added retrieval of version from modlists.json in `modlistmetadata`

Could be expanded to also display graphically alongside Title of modlist in Gallery and Installation views, but as this is my first PR , this is narrow in scope to get me situated with the flow of the code.