### PR TITLE
Updated GameFinder to 4.1.0, Added EADesktop module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ### Changelog
 
+#### Version - TBD
+* Updated GameFinder
+  * Fixes Wabbajack not Launching on some systems
+* Added the GameFinder module for EA Desktop
+  * Only `Dragon Age: Origins` & `Dragon Age: Inquisition` supported for now.
+  * For other games we still need to collect the right store IDs
+
 #### Version - 3.4.1.0 - 12/21/2023
 * Added Support for Final Fantasy 7: Remake Intergrade
 * Update CLI to .NET 8.0 (was missed in the last update)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### Changelog
 
 #### Version - TBD
-* Updated GameFinder
+* Updated GameFinder to 4.1.0
   * Fixes Wabbajack not Launching on some systems
 * Added the GameFinder module for EA Desktop
   * Only `Dragon Age: Origins` & `Dragon Age: Inquisition` supported for now.

--- a/Wabbajack.DTOs/Game/GameMetaData.cs
+++ b/Wabbajack.DTOs/Game/GameMetaData.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.InteropServices.JavaScript;
 using Wabbajack.Paths;
 
 namespace Wabbajack.DTOs;
@@ -28,6 +29,8 @@ public class GameMetaData
     // So for DA:O this is "DR208591800.mfst" -> "DR:208591800"
     // EAPlay games may have @subscription appended to the file name
     public string[] OriginIDs { get; set; } = Array.Empty<string>();
+
+    public string[] EADesktopIDs { get; set; } = Array.Empty<string>();
 
     public string[] EpicGameStoreIDs { get; internal init; } = Array.Empty<string>();
 

--- a/Wabbajack.DTOs/Game/GameRegistry.cs
+++ b/Wabbajack.DTOs/Game/GameRegistry.cs
@@ -357,6 +357,22 @@ public static class GameRegistry
                 MO2Name = "Dragon Age: Origins",
                 SteamIDs = new[] {47810},
                 OriginIDs = new[] {"DR:169789300", "DR:208591800"},
+                EADesktopIDs = new [] // Possibly Wrong
+                {
+                    "9df89a8e-b201-4507-8a8d-bd6799fedb18",
+                    "Origin.SFT.50.0000078", 
+                    "Origin.SFT.50.0000078",
+                    "Origin.SFT.50.0000078",
+                    "Origin.SFT.50.0000085",
+                    "Origin.SFT.50.0000086",
+                    "Origin.SFT.50.0000087",
+                    "Origin.SFT.50.0000088",
+                    "Origin.SFT.50.0000089",
+                    "Origin.SFT.50.0000090",
+                    "Origin.SFT.50.0000091",
+                    "Origin.SFT.50.0000097",
+                    "Origin.SFT.50.0000098"
+                },
                 GOGIDs = new long[] {1949616134},
                 RequiredFiles = new[]
                 {
@@ -374,6 +390,22 @@ public static class GameRegistry
                 MO2Name = "Dragon Age 2", // Probably wrong
                 SteamIDs = new[] {1238040},
                 OriginIDs = new[] {"OFB-EAST:59474", "DR:201797000"},
+                EADesktopIDs = new [] // Possibly Wrong
+                {
+                    "Origin.SFT.50.0000073",
+                    "Origin.SFT.50.0000255",
+                    "Origin.SFT.50.0000256",
+                    "Origin.SFT.50.0000257",
+                    "Origin.SFT.50.0000288",
+                    "Origin.SFT.50.0000310",
+                    "Origin.SFT.50.0000311",
+                    "Origin.SFT.50.0000356",
+                    "Origin.SFT.50.0000385",
+                    "Origin.SFT.50.0000429",
+                    "Origin.SFT.50.0000449",
+                    "Origin.SFT.50.0000452",
+                    "Origin.SFT.50.0000453"
+                },
                 RequiredFiles = new[]
                 {
                     @"bin_ship\DragonAge2.exe".ToRelativePath()

--- a/Wabbajack.Downloaders.GameFile/Wabbajack.Downloaders.GameFile.csproj
+++ b/Wabbajack.Downloaders.GameFile/Wabbajack.Downloaders.GameFile.csproj
@@ -18,10 +18,11 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="GameFinder.StoreHandlers.EGS" Version="4.0.0" />
-        <PackageReference Include="GameFinder.StoreHandlers.GOG" Version="4.0.0" />
-        <PackageReference Include="GameFinder.StoreHandlers.Origin" Version="4.0.0" />
-        <PackageReference Include="GameFinder.StoreHandlers.Steam" Version="4.0.0" />
+        <PackageReference Include="GameFinder.StoreHandlers.EADesktop" Version="4.1.0" />
+        <PackageReference Include="GameFinder.StoreHandlers.EGS" Version="4.1.0" />
+        <PackageReference Include="GameFinder.StoreHandlers.GOG" Version="4.1.0" />
+        <PackageReference Include="GameFinder.StoreHandlers.Origin" Version="4.1.0" />
+        <PackageReference Include="GameFinder.StoreHandlers.Steam" Version="4.1.0" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Added EA Desktop IDs for Dragon Age Origins and Dragon Age Inquisition.
Fixes #2456 .