### PR TITLE
Added check if Download path is in same location as wabbajack.exe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Version TBD
 * Fixed issues related to high RAM usage
   * The resumable downloads now reserve drive space to write to in advance instead of being managed in system RAM
+  * Added check if Downloadpath is alongside Wabbajack.exe location, to match the installpath check already existing
 
 #### Version - 3.1.0.0 - 5/7/2023
 * Fixed Readme opening twice

--- a/Wabbajack.App.Wpf/View Models/Installers/InstallerVM.cs
+++ b/Wabbajack.App.Wpf/View Models/Installers/InstallerVM.cs
@@ -291,7 +291,8 @@ public class InstallerVM : BackNavigatingVM, IBackNavigatingVM, ICpuStatusVM
         
         if (installPath.InFolder(KnownFolders.EntryPoint))
             yield return ErrorResponse.Fail("Can't install a modlist into the Wabbajack.exe path");
-
+        if (downloadPath.InFolder(KnownFolders.EntryPoint))
+            yield return ErrorResponse.Fail("Can't download a modlist into the Wabbajack.exe path");
         if (KnownFolders.EntryPoint.ThisAndAllParents().Any(path => installPath == path))
         { 
             yield return ErrorResponse.Fail("Installing in this folder may overwrite Wabbajack");


### PR DESCRIPTION
Fixes #2360 

There is already an existing check if an install path is selected that uses the same folder as wabbajack.exe 

This just adds a similar check for download path, as per the linked issue, it is something to warn the user about.

Tested and works and dosnt impact non-blocking behavior