### PR TITLE
Dont allow identical paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Version TBD
 * Fixed issues related to high RAM usage
   * The resumable downloads now reserve drive space to write to in advance instead of being managed in system RAM
+  * Added check for identical download and install paths
 
 #### Version - 3.1.0.0 - 5/7/2023
 * Fixed Readme opening twice

--- a/Wabbajack.App.Wpf/View Models/Installers/InstallerVM.cs
+++ b/Wabbajack.App.Wpf/View Models/Installers/InstallerVM.cs
@@ -273,7 +273,10 @@ public class InstallerVM : BackNavigatingVM, IBackNavigatingVM, ICpuStatusVM
             yield return ErrorResponse.Fail("Install path isn't set to a folder");
         if (installPath.InFolder(KnownFolders.Windows))
             yield return ErrorResponse.Fail("Don't install modlists into your Windows folder");
-
+        if( installPath.ToString().Length > 0 && downloadPath.ToString().Length > 0 && installPath == downloadPath)
+        {
+            yield return ErrorResponse.Fail("Can't have identical install and download folders");
+        }
         foreach (var game in GameRegistry.Games)
         {
             if (!_gameLocator.TryFindLocation(game.Key, out var location))


### PR DESCRIPTION
Fixes #2267 

Added a simple check for equality on non-zero length paths when selecting install and download locations

Tested and confirmed working and non-identical path handling not impacted

( supercedes #2359   as now PRing from main repo )