### PR TITLE
Disable opening readme website when WJ file is opened, keep it to only open on install complete

### DIFF
--- a/Wabbajack.App.Wpf/View Models/Installers/InstallerVM.cs
+++ b/Wabbajack.App.Wpf/View Models/Installers/InstallerVM.cs
@@ -329,10 +329,6 @@ public class InstallerVM : BackNavigatingVM, IBackNavigatingVM, ICpuStatusVM
         {
             ModList = await StandardInstaller.LoadFromFile(_dtos, path);
             ModListImage = BitmapFrame.Create(await StandardInstaller.ModListImageStream(path));
-            
-            if (!string.IsNullOrWhiteSpace(ModList.Readme)) 
-                UIUtils.OpenWebsite(new Uri(ModList.Readme));
-
 
             StatusText = $"Install configuration for {ModList.Name}";
             TaskBarUpdate.Send($"Loaded {ModList.Name}", TaskbarItemProgressState.Normal);
@@ -454,8 +450,8 @@ public class InstallerVM : BackNavigatingVM, IBackNavigatingVM, ICpuStatusVM
                 {
                     TaskBarUpdate.Send($"Finished install of {ModList.Name}", TaskbarItemProgressState.Normal);
                     InstallState = InstallState.Success;
-                    
-                    if (!string.IsNullOrWhiteSpace(ModList.Readme)) 
+
+                    if (!string.IsNullOrWhiteSpace(ModList.Readme))
                         UIUtils.OpenWebsite(new Uri(ModList.Readme));
 
                 }


### PR DESCRIPTION
Fixes #2279 

This may be down to preference as per the linked issue, but the argument that when testing a failing install, having the webpage open every time being annoying, has some merit.

This removes the code that opens the website when a WJ file is first opened, and only opens it when it is most relevant - when the install is complete and things need to be read.

There may be situations where having the readme open to troubleshoot install issues may be more friendly to the user, but ill leave that to others to decide, this "Fix" is just here if you want it.