### PR TITLE
Fix issues introduced by resumable downloads

### DIFF
--- a/Wabbajack.Installer/AInstaller.cs
+++ b/Wabbajack.Installer/AInstaller.cs
@@ -422,10 +422,17 @@ public abstract class AInstaller<T>
                 await destination.Value.MoveToAsync(destination.Value.Parent.Combine(archive.Hash.ToHex()), true,
                     token);
         }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
+            // No actual error. User canceled downloads.
+        }
+        catch (NotImplementedException) when (archive.State is GameFileSource)
+        {
+            _logger.LogError("Missing game file {name}. This could be caused by missing DLC or a modified installation.", archive.Name);
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Download error for file {name}", archive.Name);
-            return false;
         }
 
         return false;

--- a/Wabbajack.Networking.Http/ResumableDownloader.cs
+++ b/Wabbajack.Networking.Http/ResumableDownloader.cs
@@ -84,6 +84,8 @@ internal class ResumableDownloader
     {
         var configuration = new DownloadConfiguration
         {
+            Timeout = (int)TimeSpan.FromSeconds(120).TotalMilliseconds,
+            ReserveStorageSpaceBeforeStartingDownload = true,
             RequestConfiguration = new RequestConfiguration
             {
                 Headers = message.Headers.ToWebHeaderCollection(),

--- a/Wabbajack.Networking.Http/ResumableDownloader.cs
+++ b/Wabbajack.Networking.Http/ResumableDownloader.cs
@@ -110,12 +110,21 @@ internal class ResumableDownloader
         }
 
         await _job.Report(processedSize, _token);
+        if (_job.Current > _job.Size)
+        {
+            // Increase job size so progress doesn't appear stalled
+            _job.Size = (long)Math.Floor(_job.Current * 1.1);
+        }
     }
 
     private void OnDownloadStarted(object? sender, DownloadStartedEventArgs e)
     {
         _job.ResetProgress();
-        _job.Size = e.TotalBytesToReceive;
+
+        if (_job.Size < e.TotalBytesToReceive)
+        {
+            _job.Size = e.TotalBytesToReceive;
+        }
 
         // Get rid of package, since we can't use it to resume anymore
         DeletePackage();

--- a/Wabbajack.Networking.Http/ResumableDownloader.cs
+++ b/Wabbajack.Networking.Http/ResumableDownloader.cs
@@ -76,7 +76,8 @@ internal class ResumableDownloader
             return new Hash();
         }
 
-        return await _outputPath.Open(FileMode.Open).Hash(token);
+        await using var file = _outputPath.Open(FileMode.Open);
+        return await file.Hash(token);
     }
 
     private DownloadConfiguration CreateConfiguration(HttpRequestMessage message)

--- a/Wabbajack.Networking.Http/ResumableDownloader.cs
+++ b/Wabbajack.Networking.Http/ResumableDownloader.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Downloader;
+using Microsoft.Extensions.Logging;
 using Wabbajack.Hashing.xxHash64;
 using Wabbajack.Paths;
 using Wabbajack.Paths.IO;
@@ -19,15 +20,18 @@ internal class ResumableDownloader
     private readonly HttpRequestMessage _msg;
     private readonly AbsolutePath _outputPath;
     private readonly AbsolutePath _packagePath;
+    private readonly ILogger<SingleThreadedDownloader> _logger;
     private CancellationToken _token;
     private Exception? _error;
 
-    public ResumableDownloader(HttpRequestMessage msg, AbsolutePath outputPath, IJob job)
+
+    public ResumableDownloader(HttpRequestMessage msg, AbsolutePath outputPath, IJob job, ILogger<SingleThreadedDownloader> logger)
     {
         _job = job;
         _msg = msg;
         _outputPath = outputPath;
         _packagePath = outputPath.WithExtension(Extension.FromPath(".download_package"));
+        _logger = logger;
     }
 
     public async Task<Hash> Download(CancellationToken token)
@@ -46,10 +50,12 @@ internal class ResumableDownloader
             // Resume with different Uri in case old one is no longer valid
             downloadPackage.Address = _msg.RequestUri!.AbsoluteUri;
 
+            _logger.LogDebug("Download for {name} is resuming...", _outputPath.FileName.ToString());
             await downloader.DownloadFileTaskAsync(downloadPackage, token);
         }
         else
         {
+            _logger.LogDebug("Download for '{name}' is starting from scratch...", _outputPath.FileName.ToString());
             _outputPath.Delete();
             await downloader.DownloadFileTaskAsync(_msg.RequestUri!.AbsoluteUri, _outputPath.ToString(), token);
         }
@@ -57,13 +63,24 @@ internal class ResumableDownloader
         // Save progress if download isn't completed yet
         if (downloader.Status is DownloadStatus.Stopped or DownloadStatus.Failed)
         {
+            _logger.LogDebug("Download for '{name}' stopped before completion. Saving package...", _outputPath.FileName.ToString());
             SavePackage(downloader.Package);
-            if (_error != null && _error.GetType() != typeof(TaskCanceledException))
+            if (_error == null || _error.GetType() == typeof(TaskCanceledException))
             {
-                throw _error;
+                return new Hash();
             }
 
-            return new Hash();
+            if (_error.GetType() == typeof(NotSupportedException))
+            {
+                _logger.LogWarning("Download for '{name}' doesn't support resuming. Deleting package...", _outputPath.FileName.ToString());
+                DeletePackage();
+            }
+            else
+            {
+                _logger.LogError(_error,"Download for '{name}' encountered error. Throwing...", _outputPath.FileName.ToString());
+            }
+
+            throw _error;
         }
 
         if (downloader.Status == DownloadStatus.Completed)

--- a/Wabbajack.Services.OSIntegrated/ResourceSettingsManager.cs
+++ b/Wabbajack.Services.OSIntegrated/ResourceSettingsManager.cs
@@ -24,20 +24,25 @@ public class ResourceSettingsManager
         try
         {
             _settings ??= await _manager.Load<Dictionary<string, ResourceSetting>>("resource_settings");
-
-            if (_settings.TryGetValue(name, out var found)) return found;
-
-            var newSetting = new ResourceSetting
+            if (!_settings.ContainsKey(name))
             {
-                MaxTasks = Environment.ProcessorCount,
-                MaxThroughput = 0
-            };
+                var newSetting = new ResourceSetting
+                {
+                    MaxTasks = Environment.ProcessorCount,
+                    MaxThroughput = 0
+                };
 
-            _settings.Add(name, newSetting);
+                _settings.Add(name, newSetting);
+                await SaveSettings(_settings);
+            }
 
-            await _manager.Save("resource_settings", _settings);
-            
-            return _settings[name];
+            var setting = _settings[name];
+            if (name.Equals("Downloads"))
+            {
+                setting.MaxTasks = Math.Min(setting.MaxTasks, 8);
+            }
+
+            return setting;
         }
         finally
         {


### PR DESCRIPTION
This should fix the downloader issues introduced with the resumable downloads feature.

I've also included some of my logging changes, because they were useful in getting a clearer picture of where and how downloads may fail.

**Notable changes**:
* Downloads now reserve their full size on disk when starting
-- Fixes high RAM usage
* Limited download threads to a max of 8, regardless of available threads
-- Fixes hanging when starting a large amount of downloads simultaneously
* If a download fails, it will be retried 3 times in the `SingleThreadedDownloader` before the caller can perform its own error handling (e.g. Use a different NexusMods server)
-- Can fix failing downloads on flaky connections
* The size of download jobs is dynamically increased (by 10% of current size) if the downloader gets more than the expected number of bytes. This appears to be caused by the downloader sometimes having to re-download chunks if they don't match.
-- Fixes downloads appearing stuck in job view.

**Known issues**:
v3.1.0.0 appears to have introduced an issue where the whole UI freezes after starting the installation process, while continuing to work in the background. From user reports, limiting the number of simultaneous downloads to 8 does not seem to fix the issue.

I wasn't able to find any cause for this, and users were able to fix this by either waiting for some time, or completely restarting WJ.