### PR TITLE
Fix version conflicts caused by PR#1573

### DIFF
--- a/Wabbajack/Wabbajack.csproj
+++ b/Wabbajack/Wabbajack.csproj
@@ -77,9 +77,9 @@
     <PackageReference Include="MahApps.Metro.IconPacks" Version="4.8.0" />
     <PackageReference Include="Microsoft-WindowsAPICodePack-Shell" Version="1.1.4" />
     <PackageReference Include="PInvoke.User32" Version="0.7.104" />
-    <PackageReference Include="ReactiveUI" Version="14.1.1" />
-    <PackageReference Include="ReactiveUI.Fody" Version="14.1.1" />
-    <PackageReference Include="ReactiveUI.WPF" Version="14.1.1" />
+    <PackageReference Include="ReactiveUI" Version="14.3.1" />
+    <PackageReference Include="ReactiveUI.Fody" Version="14.3.1" />
+    <PackageReference Include="ReactiveUI.WPF" Version="14.3.1" />
     <PackageReference Include="Silk.NET.DXGI" Version="2.6.0" />
     <PackageReference Include="WPFThemes.DarkBlend" Version="1.0.8" />
   </ItemGroup>


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump ReactiveUI.WPF from 14.1.1 to 14.3.1. [(PR#1573)](https://github.com/wabbajack-tools/wabbajack/pull/1573).
Hope this fix can help you.

Best regards,
sucrose