### PR TITLE
updated logging code when closing the app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Added Support for Baldur's Gate 3 
   * Very Work in Progress
   * **NOT** Plug and Play for compiling and installing!
+* Fixed a logging error when closing the App without a `temp` folder to delete
 
 #### Version - 3.4.0.0 - 11/19/2023
 * Fixed `--outputPath` not being used for the CLI `compile` (thanks to @majcosta for fixing that)

--- a/Wabbajack.App.Wpf/Views/MainWindow.xaml.cs
+++ b/Wabbajack.App.Wpf/Views/MainWindow.xaml.cs
@@ -52,26 +52,25 @@ namespace Wabbajack
                     // Cleaning the temp folder when the app closes since it can take up multiple Gigabytes of Storage
                     var tempDirectory = Environment.CurrentDirectory + "\\temp";
                     _logger.LogInformation("Clearing {TempDir}",tempDirectory);
+                    var directoryInfo = new DirectoryInfo(tempDirectory);
                     try
                     {
-                        var directoryInfo = new DirectoryInfo(tempDirectory);
-                        
                         foreach (var file in directoryInfo.EnumerateFiles())
                         {
-                            file.Delete(); 
+                            file.Delete();
                         }
+
                         foreach (var dir in directoryInfo.EnumerateDirectories())
                         {
-                            dir.Delete(true); 
+                            dir.Delete(true);
                         }
-                        
-                        _logger.LogInformation("Finished clearing {TempDir}",tempDirectory);
+
+                        _logger.LogInformation("Finished clearing {TempDir}", tempDirectory);
                     }
-                    catch (Exception ex)
+                    catch (DirectoryNotFoundException)
                     {
-                        _logger.LogError(ex,"Failed clearing {TempDir}",tempDirectory);
+                        _logger.LogInformation("Unable to find {TempDir}", tempDirectory);
                     }
-                    
                     
                     Application.Current.Shutdown();
                 };


### PR DESCRIPTION
the previous way I implemented the temp clear was still throwing an error when the folder wasn't found. 
this is properly caught now.