### PR TITLE
Add some safety for choosing an installpath with existing files to avoid unrecoverable deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Version TBD
 * Fixed issues related to high RAM usage
   * The resumable downloads now reserve drive space to write to in advance instead of being managed in system RAM
+  * Added safety to install path selection, to ensure that no files are deleted that are not intended to be.
 
 #### Version - 3.1.0.0 - 5/7/2023
 * Fixed Readme opening twice

--- a/Wabbajack.App.Wpf/View Models/Installers/InstallerVM.cs
+++ b/Wabbajack.App.Wpf/View Models/Installers/InstallerVM.cs
@@ -34,6 +34,7 @@ using Wabbajack.RateLimiter;
 using Wabbajack.Paths.IO;
 using Wabbajack.Services.OSIntegrated;
 using Wabbajack.Util;
+using System.Windows.Forms;
 
 namespace Wabbajack;
 
@@ -132,6 +133,8 @@ public class InstallerVM : BackNavigatingVM, IBackNavigatingVM, ICpuStatusVM
     public bool ShowNSFWSlides { get; set; }
     
     public LogStream LoggerProvider { get; }
+
+    private AbsolutePath LastInstallPath { get; set; }
     
     
     // Command properties
@@ -296,6 +299,23 @@ public class InstallerVM : BackNavigatingVM, IBackNavigatingVM, ICpuStatusVM
         { 
             yield return ErrorResponse.Fail("Installing in this folder may overwrite Wabbajack");
         }
+        if (installPath.ToString().Length != 0 && installPath != LastInstallPath && 
+            !Installer.AutomaticallyOverwrite && 
+            Directory.EnumerateFileSystemEntries(installPath.ToString()).Any())
+        {
+            string message = "There are existing files in the chosen install path, they will be deleted or overwritten (if updating existing modlist), continue?";
+            string title = "Files found in install folder";
+            MessageBoxButtons buttons = MessageBoxButtons.YesNo;
+            DialogResult result = MessageBox.Show(message, title, buttons);
+            if (result == DialogResult.Yes)
+            {
+                // everythings fine
+            }
+            else
+            {
+                Installer.Location.TargetPath = "".ToAbsolutePath();
+            }
+        }
     }
 
     
@@ -357,6 +377,7 @@ public class InstallerVM : BackNavigatingVM, IBackNavigatingVM, ICpuStatusVM
             if (prevSettings.ModListLocation == path)
             {
                 ModListLocation.TargetPath = prevSettings.ModListLocation;
+                LastInstallPath = prevSettings.InstallLocation;
                 Installer.Location.TargetPath = prevSettings.InstallLocation;
                 Installer.DownloadLocation.TargetPath = prevSettings.DownloadLoadction;
                 ModlistMetadata = metadata ?? prevSettings.Metadata;


### PR DESCRIPTION
Partially Fixes #2262 

Wabbajack by default will delete any files in a folder if user chooses a folder with existing files as the installpath, with no prompt.

This adds a dialog to confirm the user wants to proceed if files are detected in that folder.

The overwrite install tickbox will avoid the dialogue prompt, selecting "no" on the dialogue will clear the installpath.

Ideally the tickbox preference would be saved, and the previous pre 3.0 behavior of only checking for existing modlists during the mo2installervm logic. But that section is a big TODO in the code, and would take a lot more work to reconnect up , so this adds some safety in the meantime