### PR TITLE
Add optional JSON flag to only show version number for modlist image in install view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### Changelog
 
+#### Version - TBA
+  * Added optional JSON flag for `DisplayVersionOnlyInInstallerView` to enable the installer image to only show version number.
+
 #### Version - 3.2.0.1 - 7/23/2023
   * Code cleanup: re-added some network and diagnostic code missing since 2.5
 

--- a/Wabbajack.App.Wpf/View Models/Gallery/ModListMetadataVM.cs
+++ b/Wabbajack.App.Wpf/View Models/Gallery/ModListMetadataVM.cs
@@ -83,6 +83,13 @@ namespace Wabbajack
         public string VersionText { get; private set; }
 
         [Reactive]
+        public bool ImageContainsTitle { get; private set; }
+
+        [Reactive]
+
+        public bool DisplayVersionOnlyInInstallerView { get; private set; }
+
+        [Reactive]
         public IErrorResponse Error { get; private set; }
 
         private readonly ObservableAsPropertyHelper<BitmapImage> _Image;
@@ -123,6 +130,8 @@ namespace Wabbajack
                     Metadata.DownloadMetadata.SizeOfArchives + Metadata.DownloadMetadata.SizeOfInstalledFiles
                 );
             VersionText = "Modlist version : " + Metadata.Version;
+            ImageContainsTitle = Metadata.ImageContainsTitle;
+            DisplayVersionOnlyInInstallerView = Metadata.DisplayVersionOnlyInInstallerView;
             IsBroken = metadata.ValidationSummary.HasFailures || metadata.ForceDown;
             // https://www.wabbajack.org/modlist/wj-featured/aldrnari
             OpenWebsiteCommand = ReactiveCommand.Create(() => UIUtils.OpenWebsite(new Uri($"https://www.wabbajack.org/modlist/{Metadata.NamespacedName}")));

--- a/Wabbajack.App.Wpf/View Models/Installers/InstallerVM.cs
+++ b/Wabbajack.App.Wpf/View Models/Installers/InstallerVM.cs
@@ -521,7 +521,14 @@ public class InstallerVM : BackNavigatingVM, IBackNavigatingVM, ICpuStatusVM
 
     private void PopulateSlideShow(ModList modList)
     {
-        SlideShowTitle = modList.Name;
+        if (ModlistMetadata.ImageContainsTitle && ModlistMetadata.DisplayVersionOnlyInInstallerView)
+        {
+            SlideShowTitle = "v" + ModlistMetadata.Version.ToString();
+        }
+        else
+        {
+            SlideShowTitle = modList.Name;
+        }
         SlideShowAuthor = modList.Author;
         SlideShowDescription = modList.Description;
         SlideShowImage = ModListImage;

--- a/Wabbajack.DTOs/ModList/ModListMetadata.cs
+++ b/Wabbajack.DTOs/ModList/ModListMetadata.cs
@@ -30,6 +30,8 @@ public class ModlistMetadata
     [JsonPropertyName("image_contains_title")]
     public bool ImageContainsTitle { get; set; }
 
+    [JsonPropertyName("DisplayVersionOnlyInInstallerView")] public bool DisplayVersionOnlyInInstallerView { get; set; }
+
     [JsonPropertyName("force_down")] public bool ForceDown { get; set; }
 
     [JsonPropertyName("links")] public LinksObject Links { get; set; } = new();


### PR DESCRIPTION
Fixes #1524 

Bit of an obscure one, but it dosnt impact those who dont want it.

Add an optional flag in the modlist metadata json for `DisplayVersionOnlyInInstallerView = true` 

if this is true, then the version number only is displayed over the modlist image in the installer view, to remain consistent with the same behavior in the gallery tile view ( where there is no overlaid title for images that have title in them )

This new behavior is down to personal preference even more so dosnt follow the same flag, and uses a new one.


![image](https://github.com/wabbajack-tools/wabbajack/assets/85711747/8f621ddc-4d9d-4cfd-b65a-ae45442d3cd1)
