### PR TITLE
Add whitespace stripping string to the regex match for [NoDelete] to idiot proof

### DIFF
--- a/Wabbajack.Installer/AInstaller.cs
+++ b/Wabbajack.Installer/AInstaller.cs
@@ -534,8 +534,8 @@ public abstract class AInstaller<T>
                     return f;
 
                 if (f.InFolder(profileFolder) && f.Parent.FileName == savePath) return f;
-
-                if (NoDeleteRegex.IsMatch(f.ToString()))
+                var fNoSpaces = new string(f.ToString().Where(c => !Char.IsWhiteSpace(c)).ToArray());
+                if (NoDeleteRegex.IsMatch(fNoSpaces))
                     return f;
 
                 if (bsaPathsToNotBuild.Contains(f))


### PR DESCRIPTION
Fixes #2351 

Just familiarizing myself with the codebase so just taking on little things as I see them.

As Luca says in the attached issue, its more a matter of reading the docs, but it cant hurt to add this functionality, and as an added bonus it also would discount leading spaces etc ( if the regex dosnt )

Built and tested with an Mo2 mod added with the name [No Delete] with space, prefixed to folder.

Wabbajack did not delete it on reinstall

Tested existing behavior was not impacted by doing the same but without any prefix, and it was deleted.