### PR TITLE
Fix Broken BSA reading

### DIFF
--- a/Wabbajack.Compression.BSA/TES5Archive/FileRecord.cs
+++ b/Wabbajack.Compression.BSA/TES5Archive/FileRecord.cs
@@ -91,7 +91,7 @@ public class FileRecord : IFile
 
         if (BSA.HeaderType == VersionType.SSE)
         {
-            if (Compressed && size.Size != size.OnDisk)
+            if (Compressed)
             {
                 await using var r = LZ4Stream.Decode(rdr.BaseStream);
                 await r.CopyToLimitAsync(output, (int) size.Original, token).ConfigureAwait(false);


### PR DESCRIPTION
Not sure why this code has been here forever, but it was wrong. If the compressed file was exact the same size as the extracted file then we'd never extract it? Why? IDK, it's bad, and I should feel bad.