### PR TITLE
Fix issues preventing downloads

### DIFF
--- a/Wabbajack.App.Wpf/Views/MainWindow.xaml.cs
+++ b/Wabbajack.App.Wpf/Views/MainWindow.xaml.cs
@@ -45,6 +45,7 @@ namespace Wabbajack
 
                 Closed += (s, e) =>
                 {
+                    _logger.LogInformation("Beginning shutdown...");
                     _mwvm.CancelRunningTasks(TimeSpan.FromSeconds(10));
                     Application.Current.Shutdown();
                 };

--- a/Wabbajack.Common/HttpExtensions.cs
+++ b/Wabbajack.Common/HttpExtensions.cs
@@ -18,7 +18,11 @@ public static class HttpExtensions
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36";
     public static HttpRequestMessage AddCookies(this HttpRequestMessage msg, Cookie[] cookies)
     {
-        msg.Headers.Add("Cookie", string.Join(";", cookies.Select(c => $"{c.Name}={c.Value}")));
+        if (cookies.Length > 0)
+        {
+            msg.Headers.Add("Cookie", string.Join(";", cookies.Select(c => $"{c.Name}={c.Value}")));
+        }
+
         return msg;
     }
 

--- a/Wabbajack.Networking.Http/ResumableDownloader.cs
+++ b/Wabbajack.Networking.Http/ResumableDownloader.cs
@@ -166,8 +166,17 @@ internal class ResumableDownloader
             return null;
         }
 
-        var packageJson = _packagePath.ReadAllText();
-        return JsonSerializer.Deserialize<DownloadPackage>(packageJson);
+        try
+        {
+            var packageJson = _packagePath.ReadAllText();
+            return JsonSerializer.Deserialize<DownloadPackage>(packageJson);
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogWarning(ex, "Package for '{name}' couldn't be parsed. Deleting package and starting from scratch...", _outputPath.FileName.ToString());
+            DeletePackage();
+            return null;
+        }
     }
 
     private void SavePackage(DownloadPackage package)


### PR DESCRIPTION
Fixes the following issues:

* Building an HttpRequestMessage when no cookies are available causes a download error
```
00:02:55.089 [ERROR] (Wabbajack.Installer.StandardInstaller) Download error for file Draugr Upgrades and Improvements (latest)-54930-2-4-2-1639244041.7z|System.FormatException: The format of value '' is invalid.
   at System.Net.Http.Headers.HttpHeaderParser.ParseValue(String value, Object storeValue, Int32& index)
   at System.Net.Http.Headers.HttpHeaders.ParseAndAddValue(HeaderDescriptor descriptor, HeaderStoreItemInfo info, String value)
   at System.Net.Http.Headers.HttpHeaders.Add(HeaderDescriptor descriptor, String value)
   at Wabbajack.Common.HttpExtensions.AddCookies(HttpRequestMessage msg, Cookie[] cookies) in C:\oss\wabbajack\Wabbajack.Common\HttpExtensions.cs:line 21
   at Wabbajack.Common.HttpExtensions.ToHttpRequestMessage(BrowserDownloadState browserState) in C:\oss\wabbajack\Wabbajack.Common\HttpExtensions.cs:line 44
   at Wabbajack.Downloaders.NexusDownloader.DownloadManually(Archive archive, Nexus state, AbsolutePath destination, IJob job, CancellationToken token) in C:\oss\wabbajack\Wabbajack.Downloaders.Nexus\NexusDownloader.cs:line 191
   at Wabbajack.Downloaders.NexusDownloader.Download(Archive archive, Nexus state, AbsolutePath destination, IJob job, CancellationToken token) in C:\oss\wabbajack\Wabbajack.Downloaders.Nexus\NexusDownloader.cs:line 123
   at Wabbajack.Downloaders.DownloadDispatcher.Download(Archive a, AbsolutePath dest, Job`1 job, CancellationToken token, Nullable`1 useProxy) in C:\oss\wabbajack\Wabbajack.Downloaders.Dispatcher\DownloadDispatcher.cs:line 112
   at Wabbajack.Downloaders.DownloadDispatcher.Download(Archive a, AbsolutePath dest, CancellationToken token, Nullable`1 proxy) in C:\oss\wabbajack\Wabbajack.Downloaders.Dispatcher\DownloadDispatcher.cs:line 54
   at Wabbajack.Downloaders.DownloadDispatcher.DownloadWithPossibleUpgrade(Archive archive, AbsolutePath destination, CancellationToken token) in C:\oss\wabbajack\Wabbajack.Downloaders.Dispatcher\DownloadDispatcher.cs:line 155
   at Wabbajack.Installer.AInstaller`1.DownloadArchive(Archive archive, Boolean download, CancellationToken token, Nullable`1 destination) in C:\oss\wabbajack\Wabbajack.Installer\AInstaller.cs:line 399
```

* Trying to parse an invalid `.download_package` throws an exception on every retry, making a download impossible
```
00:00:22.565 [ERROR] (Wabbajack.Networking.Http.SingleThreadedDownloader) Failed to download 'Unofficial Skyrim Creation Club Content Patch-18975-7-7-1691284489.zip' after 3 tries.|System.Text.Json.JsonException: The input does not contain any JSON tokens. Expected the input to start with a valid JSON token, when isFinalBlock is true. Path: $ | LineNumber: 0 | BytePositionInLine: 0.
 ---> System.Text.Json.JsonReaderException: The input does not contain any JSON tokens. Expected the input to start with a valid JSON token, when isFinalBlock is true. LineNumber: 0 | BytePositionInLine: 0.
   at System.Text.Json.ThrowHelper.ThrowJsonReaderException(Utf8JsonReader& json, ExceptionResource resource, Byte nextByte, ReadOnlySpan`1 bytes)
   at System.Text.Json.Utf8JsonReader.Read()
   at System.Text.Json.Serialization.JsonConverter`1.ReadCore(Utf8JsonReader& reader, JsonSerializerOptions options, ReadStack& state)
   --- End of inner exception stack trace ---
   at System.Text.Json.ThrowHelper.ReThrowWithPath(ReadStack& state, JsonReaderException ex)
   at System.Text.Json.Serialization.JsonConverter`1.ReadCore(Utf8JsonReader& reader, JsonSerializerOptions options, ReadStack& state)
   at System.Text.Json.JsonSerializer.ReadFromSpan[TValue](ReadOnlySpan`1 utf8Json, JsonTypeInfo`1 jsonTypeInfo, Nullable`1 actualByteCount)
   at System.Text.Json.JsonSerializer.ReadFromSpan[TValue](ReadOnlySpan`1 json, JsonTypeInfo`1 jsonTypeInfo)
   at System.Text.Json.JsonSerializer.Deserialize[TValue](String json, JsonSerializerOptions options)
   at Wabbajack.Networking.Http.ResumableDownloader.LoadPackage() in C:\oss\wabbajack\Wabbajack.Networking.Http\ResumableDownloader.cs:line 169
   at Wabbajack.Networking.Http.ResumableDownloader.Download(CancellationToken token) in C:\oss\wabbajack\Wabbajack.Networking.Http\ResumableDownloader.cs:line 50
   at Wabbajack.Networking.Http.SingleThreadedDownloader.Download(HttpRequestMessage message, AbsolutePath outputPath, IJob job, CancellationToken token) in C:\oss\wabbajack\Wabbajack.Networking.Http\SingleThreadedDownloader.cs:line 41
```