### PR TITLE
Fix Cyberpunk 2077 GOG ID

### DIFF
--- a/Wabbajack.Common/GameMetaData.cs
+++ b/Wabbajack.Common/GameMetaData.cs
@@ -670,7 +670,7 @@ namespace Wabbajack.Common
                {
                     Game = Game.Cyberpunk2077,
                     SteamIDs = new List<int> {1091500},
-                    GOGIDs = new List<int> {2093619782},
+                    GOGIDs = new List<int> {1423049311},
                     MO2Name = "Cyberpunk 2077",
                     NexusName = "cyberpunk2077",
                     NexusGameId = 3333,


### PR DESCRIPTION
The previous ID was for the package.
https://www.gogdb.org/product/2093619782#references 

This changes the WJ ID to look for the game.
https://www.gogdb.org/product/1423049311