### PR TITLE
Fix WebView2 taking up tons of memory, use single WebView window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   * Only `Dragon Age: Origins` & `Dragon Age: Inquisition` supported for now.
   * For other games we still need to collect the right store IDs
 * Fixed Final Fantasy 7: Remake Intergrade meta data
+* Fixed new WebView2 instances being created constantly causing a memory leak
+* Fixed the Nexus API key no longer being picked up when logging in
+* Fixed Baldur's Gate 3 having to be named 'badlursgate3' instead of 'baldursgate3' when defining a modlist JSON
+* Fixed wabbajack-cli.bat pointing to the wrong CLI executable path
 
 #### Version - 3.4.1.0 - 12/21/2023
 * Added Support for Final Fantasy 7: Remake Intergrade

--- a/Wabbajack.App.Wpf/App.xaml.cs
+++ b/Wabbajack.App.Wpf/App.xaml.cs
@@ -8,6 +8,7 @@ using System.Windows.Threading;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Web.WebView2.Wpf;
 using NLog.Extensions.Logging;
 using NLog.Targets;
 using Orc.FileAssociation;
@@ -164,6 +165,7 @@ namespace Wabbajack
             services.AddSingleton<SystemParametersConstructor>();
             services.AddSingleton<LauncherUpdater>();
             services.AddSingleton<ResourceMonitor>();
+            services.AddSingleton<WebView2>();
 
             services.AddTransient<CompilerVM>();
             services.AddTransient<InstallerVM>();

--- a/Wabbajack.App.Wpf/LoginManagers/LoversLabLoginManager.cs
+++ b/Wabbajack.App.Wpf/LoginManagers/LoversLabLoginManager.cs
@@ -66,7 +66,7 @@ public class LoversLabLoginManager : ViewModel, ILoginFor<LoversLabDownloader>
     
     private void StartLogin()
     {
-        var view = new BrowserWindow();
+        var view = new BrowserWindow(_serviceProvider);
         view.Closed += (sender, args) => { RefreshTokenState(); };
         var provider = _serviceProvider.GetRequiredService<LoversLabLoginHandler>();
         view.DataContext = provider;

--- a/Wabbajack.App.Wpf/LoginManagers/NexusLoginManager.cs
+++ b/Wabbajack.App.Wpf/LoginManagers/NexusLoginManager.cs
@@ -62,7 +62,7 @@ public class NexusLoginManager : ViewModel, ILoginFor<NexusDownloader>
 
     private void StartLogin()
     {
-        var view = new BrowserWindow();
+        var view = new BrowserWindow(_serviceProvider);
         view.Closed += (sender, args) => { RefreshTokenState(); };
         var provider = _serviceProvider.GetRequiredService<NexusLoginHandler>();
         view.DataContext = provider;

--- a/Wabbajack.App.Wpf/LoginManagers/VectorPlexusLoginManager.cs
+++ b/Wabbajack.App.Wpf/LoginManagers/VectorPlexusLoginManager.cs
@@ -66,7 +66,7 @@ public class VectorPlexusLoginManager : ViewModel, ILoginFor<LoversLabDownloader
         
     private void StartLogin()
     {
-        var view = new BrowserWindow();
+        var view = new BrowserWindow(_serviceProvider);
         view.Closed += (sender, args) => { RefreshTokenState(); };
         var provider = _serviceProvider.GetRequiredService<VectorPlexusLoginHandler>();
         view.DataContext = provider;

--- a/Wabbajack.App.Wpf/Verbs/NexusLogin.cs
+++ b/Wabbajack.App.Wpf/Verbs/NexusLogin.cs
@@ -25,7 +25,7 @@ public class NexusLogin
     public async Task<int> Run(CancellationToken token)
     {
         var tcs = new TaskCompletionSource<int>();
-        var view = new BrowserWindow();
+        var view = new BrowserWindow(_services);
         view.Closed += (sender, args) => { tcs.TrySetResult(0); };
         var provider = _services.GetRequiredService<NexusLoginHandler>();
         view.DataContext = provider;

--- a/Wabbajack.App.Wpf/Views/BrowserWindow.xaml
+++ b/Wabbajack.App.Wpf/Views/BrowserWindow.xaml
@@ -46,8 +46,5 @@
             <icon:PackIconModern Kind="PageCopy"></icon:PackIconModern>
         </Button>
         <TextBox  Grid.Row="2" Grid.Column="3" Margin="4" VerticalContentAlignment="Center" Name="AddressBar" IsEnabled="False"></TextBox>
-        
-        <!--<wpf:WebView2 Grid.Row="3" Grid.ColumnSpan="3" Name="Browser"></wpf:WebView2>-->
-        
     </Grid>
 </mahapps:MetroWindow>

--- a/Wabbajack.App.Wpf/Views/BrowserWindow.xaml
+++ b/Wabbajack.App.Wpf/Views/BrowserWindow.xaml
@@ -23,7 +23,7 @@
                  WindowTitleBrush="{StaticResource MahApps.Brushes.Accent}"
                  ContentRendered="BrowserWindow_OnActivated"
                  mc:Ignorable="d">
-    <Grid  Background="#121212" MouseDown="UIElement_OnMouseDown">
+    <Grid x:Name="MainGrid" Background="#121212" MouseDown="UIElement_OnMouseDown">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"></RowDefinition>
             <RowDefinition Height="Auto"></RowDefinition>
@@ -47,7 +47,7 @@
         </Button>
         <TextBox  Grid.Row="2" Grid.Column="3" Margin="4" VerticalContentAlignment="Center" Name="AddressBar" IsEnabled="False"></TextBox>
         
-        <wpf:WebView2 Grid.Row="3" Grid.ColumnSpan="3" Name="Browser"></wpf:WebView2>
+        <!--<wpf:WebView2 Grid.Row="3" Grid.ColumnSpan="3" Name="Browser"></wpf:WebView2>-->
         
     </Grid>
 </mahapps:MetroWindow>

--- a/Wabbajack.App.Wpf/Views/BrowserWindow.xaml.cs
+++ b/Wabbajack.App.Wpf/Views/BrowserWindow.xaml.cs
@@ -1,11 +1,15 @@
 using System;
+using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Input;
 using MahApps.Metro.Controls;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Web.WebView2.Wpf;
 using ReactiveUI;
 using Wabbajack.Common;
 
@@ -14,12 +18,27 @@ namespace Wabbajack;
 public partial class BrowserWindow : MetroWindow
 {
     private readonly CompositeDisposable _disposable;
+    private readonly IServiceProvider _serviceProvider;
+    public WebView2 Browser { get; set; }
 
-    public BrowserWindow()
+    public BrowserWindow(IServiceProvider serviceProvider)
     {
         InitializeComponent();
 
+
         _disposable = new CompositeDisposable();
+        _serviceProvider = serviceProvider;
+        Browser = _serviceProvider.GetRequiredService<WebView2>();
+        RxApp.MainThreadScheduler.Schedule(() =>
+        {
+            if(Browser.Parent != null)
+            {
+                ((Panel)Browser.Parent).Children.Remove(Browser);
+            }
+            MainGrid.Children.Add(Browser);
+            Grid.SetRow(Browser, 3);
+            Grid.SetColumnSpan(Browser, 3);
+        });
     }
 
     private void UIElement_OnMouseDown(object sender, MouseButtonEventArgs e)
@@ -58,7 +77,6 @@ public partial class BrowserWindow : MetroWindow
             .ContinueWith(_ => Dispatcher.Invoke(() =>
             {
                 Close();
-                Browser = null;
             }));
     }
 }

--- a/Wabbajack.Launcher/ViewModels/MainWindowViewModel.cs
+++ b/Wabbajack.Launcher/ViewModels/MainWindowViewModel.cs
@@ -303,10 +303,13 @@ public class MainWindowViewModel : ViewModelBase
     {
         try
         {
-            filename = filename.Parent.Combine("wabbajack-cli.exe");
+            filename = filename.Parent.Combine("cli", "wabbajack-cli.exe");
             var data = $"\"{filename}\" %*";
             var file = Path.Combine(Directory.GetCurrentDirectory(), "wabbajack-cli.bat");
             if (File.Exists(file) && await File.ReadAllTextAsync(file) == data) return;
+            var parent = Directory.GetParent(file).FullName;
+            if (!Directory.Exists(file))
+                Directory.CreateDirectory(parent);
             await File.WriteAllTextAsync(file, data);
         }
         catch (Exception ex)


### PR DESCRIPTION
Still could use work since we're only detaching the previous WebView2 instance when launching the next browser window. But at least it's not taking up a ton of memory now!