### PR TITLE
Check if temp directory exists before cleaning.

### DIFF
--- a/Wabbajack.Services.OSIntegrated/ServiceExtensions.cs
+++ b/Wabbajack.Services.OSIntegrated/ServiceExtensions.cs
@@ -194,6 +194,7 @@ public static class ServiceExtensions
 
     private static void CleanAllTempData(AbsolutePath path)
     {
+        if (!path.DirectoryExists()) return;
         // Get directories first and cache them, this freezes the directories were looking at
         // so any new ones don't show up in the middle of our deletes.
         


### PR DESCRIPTION
If the temp directory doesn't exist, `AbsolutePathExtensions.EnumerateDirectories()` throws an ERROR_PATH_NOT_FOUND exception.

This fixes this by checking if the temp directory exists first.