### PR TITLE
#2194 Set Archives to Hidden in MO2

### DIFF
--- a/Wabbajack.Paths.IO/AbsolutePathExtensions.cs
+++ b/Wabbajack.Paths.IO/AbsolutePathExtensions.cs
@@ -165,6 +165,15 @@ public static class AbsolutePathExtensions
 
         await sw.DisposeAsync();
     }
+    
+    public static async Task WriteAllLinesAsync(this AbsolutePath file, IEnumerable<string> src,
+        FileMode fileMode, CancellationToken token)
+    {
+        await using var dest = file.Open(fileMode, FileAccess.Write, FileShare.None);
+        await using var sw = new StreamWriter(dest, Encoding.UTF8);
+        foreach (var line in src) await sw.WriteLineAsync(line);
+        await sw.DisposeAsync();
+    }
 
     public static async ValueTask WriteAllBytesAsync(this AbsolutePath file, Memory<byte> data,
         CancellationToken token = default)


### PR DESCRIPTION
If meta exists, check if file is valid or not and depending on that make a new one or append to the existing one. If no file exists create one.
The tag added is `removed=true`
closes #2194.