### PR TITLE
Fix readme opening twice when loading last modlist

### DIFF
--- a/Wabbajack.App.Wpf/View Models/Installers/InstallerVM.cs
+++ b/Wabbajack.App.Wpf/View Models/Installers/InstallerVM.cs
@@ -312,7 +312,9 @@ public class InstallerVM : BackNavigatingVM, IBackNavigatingVM, ICpuStatusVM
     {
         var lst = await _settingsManager.Load<AbsolutePath>(LastLoadedModlist);
         if (lst.FileExists())
-            await LoadModlist(lst, null);
+        {
+            ModListLocation.TargetPath = lst;
+        }
     }
 
     private async Task LoadModlist(AbsolutePath path, ModlistMetadata? metadata)


### PR DESCRIPTION
The readme was opened twice because `LoadModlist()` was called twice. Once in `LoadLastModlist()`, and then again when triggered by `LoadModlist()` itself setting the `ModListLocation.TargetPath`.

Fixes #2279 