### PR TITLE
Commenting out LoversLab login from the settings page to avoid user confusion.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 #### Version TBD
 * Fixed issues related to high RAM usage
   * The resumable downloads now reserve drive space to write to in advance instead of being managed in system RAM
+* remove LoversLab from the "Logins" Setting because it is deprecated for ages now and only causes confusion,
+  just for the unlikely probability that LL will fix their proper API.
 
 #### Version - 3.1.0.0 - 5/7/2023
 * Fixed Readme opening twice

--- a/Wabbajack.App.Wpf/App.xaml.cs
+++ b/Wabbajack.App.Wpf/App.xaml.cs
@@ -182,7 +182,9 @@ namespace Wabbajack
             services.AddTransient<LoversLabLoginHandler>();
 
             // Login Managers
-            services.AddAllSingleton<INeedsLogin, LoversLabLoginManager>();
+            
+            //Disabled because they are currently not used and bro
+            //services.AddAllSingleton<INeedsLogin, LoversLabLoginManager>();
             services.AddAllSingleton<INeedsLogin, NexusLoginManager>();
             services.AddAllSingleton<INeedsLogin, VectorPlexusLoginManager>();
             services.AddSingleton<ManualDownloadHandler>();

--- a/Wabbajack.App.Wpf/App.xaml.cs
+++ b/Wabbajack.App.Wpf/App.xaml.cs
@@ -183,7 +183,7 @@ namespace Wabbajack
 
             // Login Managers
             
-            //Disabled because they are currently not used and bro
+            //Disabled LL because it is currently not used and broken due to the way LL butchers their API
             //services.AddAllSingleton<INeedsLogin, LoversLabLoginManager>();
             services.AddAllSingleton<INeedsLogin, NexusLoginManager>();
             services.AddAllSingleton<INeedsLogin, VectorPlexusLoginManager>();


### PR DESCRIPTION
The current way to implement LL downloads is `manualURL=` + `prompt=` https://wiki.wabbajack.org/modlist_author_documentation/Meta%20Files.html#manualurl

The branch contains Vector Plexus in its name since I thought it was broken due to no one using it, but it was already updated to the vectorplexis domain change and seems to be working so far.