### PR TITLE
Improve existing install speed by utilising SQL LIKE and a dictionary.

### DIFF
--- a/Wabbajack.Common/Hash.cs
+++ b/Wabbajack.Common/Hash.cs
@@ -138,10 +138,6 @@ namespace Wabbajack.Common
             Hash BIGINT)
             WITHOUT ROWID";
             cmd.ExecuteNonQuery();
-
-
-
-
         }
 
         private static (AbsolutePath Path, long LastModified, Hash Hash) GetFromCache(AbsolutePath path)
@@ -159,7 +155,25 @@ namespace Wabbajack.Common
 
             return default;
         }
-        
+
+        public static Dictionary<string, (long, Hash)> GetChildrenFromCache(AbsolutePath path)
+        {
+            using var cmd = new SQLiteCommand(_conn);
+            cmd.CommandText = "SELECT Path, LastModified, Hash FROM HashCache WHERE Path LIKE @path";
+            cmd.Parameters.AddWithValue("@path", path.ToString() + '%');
+            cmd.PrepareAsync();
+
+            Dictionary<string, (long, Hash)> dictionary = new();
+
+            using var reader = cmd.ExecuteReader();
+            while (reader.Read())
+            {
+                dictionary.Add(reader.GetString(0), (reader.GetInt64(1), Hash.FromLong(reader.GetInt64(2))));
+            }
+
+            return dictionary;
+        }
+
         private static void PurgeCacheEntry(AbsolutePath path)
         {
             using var cmd = new SQLiteCommand(_conn);


### PR DESCRIPTION
This PR speeds up installing on existing files by doing a SELECT LIKE query using the install folder and saving the results to a dictionary where we can then do a simple lookup from. 

Using a full pre-cached install of Elysium, these are the results before and after this change:
(From "Looking for unmodified files" to "Updating ModList", in milliseconds)

Before changes:
Start: 10863281 End: 10928968 Total: 65687
Start: 11028906 End: 11093031 Total: 64125
Start: 11144890 End: 11208796 Total: 63906

After changes:
Start: 10464531 End: 10491578 Total: 27047
Start: 10546437 End: 10572953 Total: 26516
Start: 10627390 End: 10653875 Total: 26485