### PR TITLE
Fix writing metas task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ### Changelog
 
+#### Version - 3.0.4.1 - TBD
+
+* Fix recursive writing of meta files for meta files
+
 #### Version - 3.0.4.0 - 11/12/2022
 * Upgrade GameFinder to 2.2.1
 * Update to .NET 7.0 (no user updates required)

--- a/Wabbajack.Installer/StandardInstaller.cs
+++ b/Wabbajack.Installer/StandardInstaller.cs
@@ -229,9 +229,9 @@ public class StandardInstaller : AInstaller<StandardInstaller>
 
         _logger.LogInformation("Writing Metas");
         await _configuration.Downloads.EnumerateFiles()
+            .Where(download => download.Extension != Ext.Meta)
             .PDoAll(async download =>
             {
-                if (download.Extension == Ext.Meta) return;
                 var metaFile = download.WithExtension(Ext.Meta);
 
                 var found = bySize[download.Size()];

--- a/Wabbajack.Installer/StandardInstaller.cs
+++ b/Wabbajack.Installer/StandardInstaller.cs
@@ -231,6 +231,7 @@ public class StandardInstaller : AInstaller<StandardInstaller>
         await _configuration.Downloads.EnumerateFiles()
             .PDoAll(async download =>
             {
+                if (download.Extension == Ext.Meta) return;
                 var metaFile = download.WithExtension(Ext.Meta);
 
                 var found = bySize[download.Size()];


### PR DESCRIPTION
should be pushed out ASAP because right now installations seem to be in an infinite loop for at least one user without the fix.
[Wabbajack.current (1).log](https://github.com/wabbajack-tools/wabbajack/files/9996990/Wabbajack.current.1.log)
