### PR TITLE
Add IgnoreEndsWith to native compiler

### DIFF
--- a/Wabbajack.Lib/NativeCompiler.cs
+++ b/Wabbajack.Lib/NativeCompiler.cs
@@ -286,15 +286,16 @@ namespace Wabbajack.Lib
         {
             return step[0] switch
             {
-                "IgnoreStartsWith" => new IgnoreStartsWith(this, step[1]),
                 "IgnoreEndsWith" => new IgnoreEndsWith(this, step[1]),
+                "IgnoreStartsWith" => new IgnoreStartsWith(this, step[1]),
                 "IgnoreRegex" => new IgnoreRegex(this, step[1]),
                 "IgnoreTaggedFolders" => new IgnoreTaggedFolders(this, Consts.WABBAJACK_IGNORE),
                 "IgnoreTaggedFiles" => new IgnoreTaggedFiles(this, Consts.WABBAJACK_IGNORE_FILES),
-                "IncludeTaggedFolders" => new IncludeTaggedFolders(this, Consts.WABBAJACK_INCLUDE),
                 "IncludeConfigs" => new IncludeAllConfigs(this),
                 "IncludeDirectMatches" => new DirectMatch(this),
                 "IncludePatches" => new IncludePatches(this),
+                "IncludeRegex" => new IncludeRegex(this, step[1]),
+                "IncludeTaggedFolders" => new IncludeTaggedFolders(this, Consts.WABBAJACK_INCLUDE),
                 "IncludeUnmatchedFilesInTaggedFolders" => new IncludeTaggedFolders(this, Consts.WABBAJACK_NOMATCH_INCLUDE),
                 "IncludeUnmatchedTaggedFiles" => new IncludeTaggedFiles(this, Consts.WABBAJACK_NOMATCH_INCLUDE_FILES),
                 _ => throw new ArgumentException($"No interpretation for step {step[0]}")

--- a/Wabbajack.Lib/NativeCompiler.cs
+++ b/Wabbajack.Lib/NativeCompiler.cs
@@ -287,6 +287,7 @@ namespace Wabbajack.Lib
             return step[0] switch
             {
                 "IgnoreStartsWith" => new IgnoreStartsWith(this, step[1]),
+                "IgnoreEndsWith" => new IgnoreEndsWith(this, step[1]),
                 "IgnoreTaggedFolders" => new IgnoreTaggedFolders(this, Consts.WABBAJACK_IGNORE),
                 "IgnoreTaggedFiles" => new IgnoreTaggedFiles(this, Consts.WABBAJACK_IGNORE_FILES),
                 "IncludeTaggedFolders" => new IncludeTaggedFolders(this, Consts.WABBAJACK_INCLUDE),

--- a/Wabbajack.Lib/NativeCompiler.cs
+++ b/Wabbajack.Lib/NativeCompiler.cs
@@ -288,6 +288,7 @@ namespace Wabbajack.Lib
             {
                 "IgnoreStartsWith" => new IgnoreStartsWith(this, step[1]),
                 "IgnoreEndsWith" => new IgnoreEndsWith(this, step[1]),
+                "IgnoreRegex" => new IgnoreRegex(this, step[1]),
                 "IgnoreTaggedFolders" => new IgnoreTaggedFolders(this, Consts.WABBAJACK_IGNORE),
                 "IgnoreTaggedFiles" => new IgnoreTaggedFiles(this, Consts.WABBAJACK_IGNORE_FILES),
                 "IncludeTaggedFolders" => new IncludeTaggedFolders(this, Consts.WABBAJACK_INCLUDE),


### PR DESCRIPTION
Apoaspe is doing weird stuff so this might just turn into "misc. improvements to the native game compiler". Not real high priority stuff given there's only one user and it's on the compilation side.