### PR TITLE
Fix getting game files when build server is down

### DIFF
--- a/Wabbajack.Lib/ClientAPI.cs
+++ b/Wabbajack.Lib/ClientAPI.cs
@@ -155,9 +155,6 @@ using Wabbajack.Lib.Downloaders;
 
         public static async Task<Archive[]> GetExistingGameFiles(WorkQueue queue, Game game)
         {
-            if(BuildServerStatus.IsBuildServerDown)
-                return new Archive[0];
-            var client = await GetClient();
             var metaData = game.MetaData();
             var results = await GetGameFilesFromGithub(game, metaData.InstalledVersion);
 


### PR DESCRIPTION
There's really no need for the build server to be up when WJ
is just getting some files from Github. I'm guessing these files
used to be stored on the build server.