### PR TITLE
Actually use the compile --outputPath option if the user provides one

### DIFF
--- a/Wabbajack.CLI/Verbs/Compile.cs
+++ b/Wabbajack.CLI/Verbs/Compile.cs
@@ -11,6 +11,7 @@ using Wabbajack.Downloaders.GameFile;
 using Wabbajack.DTOs.JsonConverters;
 using Wabbajack.Networking.WabbajackClientApi;
 using Wabbajack.Paths;
+using Wabbajack.Paths.IO;
 using Wabbajack.VFS;
 
 namespace Wabbajack.CLI.Verbs;
@@ -58,6 +59,12 @@ public class Compile
 
         inferredSettings.UseGamePaths = true;
         
+        if(outputPath.DirectoryExists())
+        {
+            inferredSettings.OutputFile = outputPath.Combine(inferredSettings.OutputFile.FileName);
+            _logger.LogInformation("Output file will be in: {outputPath}", inferredSettings.OutputFile);
+        }
+
         var compiler = MO2Compiler.Create(_serviceProvider, inferredSettings);
         var result = await compiler.Begin(token);
         if (!result)


### PR DESCRIPTION
It was just not being used, defaulting to the parent of installPath. it still does, if the user does not specify a directory using --outputPath