### PR TITLE
Fixed Search filter not reapplying after pressing back and re-accessing Gallery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 #### Version TBD
 * Fixed issues related to high RAM usage
   * The resumable downloads now reserve drive space to write to in advance instead of being managed in system RAM
-  * fixed search filter nto applying when pressing back button and reaccessing gallery
+  * fixed search filter not applying when pressing back button and reaccessing gallery
 
 #### Version - 3.1.0.0 - 5/7/2023
 * Fixed Readme opening twice

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Version TBD
 * Fixed issues related to high RAM usage
   * The resumable downloads now reserve drive space to write to in advance instead of being managed in system RAM
+  * fixed search filter nto applying when pressing back button and reaccessing gallery
 
 #### Version - 3.1.0.0 - 5/7/2023
 * Fixed Readme opening twice

--- a/Wabbajack.App.Wpf/View Models/Gallery/ModListGalleryVM.cs
+++ b/Wabbajack.App.Wpf/View Models/Gallery/ModListGalleryVM.cs
@@ -121,7 +121,7 @@ namespace Wabbajack
 
                 var searchTextPredicates = this.ObservableForProperty(vm => vm.Search)
                     .Select(change => change.Value)
-                    .StartWith("")
+                    .StartWith(Search)
                     .Select<string, Func<ModListMetadataVM, bool>>(txt =>
                     {
                         if (string.IsNullOrWhiteSpace(txt)) return _ => true;


### PR DESCRIPTION
Fixes #2084 

Applied the saved search string to the searchtextpredicate .startwith parameter, so that it always applies the last text filter.

This will ensure that when pressing back and then re-accessing the gallery, it dosnt just display the last text filter, it also applies it, instead of the default "" previously.