### PR TITLE
Update MEGADownloader

### DIFF
--- a/Wabbajack.Lib/Downloaders/DropboxDownloader.cs
+++ b/Wabbajack.Lib/Downloaders/DropboxDownloader.cs
@@ -13,11 +13,12 @@ namespace Wabbajack.Lib.Downloaders
             return GetDownloaderState(urlstring);
         }
 
-        public AbstractDownloadState? GetDownloaderState(string url)
+        public AbstractDownloadState? GetDownloaderState(string? url)
         {
+            if (url == null) return null;
+        
             try
             {
-                if (url == null) return null;
                 var uri = new UriBuilder(url);
                 if (uri.Host != "www.dropbox.com") return null;
                 var query = HttpUtility.ParseQueryString(uri.Query);

--- a/Wabbajack.Lib/Downloaders/GoogleDriveDownloader.cs
+++ b/Wabbajack.Lib/Downloaders/GoogleDriveDownloader.cs
@@ -20,16 +20,17 @@ namespace Wabbajack.Lib.Downloaders
             return GetDownloaderState(url);
         }
 
-        public AbstractDownloadState? GetDownloaderState(string url)
+        public AbstractDownloadState? GetDownloaderState(string? url)
         {
-            if (url != null && url.StartsWith("https://drive.google.com"))
-            {
-                var regex = new Regex("((?<=id=)[a-zA-Z0-9_-]*)|(?<=\\/file\\/d\\/)[a-zA-Z0-9_-]*");
-                var match = regex.Match(url);
-                return new State(match.ToString());
-            }
+            if (url == null) return null;
 
-            return null;
+            if (!url.StartsWith("https://drive.google.com"))
+                return null;
+
+            var regex = new Regex("((?<=id=)[a-zA-Z0-9_-]*)|(?<=\\/file\\/d\\/)[a-zA-Z0-9_-]*");
+            var match = regex.Match(url);
+            return new State(match.ToString());
+
         }
 
         public async Task Prepare()

--- a/Wabbajack.Lib/Downloaders/HTTPDownloader.cs
+++ b/Wabbajack.Lib/Downloaders/HTTPDownloader.cs
@@ -23,24 +23,23 @@ namespace Wabbajack.Lib.Downloaders
             return GetDownloaderState(url, archiveINI);
         }
 
-        public AbstractDownloadState? GetDownloaderState(string uri)
+        public AbstractDownloadState? GetDownloaderState(string? uri)
         {
             return GetDownloaderState(uri, null);
         }
 
-        public AbstractDownloadState? GetDownloaderState(string url, dynamic? archiveINI)
+        public AbstractDownloadState? GetDownloaderState(string? url, dynamic? archiveINI)
         {
-            if (url != null)
-            {
-                var tmp = new State(url);
-                if (archiveINI?.General?.directURLHeaders != null)
-                {
-                    tmp.Headers.AddRange(archiveINI?.General.directURLHeaders.Split('|'));
-                }
-                return tmp;
-            }
+            if (url == null)
+                return null;
 
-            return null;
+            var tmp = new State(url);
+            if (archiveINI?.General?.directURLHeaders != null)
+            {
+                tmp.Headers.AddRange(archiveINI?.General.directURLHeaders.Split('|'));
+            }
+            return tmp;
+
         }
 
         public async Task Prepare()

--- a/Wabbajack.Lib/Downloaders/IUrlDownloader.cs
+++ b/Wabbajack.Lib/Downloaders/IUrlDownloader.cs
@@ -2,6 +2,6 @@
 {
     public interface IUrlDownloader : IDownloader
     {
-        AbstractDownloadState? GetDownloaderState(string url);
+        AbstractDownloadState? GetDownloaderState(string? url);
     }
 }

--- a/Wabbajack.Lib/Downloaders/MEGADownloader.cs
+++ b/Wabbajack.Lib/Downloaders/MEGADownloader.cs
@@ -117,8 +117,10 @@ namespace Wabbajack.Lib.Downloaders
             return GetDownloaderState(url);
         }
 
-        public AbstractDownloadState? GetDownloaderState(string url)
+        public AbstractDownloadState? GetDownloaderState(string? url)
         {
+            if (url == null) return null;
+            
             if ((url.StartsWith(Consts.MegaPrefix) || url.StartsWith(Consts.MegaFilePrefix)))
                 return new State(url);
             return null;

--- a/Wabbajack.Lib/Downloaders/MediaFireDownloader.cs
+++ b/Wabbajack.Lib/Downloaders/MediaFireDownloader.cs
@@ -92,12 +92,12 @@ namespace Wabbajack.Lib.Downloaders
         {
         }
 
-        public AbstractDownloadState? GetDownloaderState(string u)
+        public AbstractDownloadState? GetDownloaderState(string? u)
         {
+            if (u == null) return null;
+            
             var url = new Uri(u);
-            if (url.Host != "www.mediafire.com") return null;
-
-            return new State(url.ToString());
+            return url.Host != "www.mediafire.com" ? null : new State(url.ToString());
         }
     }
 }

--- a/Wabbajack.Lib/Downloaders/ModDBDownloader.cs
+++ b/Wabbajack.Lib/Downloaders/ModDBDownloader.cs
@@ -18,7 +18,7 @@ namespace Wabbajack.Lib.Downloaders
             return GetDownloaderState(url);
         }
 
-        public AbstractDownloadState? GetDownloaderState(string url)
+        public AbstractDownloadState? GetDownloaderState(string? url)
         {
             if (url != null && url.StartsWith("https://www.moddb.com/downloads/start"))
             {

--- a/Wabbajack.Lib/Downloaders/WabbajackCDNDownloader.cs
+++ b/Wabbajack.Lib/Downloaders/WabbajackCDNDownloader.cs
@@ -40,9 +40,9 @@ namespace Wabbajack.Lib.Downloaders
         {
         }
 
-        public AbstractDownloadState? GetDownloaderState(string url)
+        public AbstractDownloadState? GetDownloaderState(string? url)
         {
-            return StateFromUrl(new Uri(url));
+            return url == null ? null : StateFromUrl(new Uri(url));
         }
 
 

--- a/Wabbajack.Lib/Downloaders/YandexDownloader.cs
+++ b/Wabbajack.Lib/Downloaders/YandexDownloader.cs
@@ -22,15 +22,12 @@ namespace Wabbajack.Lib.Downloaders
         {
         }
 
-        public AbstractDownloadState? GetDownloaderState(string url)
+        public AbstractDownloadState? GetDownloaderState(string? url)
         {
+            if (url == null) return null;
+            
             var uri = new Uri(url);
-            if (uri.Host == "yadi.sk")
-            {
-                return new State(uri);
-            }
-
-            return null;
+            return uri.Host == "yadi.sk" ? new State(uri) : null;
         }
 
         [JsonName("YandexDownloader+State")]


### PR DESCRIPTION
Some small fixes for the MEGADownloader:
- use `IsLoggedIn` instead of a try catch block to check if we are logged in
- don't call `MegaLogin` if we are already logged in, this should increase performance since we stop hitting the `AsyncLock` every time we wan't to do something even if we are already logged in