### PR TITLE
Fix typos in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ Other modlists opt to host all of their information on a dedicated website:
 
 ### Meta Files
 
-_Read [Everything comes for somewhere](#everything-comes-for-somewhere) first, as that section explains the basic concept of meta files. This section focuses more on advances uses._
+_Read [Everything comes from somewhere](#everything-comes-from-somewhere) first, as that section explains the basic concept of meta files. This section focuses more on advanced uses._
 
 You already know how `.meta` files should look for mods that come from Nexus Mods:
 


### PR DESCRIPTION
This fixes some typos in the readme referring to the [Everything comes from somewhere](https://github.com/wabbajack-tools/wabbajack#everything-comes-from-somewhere) section (the original typo was fixed in 1316ca7e21297ec7f4ebcbdc8fb53d33bd26c29e, but this reference was not).

I also noticed a dead link to the GPL3 license in the [License & Copyright section](https://github.com/wabbajack-tools/wabbajack#license--copyright), which was deleted in 2e6c756d6fd7e0f3d9c30a20635ded71e8f6a7bd. Should this file be re-added or would it be sufficient to link to https://github.com/halgari/wabbajack/blob/master/LICENSE.txt?