### PR TITLE
Fix readme opening twice after pressing install button from gallery view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Version TBD
 * Fixed issues related to high RAM usage
   * The resumable downloads now reserve drive space to write to in advance instead of being managed in system RAM
+  * Fixed readme double opening when modlist details are prepoulated
 
 #### Version - 3.1.0.0 - 5/7/2023
 * Fixed Readme opening twice

--- a/Wabbajack.App.Wpf/View Models/Installers/InstallerVM.cs
+++ b/Wabbajack.App.Wpf/View Models/Installers/InstallerVM.cs
@@ -218,7 +218,8 @@ public class InstallerVM : BackNavigatingVM, IBackNavigatingVM, ICpuStatusVM
         });
         
         MessageBus.Current.Listen<LoadModlistForInstalling>()
-            .Subscribe(msg => LoadModlist(msg.Path, msg.Metadata).FireAndForget())
+            .Subscribe(msg => LoadModlistFromGallery(msg.Path, msg.Metadata).FireAndForget())
+            //.Subscribe(msg => LoadModlist(msg.Path, msg.Metadata).FireAndForget())
             .DisposeWith(CompositeDisposable);
 
         MessageBus.Current.Listen<LoadLastLoadedModlist>()
@@ -318,6 +319,12 @@ public class InstallerVM : BackNavigatingVM, IBackNavigatingVM, ICpuStatusVM
         {
             ModListLocation.TargetPath = lst;
         }
+    }
+
+    private async Task LoadModlistFromGallery(AbsolutePath path, ModlistMetadata metadata)
+    {
+        ModListLocation.TargetPath = path;
+        ModlistMetadata = metadata;
     }
 
     private async Task LoadModlist(AbsolutePath path, ModlistMetadata? metadata)

--- a/Wabbajack.App.Wpf/View Models/Installers/InstallerVM.cs
+++ b/Wabbajack.App.Wpf/View Models/Installers/InstallerVM.cs
@@ -219,7 +219,6 @@ public class InstallerVM : BackNavigatingVM, IBackNavigatingVM, ICpuStatusVM
         
         MessageBus.Current.Listen<LoadModlistForInstalling>()
             .Subscribe(msg => LoadModlistFromGallery(msg.Path, msg.Metadata).FireAndForget())
-            //.Subscribe(msg => LoadModlist(msg.Path, msg.Metadata).FireAndForget())
             .DisposeWith(CompositeDisposable);
 
         MessageBus.Current.Listen<LoadLastLoadedModlist>()


### PR DESCRIPTION
Fixes #2279 

I think I did this following the style of Reactive, like the wrapper for LoadLastModlist() which is prompted when "load from file" is chosen - it dosnt run loadmodlist() it just changes the targetpath and the listener for the path change runs loadmodlist()

Tested everything seems to work as it should, and readme only opens once after pressing install button in gallery view.

New to Reactive , so please let me know if I misunderstood anything

(Supersedes #2356 as now PRing from main repo )