### PR TITLE
Protected folder subfolder handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Version TBD
 * Fixed issues related to high RAM usage
   * The resumable downloads now reserve drive space to write to in advance instead of being managed in system RAM
+  * Added more robust checking for protected location paths and subfolders for the launcher exe and install and download paths
 
 #### Version - 3.1.0.0 - 5/7/2023
 * Fixed Readme opening twice

--- a/Wabbajack.App.Wpf/View Models/Installers/InstallerVM.cs
+++ b/Wabbajack.App.Wpf/View Models/Installers/InstallerVM.cs
@@ -34,6 +34,7 @@ using Wabbajack.RateLimiter;
 using Wabbajack.Paths.IO;
 using Wabbajack.Services.OSIntegrated;
 using Wabbajack.Util;
+using System.Diagnostics;
 
 namespace Wabbajack;
 
@@ -295,6 +296,10 @@ public class InstallerVM : BackNavigatingVM, IBackNavigatingVM, ICpuStatusVM
         if (KnownFolders.EntryPoint.ThisAndAllParents().Any(path => installPath == path))
         { 
             yield return ErrorResponse.Fail("Installing in this folder may overwrite Wabbajack");
+        }
+        if (KnownFolders.IsInSpecialFolder(installPath) || KnownFolders.IsInSpecialFolder(downloadPath))
+        {
+            yield return ErrorResponse.Fail("Can't install a modlist into Windows protected locations - such as Downloads, Documents etc");
         }
     }
 

--- a/Wabbajack.App.Wpf/View Models/Installers/InstallerVM.cs
+++ b/Wabbajack.App.Wpf/View Models/Installers/InstallerVM.cs
@@ -301,7 +301,6 @@ public class InstallerVM : BackNavigatingVM, IBackNavigatingVM, ICpuStatusVM
             yield return ErrorResponse.Fail("Can't install a modlist into Windows protected locations - such as Downloads, Documents etc");
         }
     }
-
     
     private async Task BeginSlideShow(CancellationToken token)
     {

--- a/Wabbajack.App.Wpf/View Models/Installers/InstallerVM.cs
+++ b/Wabbajack.App.Wpf/View Models/Installers/InstallerVM.cs
@@ -34,7 +34,6 @@ using Wabbajack.RateLimiter;
 using Wabbajack.Paths.IO;
 using Wabbajack.Services.OSIntegrated;
 using Wabbajack.Util;
-using System.Diagnostics;
 
 namespace Wabbajack;
 

--- a/Wabbajack.Launcher/ViewModels/MainWindowViewModel.cs
+++ b/Wabbajack.Launcher/ViewModels/MainWindowViewModel.cs
@@ -51,6 +51,7 @@ public class MainWindowViewModel : ViewModelBase
     private async Task CheckForUpdates()
     {
         await VerifyCurrentLocation();
+
         _client.Headers.Add("user-agent", "Wabbajack Launcher");
         Status = "Selecting Release";
 

--- a/Wabbajack.Launcher/ViewModels/MainWindowViewModel.cs
+++ b/Wabbajack.Launcher/ViewModels/MainWindowViewModel.cs
@@ -51,7 +51,6 @@ public class MainWindowViewModel : ViewModelBase
     private async Task CheckForUpdates()
     {
         await VerifyCurrentLocation();
-
         _client.Headers.Add("user-agent", "Wabbajack Launcher");
         Status = "Selecting Release";
 
@@ -222,11 +221,9 @@ public class MainWindowViewModel : ViewModelBase
         try
         {
             var entryPoint = KnownFolders.EntryPoint;
-            if (entryPoint.FileName == "Desktop".ToRelativePath()
-                || entryPoint.Depth <= 1
-                || entryPoint.FileName == "Downloads".ToRelativePath())
+            Debug.WriteLine("entrypoint = " + entryPoint.ToString());
+            if (KnownFolders.IsInSpecialFolder(entryPoint) || entryPoint.Depth <= 1)
             {
-
                 var msg = MessageBox.Avalonia.MessageBoxManager
                     .GetMessageBoxStandardWindow(new MessageBoxStandardParams()
                     {
@@ -234,7 +231,7 @@ public class MainWindowViewModel : ViewModelBase
                         ShowInCenter = true,
                         ContentTitle = "Wabbajack Launcher: Bad startup path",
                         ContentMessage =
-                            "Cannot start in the root, Downloads or Desktop folders.\nPlease move Wabbajack to another folder."
+                            "Cannot start in the root of a drive, or protected folder locations such as Downloads, Desktop etc.\nPlease move Wabbajack to another folder."
                     });
                 var result = await msg.Show();
                 Environment.Exit(1);

--- a/Wabbajack.Paths.IO/KnownFolders.cs
+++ b/Wabbajack.Paths.IO/KnownFolders.cs
@@ -49,7 +49,6 @@ public static class KnownFolders
         foreach (var val in Enum.GetValues(typeof(Environment.SpecialFolder)))
         {
             AbsolutePath specialPath = Environment.GetFolderPath((Environment.SpecialFolder)val).ToAbsolutePath();
-
             if ((candidate.ToString().Length > 0 && candidate == specialPath)
                 || KnownFolders.IsSubDirectoryOf(candidate.ToString(), specialPath.ToString()))
             {

--- a/Wabbajack.Paths.IO/KnownFolders.cs
+++ b/Wabbajack.Paths.IO/KnownFolders.cs
@@ -44,6 +44,49 @@ public static class KnownFolders
         }
     }
 
+    public static bool IsInSpecialFolder(this AbsolutePath candidate)
+    {
+        foreach (var val in Enum.GetValues(typeof(Environment.SpecialFolder)))
+        {
+            AbsolutePath specialPath = Environment.GetFolderPath((Environment.SpecialFolder)val).ToAbsolutePath();
+
+            if ((candidate.ToString().Length > 0 && candidate == specialPath)
+                || KnownFolders.IsSubDirectoryOf(candidate.ToString(), specialPath.ToString()))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+    public static bool IsSubDirectoryOf(this string candidate, string other)
+    {
+        if (candidate.Length == 0) return false;
+        if (other.Length == 0) return false;
+        var isChild = false;
+        try
+        {
+            var candidateInfo = new DirectoryInfo(candidate);
+            var otherInfo = new DirectoryInfo(other);
+
+            while (candidateInfo.Parent != null)
+            {
+                if (candidateInfo.Parent.FullName == otherInfo.FullName)
+                {
+                    isChild = true;
+                    break;
+                }
+                else candidateInfo = candidateInfo.Parent;
+            }
+        }
+        catch (Exception error)
+        {
+            var message = String.Format("Unable to check directories {0} and {1}: {2}", candidate, other, error);
+            Trace.WriteLine(message);
+        }
+
+        return isChild;
+    }
+
     public static AbsolutePath AppDataLocal =>
         Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData).ToAbsolutePath();
 


### PR DESCRIPTION
Fixes #2272 

Added more comprehensive checking for paths being special Windows protected locations, or subfolders of them.

Added checks to install path/download path verification, and wabbajack launcher exe location.

Compiled and tested by selecting install/download paths in Documents folder, Desktop, Downloads, and subfolders of them, and WJ blocked it.

Tested the exe running from those same folders and got the error message

Tested existing behavior was not impacted in non-special locations.

I am not entirely sure how this would (if at all ) change anything for those who attempt to use WJ via Linux 
( feedback welcome on that )

