### PR TITLE
Additional UI changes to help user confusion and information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### Changelog
 
+### Version - TBA
+  * Fixed some UI issues arising from 3.2.0.0 changes - more informative error text, drive space checking, wiki link button
+
 #### Version - 3.2.0.0 - 7/16/2023
   * Fixed issues related to high RAM usage
   * The resumable downloads now reserve drive space to write to in advance instead of being managed in system RAM

--- a/Wabbajack.App.Wpf/View Models/Installers/InstallerVM.cs
+++ b/Wabbajack.App.Wpf/View Models/Installers/InstallerVM.cs
@@ -336,7 +336,7 @@ public class InstallerVM : BackNavigatingVM, IBackNavigatingVM, ICpuStatusVM
 
         if (KnownFolders.IsInSpecialFolder(installPath) || KnownFolders.IsInSpecialFolder(downloadPath))
         {
-            yield return ErrorResponse.Fail("Can't install a modlist into Windows protected locations - such as Downloads,Documents etc, please make a new folder for the modlist.");
+            yield return ErrorResponse.Fail("Can't install into Windows locations such as Documents etc, please make a new folder for the modlist - C:\Wabbajack\ for example.");
         }
 
         if (installPath.ToString().Length > 0 && downloadPath.ToString().Length > 0 && !HasEnoughSpace(installPath, downloadPath)){

--- a/Wabbajack.App.Wpf/View Models/Installers/InstallerVM.cs
+++ b/Wabbajack.App.Wpf/View Models/Installers/InstallerVM.cs
@@ -336,7 +336,7 @@ public class InstallerVM : BackNavigatingVM, IBackNavigatingVM, ICpuStatusVM
 
         if (KnownFolders.IsInSpecialFolder(installPath) || KnownFolders.IsInSpecialFolder(downloadPath))
         {
-            yield return ErrorResponse.Fail("Can't install into Windows locations such as Documents etc, please make a new folder for the modlist - C:\Wabbajack\ for example.");
+            yield return ErrorResponse.Fail("Can't install into Windows locations such as Documents etc, please make a new folder for the modlist - C:\\ModList\\ for example.");
         }
 
         if (installPath.ToString().Length > 0 && downloadPath.ToString().Length > 0 && !HasEnoughSpace(installPath, downloadPath)){

--- a/Wabbajack.App.Wpf/View Models/Installers/InstallerVM.cs
+++ b/Wabbajack.App.Wpf/View Models/Installers/InstallerVM.cs
@@ -322,7 +322,8 @@ public class InstallerVM : BackNavigatingVM, IBackNavigatingVM, ICpuStatusVM
         if (installPath.ToString().Length != 0 && installPath != LastInstallPath && !OverwriteFiles &&
             Directory.EnumerateFileSystemEntries(installPath.ToString()).Any())
         {
-            yield return ErrorResponse.Fail("There are files in the install folder, please tick 'Overwrite Installation' to confirm you want to install to this folder, if you are updating an existing modlist, this is fine.");
+            yield return ErrorResponse.Fail("There are files in the install folder, please tick 'Overwrite Installation' to confirm you want to install to this folder " + Environment.NewLine + 
+                 "if you are updating an existing modlist, then this is expected and can be overwritten.");
         }
 
         if (KnownFolders.IsInSpecialFolder(installPath) || KnownFolders.IsInSpecialFolder(downloadPath))

--- a/Wabbajack.App.Wpf/View Models/Installers/InstallerVM.cs
+++ b/Wabbajack.App.Wpf/View Models/Installers/InstallerVM.cs
@@ -35,8 +35,6 @@ using Wabbajack.Paths.IO;
 using Wabbajack.Services.OSIntegrated;
 using Wabbajack.Util;
 using System.Windows.Forms;
-using System.Web;
-using System.Diagnostics;
 
 namespace Wabbajack;
 

--- a/Wabbajack.App.Wpf/View Models/Installers/MO2InstallerVM.cs
+++ b/Wabbajack.App.Wpf/View Models/Installers/MO2InstallerVM.cs
@@ -39,6 +39,9 @@ namespace Wabbajack
 
         public bool SupportsAfterInstallNavigation => true;
 
+        [Reactive]
+        public bool AutomaticallyOverwrite { get; set; }
+        
         public int ConfigVisualVerticalOffset => 25;
 
         public MO2InstallerVM(InstallerVM installerVM)
@@ -163,6 +166,7 @@ namespace Wabbajack
             if (settings == null) return;
             settings.InstallationLocation = Location.TargetPath;
             settings.DownloadLocation = DownloadLocation.TargetPath;
+            settings.AutomaticallyOverrideExistingInstall = AutomaticallyOverwrite;
         }
 
         public void AfterInstallNavigation()

--- a/Wabbajack.App.Wpf/View Models/Installers/MO2InstallerVM.cs
+++ b/Wabbajack.App.Wpf/View Models/Installers/MO2InstallerVM.cs
@@ -41,7 +41,7 @@ namespace Wabbajack
 
         [Reactive]
         public bool AutomaticallyOverwrite { get; set; }
-        
+
         public int ConfigVisualVerticalOffset => 25;
 
         public MO2InstallerVM(InstallerVM installerVM)

--- a/Wabbajack.App.Wpf/View Models/Installers/MO2InstallerVM.cs
+++ b/Wabbajack.App.Wpf/View Models/Installers/MO2InstallerVM.cs
@@ -39,9 +39,6 @@ namespace Wabbajack
 
         public bool SupportsAfterInstallNavigation => true;
 
-        [Reactive]
-        public bool AutomaticallyOverwrite { get; set; }
-
         public int ConfigVisualVerticalOffset => 25;
 
         public MO2InstallerVM(InstallerVM installerVM)
@@ -166,7 +163,6 @@ namespace Wabbajack
             if (settings == null) return;
             settings.InstallationLocation = Location.TargetPath;
             settings.DownloadLocation = DownloadLocation.TargetPath;
-            settings.AutomaticallyOverrideExistingInstall = AutomaticallyOverwrite;
         }
 
         public void AfterInstallNavigation()

--- a/Wabbajack.App.Wpf/Views/Installers/InstallationCompleteView.xaml
+++ b/Wabbajack.App.Wpf/Views/Installers/InstallationCompleteView.xaml
@@ -12,12 +12,13 @@
     x:TypeArguments="local:InstallerVM"
     mc:Ignorable="d">
     <local:AttentionBorder x:Name="AttentionBorder" ClipToBounds="True">
-        <Grid Margin="5">
+        <Grid Margin="6">
             <Grid.RowDefinitions>
                 <RowDefinition Height="*" />
                 <RowDefinition Height="3*" />
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="*" />
@@ -124,11 +125,34 @@
                 <TextBlock Grid.Row="1"
                     Margin="0,10,0,0"
                     HorizontalAlignment="Center"
-                    Text="Readme" />
+                    Text="Modlist Readme" />
             </Grid>
             <Grid Grid.Row="1" Grid.Column="4"
+                VerticalAlignment="Center"
+                Background="Transparent">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+                <Button
+                    x:Name="OpenWikiButton"
+                    Width="50"
+                    Height="50"
+                    Style="{StaticResource CircleButtonStyle}">
+                    <icon:PackIconFontAwesome
+                        Width="25"
+                        Height="25"
+                        Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type Button}}}"
+                        Kind="QuestionSolid" />
+                </Button>
+                <TextBlock Grid.Row="1"
+                    Margin="0,10,0,0"
+                    HorizontalAlignment="Center"
+                    Text="Help and Wiki" />
+            </Grid>
+            <Grid Grid.Row="1" Grid.Column="5"
                   VerticalAlignment="Center"
-                  Background="Transparent">
+                  Background="Transparent" Grid.ColumnSpan="2" Margin="0,0,10,0">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />

--- a/Wabbajack.App.Wpf/Views/Installers/InstallationCompleteView.xaml.cs
+++ b/Wabbajack.App.Wpf/Views/Installers/InstallationCompleteView.xaml.cs
@@ -46,6 +46,9 @@ namespace Wabbajack
                 this.WhenAny(x => x.ViewModel.OpenReadmeCommand)
                     .BindToStrict(this, x => x.OpenReadmeButton.Command)
                     .DisposeWith(dispose);
+                this.WhenAny(x => x.ViewModel.OpenWikiCommand)
+                    .BindToStrict(this, x => x.OpenWikiButton.Command)
+                    .DisposeWith(dispose);
                 this.WhenAny(x => x.ViewModel.CloseWhenCompleteCommand)
                     .BindToStrict(this, x => x.CloseButton.Command)
                     .DisposeWith(dispose);

--- a/Wabbajack.App.Wpf/Views/Installers/InstallationConfigurationView.xaml
+++ b/Wabbajack.App.Wpf/Views/Installers/InstallationConfigurationView.xaml
@@ -81,10 +81,11 @@
                 <RowDefinition Height="*" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="*" />
+                <RowDefinition Height="*" />
             </Grid.RowDefinitions>
             <local:BeginButton Grid.Row="1"
                 x:Name="BeginButton"
-                HorizontalAlignment="Right"
+                HorizontalAlignment="Center"
                 VerticalAlignment="Center" />
             <icon:PackIconFontAwesome Grid.Row="2"
                 x:Name="ErrorSummaryIconGlow"
@@ -99,8 +100,27 @@
             <icon:PackIconFontAwesome Grid.Row="2"
                 x:Name="ErrorSummaryIcon"
                 HorizontalAlignment="Center"
+                VerticalAlignment="Top"
                 Foreground="{StaticResource WarningBrush}"
                 Kind="ExclamationTriangleSolid" />
+            <CheckBox Grid.Row="2" Grid.Column="2"
+            HorizontalAlignment="Center"
+            VerticalAlignment="Bottom"
+            x:Name="OverwriteCheckBox"
+            Content="Overwrite Installation"
+            IsChecked="False"
+            ToolTip="Confirm to overwrite files in install folder.">
+                <CheckBox.Style>
+                    <Style TargetType="CheckBox">
+                        <Setter Property="Opacity" Value="0.6" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding IsMouseOver, RelativeSource={RelativeSource Self}}" Value="True">
+                                <Setter Property="Opacity" Value="1" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </CheckBox.Style>
+            </CheckBox>
         </Grid>
     </Grid>
 </rxui:ReactiveUserControl>

--- a/Wabbajack.App.Wpf/Views/Installers/InstallationConfigurationView.xaml
+++ b/Wabbajack.App.Wpf/Views/Installers/InstallationConfigurationView.xaml
@@ -39,6 +39,13 @@
                 FontSize="14"
                 Text="Target Modlist"
                 TextAlignment="Center" />
+            <TextBlock x:Name="errorTextBox"
+                Grid.Row="3"
+                FontFamily="Verdana" FontSize="10" FontWeight="ExtraBold"
+                Background="{StaticResource WindowBackgroundBrush}"
+                Foreground="Red"
+                Text=""
+                TextAlignment="Left" Margin="0,79,0,-45" Grid.ColumnSpan="3" />
             <local:FilePicker Grid.Row="1" Grid.Column="2"
                 x:Name="ModListLocationPicker"
                 Height="30"

--- a/Wabbajack.App.Wpf/Views/Installers/InstallationConfigurationView.xaml.cs
+++ b/Wabbajack.App.Wpf/Views/Installers/InstallationConfigurationView.xaml.cs
@@ -46,7 +46,12 @@ namespace Wabbajack
                     .Select(v => !v.Failed)
                     .BindToStrict(this, view => view.BeginButton.IsEnabled)
                     .DisposeWith(dispose);
-                
+
+                this.WhenAnyValue(x => x.ViewModel.ErrorState)
+                    .Select(v => v.Reason)
+                    .BindToStrict(this, view => view.errorTextBox.Text)
+                    .DisposeWith(dispose);
+
                 this.WhenAnyValue(x => x.ViewModel.ErrorState)
                     .Select(v => v.Failed ? Visibility.Visible : Visibility.Hidden)
                     .BindToStrict(this, view => view.ErrorSummaryIcon.Visibility)

--- a/Wabbajack.App.Wpf/Views/Installers/InstallationConfigurationView.xaml.cs
+++ b/Wabbajack.App.Wpf/Views/Installers/InstallationConfigurationView.xaml.cs
@@ -39,9 +39,11 @@ namespace Wabbajack
                 this.WhenAny(x => x.ViewModel.BeginCommand)
                     .BindToStrict(this, x => x.BeginButton.Command)
                     .DisposeWith(dispose);
-                
+                this.BindStrict(ViewModel, vm => vm.OverwriteFiles, x => x.OverwriteCheckBox.IsChecked)
+                    .DisposeWith(dispose);
+
                 // Error handling
-                
+
                 this.WhenAnyValue(x => x.ViewModel.ErrorState)
                     .Select(v => !v.Failed)
                     .BindToStrict(this, view => view.BeginButton.IsEnabled)

--- a/Wabbajack.App.Wpf/Views/Installers/MO2InstallerConfigView.xaml
+++ b/Wabbajack.App.Wpf/Views/Installers/MO2InstallerConfigView.xaml
@@ -46,21 +46,5 @@
             FontSize="14"
             PickerVM="{Binding DownloadLocation}"
             ToolTip="The directory where modlist archives will be downloaded to" />
-        <CheckBox Grid.Row="2" Grid.Column="2"
-            HorizontalAlignment="Right"
-            Content="Overwrite Installation"
-            IsChecked="{Binding AutomaticallyOverwrite}"
-            ToolTip="If installing over an existing installation, automatically replace it without asking permission.">
-            <CheckBox.Style>
-                <Style TargetType="CheckBox">
-                    <Setter Property="Opacity" Value="0.6" />
-                    <Style.Triggers>
-                        <DataTrigger Binding="{Binding IsMouseOver, RelativeSource={RelativeSource Self}}" Value="True">
-                            <Setter Property="Opacity" Value="1" />
-                        </DataTrigger>
-                    </Style.Triggers>
-                </Style>
-            </CheckBox.Style>
-        </CheckBox>
     </Grid>
 </UserControl>

--- a/Wabbajack.App.Wpf/Views/Interventions/ConfirmUpdateOfExistingInstallView.xaml
+++ b/Wabbajack.App.Wpf/Views/Interventions/ConfirmUpdateOfExistingInstallView.xaml
@@ -33,13 +33,6 @@
         <TextBlock Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="3"
             x:Name="ExtendedDescription"
             TextWrapping="WrapWithOverflow" />
-        <CheckBox Grid.Row="2" Grid.Column="2"
-            x:Name="AutoOverwriteCheckbox"
-            Margin="4"
-            HorizontalAlignment="Right"
-            Content="Remember"
-            IsChecked="{Binding Installer.AutomaticallyOverwrite}"
-            ToolTip="If installing over an existing installation next time, automatically replace it without asking permission." />
         <Button Grid.Row="3" Grid.Column="0"
             x:Name="CancelButton"
             Content="Cancel" />

--- a/Wabbajack.App.Wpf/Views/Interventions/ConfirmUpdateOfExistingInstallView.xaml.cs
+++ b/Wabbajack.App.Wpf/Views/Interventions/ConfirmUpdateOfExistingInstallView.xaml.cs
@@ -40,11 +40,6 @@ namespace Wabbajack
                 this.WhenAny(x => x.ViewModel.Source.CancelCommand)
                     .BindToStrict(this, x => x.CancelButton.Command)
                     .DisposeWith(dispose);
-
-                this.BindStrict(this.ViewModel, x => x.Installer.AutomaticallyOverwrite, x => x.AutoOverwriteCheckbox.IsChecked,
-                        vmToViewConverter: x => x,
-                        viewToVmConverter: x => x ?? false)
-                    .DisposeWith(dispose);
             });
         }
     }

--- a/Wabbajack.Launcher/ViewModels/MainWindowViewModel.cs
+++ b/Wabbajack.Launcher/ViewModels/MainWindowViewModel.cs
@@ -22,6 +22,7 @@ using Wabbajack.Networking.Http.Interfaces;
 using Wabbajack.Networking.NexusApi;
 using Wabbajack.Paths;
 using Wabbajack.Paths.IO;
+#pragma warning disable SYSLIB0014
 
 namespace Wabbajack.Launcher.ViewModels;
 

--- a/Wabbajack.Launcher/ViewModels/MainWindowViewModel.cs
+++ b/Wabbajack.Launcher/ViewModels/MainWindowViewModel.cs
@@ -22,7 +22,6 @@ using Wabbajack.Networking.Http.Interfaces;
 using Wabbajack.Networking.NexusApi;
 using Wabbajack.Paths;
 using Wabbajack.Paths.IO;
-#pragma warning disable SYSLIB0014
 
 namespace Wabbajack.Launcher.ViewModels;
 
@@ -231,7 +230,7 @@ public class MainWindowViewModel : ViewModelBase
                         ShowInCenter = true,
                         ContentTitle = "Wabbajack Launcher: Bad startup path",
                         ContentMessage =
-                            "Cannot start in the root of a drive, or protected folder locations such as Downloads, Desktop etc.\nPlease move Wabbajack to another folder."
+                            "Cannot start in the root of a drive, or protected folder locations such as Downloads, Desktop etc.\nPlease move Wabbajack to another folder, creating a new folder if necessary ( example : C:\\Wabbajack\\, outside of these locations."
                     });
                 var result = await msg.Show();
                 Environment.Exit(1);

--- a/Wabbajack.Launcher/ViewModels/MainWindowViewModel.cs
+++ b/Wabbajack.Launcher/ViewModels/MainWindowViewModel.cs
@@ -231,7 +231,7 @@ public class MainWindowViewModel : ViewModelBase
                         ShowInCenter = true,
                         ContentTitle = "Wabbajack Launcher: Bad startup path",
                         ContentMessage =
-                            "Cannot start in the root of a drive, or protected folder locations such as Downloads, Desktop etc.\nPlease move Wabbajack to another folder, creating a new folder if necessary ( example : C:\\Wabbajack\\, outside of these locations."
+                            "Cannot start in the root of a drive, or protected folder locations such as Downloads, Desktop etc.\nPlease move Wabbajack to another folder, creating a new folder if necessary ( example : C:\\Wabbajack\\), outside of these locations."
                     });
                 var result = await msg.Show();
                 Environment.Exit(1);


### PR DESCRIPTION
Fixes #2372 

Added a few more features to the UI to help ease support burden.

Added check that the install folder isnt inside the download folder

Removed the overwrite installation checkbox - it didnt save its state anymore as far as I can tell, and clicking it saved you one click by avoiding the "are you sure you want to overwrite?" prompt.  - so clicking once to avoid one click isnt much of a good deal, and it caused user confusion as to its actual purpose.

I've added a hard drive space checker to the install and download paths, ( if same drive itll add the required download and install together ), and itll block the install if there isnt enough space

Ive added some red warning text under the file picker textbox, to additionally outline the current blocking error, so user does not need to be told "hover your mouse over warning label" to find out what the current error is.

Ive expanded the error message text for existing files in the chosen install path, to make it clear that if user is updating an existing modlist, then it is fine to continue.

Updated error message text for protected folders to be more clear about what a protected folder means, and what user might need to do to avoid targeting them

Ive added an additional button to the install failure screen, that links to the wabbajack wiki, so users might press it on an install failure and get some self-help

I have more comprehensive plans in this area, but I see this as more pressing in the meantime due to the number of support queries regarding these install blocking errors.

( self-conscious disclaimer - I am obviously still very new to ReactiveUI/WPF, and c# in general , coming from other languages I may not be aware of some common patterns, so apologies for the roughness of this  - currently nobody else is stepping up to fix these things in the short-term, so I will, but I will gladly step back if somebody implements these things better )


Pictures here: 


![image](https://github.com/wabbajack-tools/wabbajack/assets/85711747/525db093-57e7-447c-9095-dfcb7c7353c8)


![image](https://github.com/wabbajack-tools/wabbajack/assets/85711747/6b34f119-7fbb-4aa7-a64b-e1c19227c869)
