### PR TITLE
Improve Regex performance by compiling during instantiation

### DIFF
--- a/Wabbajack.Lib/AInstaller.cs
+++ b/Wabbajack.Lib/AInstaller.cs
@@ -350,13 +350,13 @@ namespace Wabbajack.Lib
                 });
             */
         }
-
-
+        
+        private static readonly Regex NoDeleteRegex = new(@"(?i)[\\\/]\[NoDelete\]", RegexOptions.Compiled);
         /// <summary>
         /// The user may already have some files in the OutputFolder. If so we can go through these and
         /// figure out which need to be updated, deleted, or left alone
         /// </summary>
-        public async Task OptimizeModlist()
+        protected async Task OptimizeModlist()
         {
             Utils.Log("Optimizing ModList directives");
             
@@ -370,7 +370,6 @@ namespace Wabbajack.Lib
             var savePath = (RelativePath)"saves";
             
             UpdateTracker.NextStep("Looking for files to delete");
-            var regex = new Regex(@"(?i)[\\\/]\[NoDelete\]");
             await OutputFolder.EnumerateFiles()
                 .PMap(Queue, UpdateTracker, async f =>
                 {
@@ -380,7 +379,7 @@ namespace Wabbajack.Lib
 
                     if (f.InFolder(profileFolder) && f.Parent.FileName == savePath) return;
                     
-                    if (regex.IsMatch(f.ToString()))
+                    if (NoDeleteRegex.IsMatch(f.ToString()))
                         return;
                         
                     Utils.Log($"Deleting {relativeTo} it's not part of this ModList");

--- a/Wabbajack.Lib/CompilationSteps/IgnoreRegex.cs
+++ b/Wabbajack.Lib/CompilationSteps/IgnoreRegex.cs
@@ -14,7 +14,7 @@ namespace Wabbajack.Lib.CompilationSteps
         {
             _pattern = pattern;
             _reason = $"Ignored because path matches regex {pattern}";
-            _regex = new Regex(pattern);
+            _regex = new Regex(pattern, RegexOptions.Compiled);
         }
 
         public override async ValueTask<Directive?> Run(RawSourceFile source)

--- a/Wabbajack.Lib/CompilationSteps/IncludeRegex.cs
+++ b/Wabbajack.Lib/CompilationSteps/IncludeRegex.cs
@@ -13,7 +13,7 @@ namespace Wabbajack.Lib.CompilationSteps
         public IncludeRegex(ACompiler compiler, string pattern) : base(compiler)
         {
             _pattern = pattern;
-            _regex = new Regex(pattern);
+            _regex = new Regex(pattern, RegexOptions.Compiled);
         }
 
         public override async ValueTask<Directive?> Run(RawSourceFile source)

--- a/Wabbajack.Lib/Downloaders/GoogleDriveDownloader.cs
+++ b/Wabbajack.Lib/Downloaders/GoogleDriveDownloader.cs
@@ -12,24 +12,23 @@ using Wabbajack.Lib.Validation;
 
 namespace Wabbajack.Lib.Downloaders
 {
-    public class GoogleDriveDownloader : IDownloader, IUrlDownloader
+    public class GoogleDriveDownloader : IUrlDownloader
     {
         public async Task<AbstractDownloadState?> GetDownloaderState(dynamic archiveINI, bool quickMode)
         {
-            var url = archiveINI?.General?.directURL;
+            var url = archiveINI.General?.directURL;
             return GetDownloaderState(url);
         }
 
+        private static readonly Regex GDriveRegex = new("((?<=id=)[a-zA-Z0-9_-]*)|(?<=\\/file\\/d\\/)[a-zA-Z0-9_-]*", RegexOptions.Compiled);
         public AbstractDownloadState? GetDownloaderState(string url)
         {
-            if (url != null && url.StartsWith("https://drive.google.com"))
-            {
-                var regex = new Regex("((?<=id=)[a-zA-Z0-9_-]*)|(?<=\\/file\\/d\\/)[a-zA-Z0-9_-]*");
-                var match = regex.Match(url);
-                return new State(match.ToString());
-            }
+            if (!url.StartsWith("https://drive.google.com"))
+                return null;
 
-            return null;
+            var match = GDriveRegex.Match(url);
+            return new State(match.ToString());
+
         }
 
         public async Task Prepare()

--- a/Wabbajack/View Models/ModListContentsVM.cs
+++ b/Wabbajack/View Models/ModListContentsVM.cs
@@ -25,19 +25,18 @@ namespace Wabbajack
         private readonly ReadOnlyObservableCollection<ModListArchive> _archives;
         public ReadOnlyObservableCollection<ModListArchive> Archives => _archives;
 
+        private static readonly Regex NameMatcher = new(@"(?<=\.)[^\.]+(?=\+State)", RegexOptions.Compiled); 
         public ModListContentsVM(MainWindowVM mwvm) : base(mwvm)
         {
             _mwvm = mwvm;
             Status = new ObservableCollectionExtended<DetailedStatusItem>();
             
-
-            Regex nameMatcher = new Regex(@"(?<=\.)[^\.]+(?=\+State)");
             string TransformClassName(Archive a)
             {
                 var cname = a.State.GetType().FullName;
                 if (cname == null) return null;
 
-                var match = nameMatcher.Match(cname);
+                var match = NameMatcher.Match(cname);
                 return match.Success ? match.ToString() : null;
             }
 

--- a/Wabbajack/View Models/SlideShow.cs
+++ b/Wabbajack/View Models/SlideShow.cs
@@ -132,8 +132,11 @@ namespace Wabbajack
                 canExecute: this.WhenAny(x => x.TargetMod.State.URL)
                     .Select(x =>
                     {
-                        var regex = new Regex("^(http|https):\\/\\/");
-                        return x != null && regex.Match(x.ToString()).Success;
+                        //var regex = new Regex("^(http|https):\\/\\/");
+                        var scheme = x?.Scheme;
+                        return scheme != null && 
+                               (scheme.Equals("https", StringComparison.OrdinalIgnoreCase) ||
+                                scheme.Equals("http", StringComparison.OrdinalIgnoreCase));
                     })
                     .ObserveOnGuiThread());
 


### PR DESCRIPTION
The biggest performance gains should come from the changes in `IgnoreRegex`, `IncludeRegex` and `AInstaller` with the `NoDeleteRegex`. These regex operations are hit constantly with many files so having them in a `static readonly` variable and compiled can massivly increase performance.

Also removed that _interesting_ regex for checking if a Uri is a web URL.