### PR TITLE
add Baldur's Gate 3 meta data for the Generic MO2 Plugin.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 #### Version - TBD
 * Added Support for Final Fantasy 7: Remake Intergrade
+* Added Support for Baldur's Gate 3 
+  * Very Work in Progress
+  * **NOT** Plug and Play for compiling and installing!
 
 #### Version - 3.4.0.0 - 11/19/2023
 * Fixed `--outputPath` not being used for the CLI `compile` (thanks to @majcosta for fixing that)

--- a/Wabbajack.DTOs/Game/Game.cs
+++ b/Wabbajack.DTOs/Game/Game.cs
@@ -53,5 +53,6 @@ public enum Game
     [Description("Valheim")]Valheim,
     [Description("Modding Tools")] ModdingTools,
 
-    [Description("Final Fantasy VII Remake")] FinalFantasy7Remake
+    [Description("Final Fantasy VII Remake")] FinalFantasy7Remake,
+    [Description("Baldur's Gate 3")] BadlursGate3
 }

--- a/Wabbajack.DTOs/Game/GameRegistry.cs
+++ b/Wabbajack.DTOs/Game/GameRegistry.cs
@@ -552,6 +552,24 @@ public static class GameRegistry
             }
         },
         {
+            Game.BadlursGate3, new GameMetaData
+            {
+                Game = Game.BadlursGate3,
+                NexusName = "baldursgate3",
+                NexusGameId = 3474,
+                MO2Name = "Baldur's Gate 3",
+                MO2ArchiveName = "baldursgate3",
+                SteamIDs = [1086940],
+                GOGIDs = [1456460669],
+                IsGenericMO2Plugin = true,
+                RequiredFiles = new []
+                {
+                    @"bin/bg3.exe".ToRelativePath()
+                },
+                MainExecutable = @"bin/bg3.exe".ToRelativePath()
+            }
+        },
+        {
             Game.ModdingTools, new GameMetaData
             {
                 Game = Game.ModdingTools,


### PR DESCRIPTION
closes #2455.

- Does only include GOG and Steam support.
- Indexed Game Files Repo update isn't done. (WJ won't be able to source game files from the local installation)
- Due to the method of how the MO2 plugin still needs the BG3 mod manager it might not work without some heavy workarounds for compiling and installing the lists!

VERY VERY Work in Progress!