### PR TITLE
Fixed Drive Letters for Windows Platform

### DIFF
--- a/Wabbajack.Paths/AbsolutePath.cs
+++ b/Wabbajack.Paths/AbsolutePath.cs
@@ -37,7 +37,7 @@ public readonly struct AbsolutePath : IPath, IComparable<AbsolutePath>, IEquatab
     }
 
     private static readonly HashSet<char>
-        DriveLetters = new("ABCDEFGJIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz");
+        DriveLetters = new("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz");
 
     private static PathFormat DetectPathType(string path)
     {


### PR DESCRIPTION
Had an issue with AbsolutePath not recognizing a "H" partition. Updated the hashset accordingly.