### PR TITLE
Swap main executable for cyberpunk2077

### DIFF
--- a/Wabbajack.DTOs/Game/GameRegistry.cs
+++ b/Wabbajack.DTOs/Game/GameRegistry.cs
@@ -412,9 +412,9 @@ public static class GameRegistry
                 IsGenericMO2Plugin = true,
                 RequiredFiles = new[]
                 {
-                    @"REDprelauncher.exe".ToRelativePath()
+                    @"bin\x64\Cyberpunk2077.exe".ToRelativePath()
                 },
-                MainExecutable = @"REDprelauncher.exe".ToRelativePath()
+                MainExecutable = @"bin\x64\Cyberpunk2077.exe".ToRelativePath()
             }
         }
     };


### PR DESCRIPTION
Swap from RedPreLauncher to Cyberpunk2077.exe to accomodate GoG users as they don't have the PreLauncher exe