### PR TITLE
Hide back button and settings button during install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Version TBD
 * Fixed issues related to high RAM usage
   * The resumable downloads now reserve drive space to write to in advance instead of being managed in system RAM
+  * Fixed allowing back button during install which can result in multiple install processes
 
 #### Version - 3.1.0.0 - 5/7/2023
 * Fixed Readme opening twice

--- a/Wabbajack.App.Wpf/Views/Installers/InstallationView.xaml.cs
+++ b/Wabbajack.App.Wpf/Views/Installers/InstallationView.xaml.cs
@@ -39,6 +39,11 @@ namespace Wabbajack
                     .BindToStrict(this, view => view.BackButton.Command)
                     .DisposeWith(disposables);
 
+                ViewModel.WhenAnyValue(vm => vm.InstallState)
+                    .Select(v => v == InstallState.Installing ? Visibility.Collapsed : Visibility.Visible)
+                    .BindToStrict(this, view => view.BackButton.Visibility)
+                    .DisposeWith(disposables);
+
                 ViewModel.WhenAnyValue(vm => vm.OpenReadmeCommand)
                     .BindToStrict(this, view => view.OpenReadmePreInstallButton.Command)
                     .DisposeWith(disposables);

--- a/Wabbajack.App.Wpf/Views/MainWindow.xaml.cs
+++ b/Wabbajack.App.Wpf/Views/MainWindow.xaml.cs
@@ -118,7 +118,12 @@ namespace Wabbajack
 
                 ((MainWindowVM) DataContext).WhenAnyValue(vm => vm.OpenSettingsCommand)
                     .BindTo(this, view => view.SettingsButton.Command);
-                    
+
+                ((MainWindowVM)DataContext).WhenAnyValue(vm => vm.Installer.InstallState)
+                    .ObserveOn(RxApp.MainThreadScheduler)
+                    .Select(v => v == InstallState.Installing ? Visibility.Collapsed : Visibility.Visible)
+                    .BindTo(this, view => view.SettingsButton.Visibility);
+
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Partially fixes #2315 

Currently a user can press the back button during downloading/install, and the download threads will still keep going, but the user can then select a modlist again, and start the install, prompting another install process to start ( and get the errors in the linked issue )

The same can happen with settings menu ( pressing back on that will take back to main mode selection window )

This fixes that behavior by hiding those UI elements during install.

The settings menu changes do not likely take effect during an install anyway, so there is no point in allowing access to that menu during install.

I say Partially Fixes because the linked issue is also a matter of documentation