### PR TITLE
Remove hard limit for download threads

### DIFF
--- a/Wabbajack.Services.OSIntegrated/ResourceSettingsManager.cs
+++ b/Wabbajack.Services.OSIntegrated/ResourceSettingsManager.cs
@@ -37,11 +37,6 @@ public class ResourceSettingsManager
             }
 
             var setting = _settings[name];
-            if (name.Equals("Downloads"))
-            {
-                setting.MaxTasks = Math.Min(setting.MaxTasks, 8);
-            }
-
             return setting;
         }
         finally


### PR DESCRIPTION
Removes the hard upper limit of 8 simultaneous downloads.

@EzioTheDeadPoet Sorry for missing to update this on the previous PR!