### PR TITLE
Change wording of Utility list filter for consistency

### DIFF
--- a/Wabbajack/Views/ModListGalleryView.xaml
+++ b/Wabbajack/Views/ModListGalleryView.xaml
@@ -121,7 +121,7 @@
                 x:Name="ShowUtilityLists"
                 Margin="10,0,10,0"
                 VerticalAlignment="Center"
-                Content="Show Utility Lists"
+                Content="Only Utility Lists"
                 Foreground="{StaticResource ForegroundBrush}" />
 
             <CheckBox


### PR DESCRIPTION
Fixes #1196 

A minor thing - checkbox for "show nsfw" shows them in addition to non-nsfw lists.
checkbox for "show utility lists" *only* shows the utility lists.

Changed wording to "Only Utility lists" to avoid any minor confusion.