### PR TITLE
WABBAJACK_ALWAYS_DISABLE tag inferring #2181

### DIFF
--- a/Wabbajack.Compiler/CompilerSettingsInferencer.cs
+++ b/Wabbajack.Compiler/CompilerSettingsInferencer.cs
@@ -127,7 +127,9 @@ public class CompilerSettingsInferencer
                         cs.Include = cs.Include.Append(modFolder.RelativeTo(mo2Folder)).ToArray();
                     
                     if ((generalModData["notes"]?.Contains(Consts.WABBAJACK_IGNORE) ?? false) ||
-                        (generalModData["comments"]?.Contains(Consts.WABBAJACK_IGNORE) ?? false))
+                        (generalModData["comments"]?.Contains(Consts.WABBAJACK_IGNORE) ?? false) ||
+                        (generalModData["notes"]?.Contains(Consts.WABBAJACK_ALWAYS_DISABLE) ?? false) ||
+                        (generalModData["comments"]?.Contains(Consts.WABBAJACK_ALWAYS_DISABLE) ?? false))
                         cs.Ignore = cs.Ignore.Append(modFolder.RelativeTo(mo2Folder)).ToArray();
                 }
 


### PR DESCRIPTION
Fixes another missed backwards compatibility inferring issue.
Closes #2181.