### PR TITLE
Edit Wabbajack CLI button text

### DIFF
--- a/Wabbajack.App.Wpf/Views/Settings/MiscSettingsView.xaml
+++ b/Wabbajack.App.Wpf/Views/Settings/MiscSettingsView.xaml
@@ -82,7 +82,7 @@
                 <Button Grid.Row="3"
                     Name="OpenTerminal"
                     Margin="0,5,0,0"
-                    Content="Open Terminal and Close WJ" />
+                    Content="Launch Wabbajack CLI" />
             </Grid>
         </Grid>
     </Border>


### PR DESCRIPTION
Changed the button text from "Open Terminal and Close WJ" to "Launch Wabbajack CLI" as clicking the button doesn't actually close the Wabbajack client