### PR TITLE
update Final Fantasy VII: RI metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### Changelog
 
+#### Version - TBD
+* Fixed Final Fantasy 7: Remake Intergrade meta data
+
 #### Version - 3.4.1.0 - 12/21/2023
 * Added Support for Final Fantasy 7: Remake Intergrade
 * Update CLI to .NET 8.0 (was missed in the last update)

--- a/Wabbajack.DTOs/Game/GameRegistry.cs
+++ b/Wabbajack.DTOs/Game/GameRegistry.cs
@@ -549,7 +549,7 @@ public static class GameRegistry
                     @"End\Binaries\Win64\ff7remake_.exe".ToRelativePath(),
                     @"ff7remake_.exe".ToRelativePath()
                 },
-                MainExecutable = @"End\Binaries\Win64\ff7remake_.exe"ToRelativePath()
+                MainExecutable = @"End\Binaries\Win64\ff7remake_.exe".ToRelativePath()
             }
         },
         {

--- a/Wabbajack.DTOs/Game/GameRegistry.cs
+++ b/Wabbajack.DTOs/Game/GameRegistry.cs
@@ -546,9 +546,10 @@ public static class GameRegistry
                 IsGenericMO2Plugin = true,
                 RequiredFiles = new []
                 {
-                    @"ff7remake.exe".ToRelativePath()
+                    @"End\Binaries\Win64\ff7remake_.exe".ToRelativePath(),
+                    @"ff7remake_.exe".ToRelativePath()
                 },
-                MainExecutable = @"ff7remake.exe".ToRelativePath()
+                MainExecutable = @"End\Binaries\Win64\ff7remake_.exe"ToRelativePath()
             }
         },
         {

--- a/Wabbajack.DTOs/Game/GameRegistry.cs
+++ b/Wabbajack.DTOs/Game/GameRegistry.cs
@@ -540,7 +540,7 @@ public static class GameRegistry
                 Game = Game.FinalFantasy7Remake,
                 NexusName = "finalfantasy7remake",
                 NexusGameId = 4202,
-                MO2Name = "FINAL FANTASY VII REMAKE",
+                MO2Name = "FINAL FANTASY VII REMAKE INTERGRADE",
                 MO2ArchiveName = "finalfantasy7remake",
                 SteamIDs = new[] { 1462040 },
                 IsGenericMO2Plugin = true,


### PR DESCRIPTION
Fix an issue where the main executable was set to a "launcher" executable and not the actual main executable that contains the proper version number. (This is important for the hashes to target the correct game version)