### PR TITLE
Add Wabbajack.Downloaders.VerificationCache to the list of published modules

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -84,6 +84,7 @@ jobs:
           - Wabbajack.Downloaders.Mega
           - Wabbajack.Downloaders.ModDB
           - Wabbajack.Downloaders.Nexus
+          - Wabbajack.Downloaders.VerificationCache
           - Wabbajack.Downloaders.WabbajackCDN
           - Wabbajack.DTOs
           - Wabbajack.FileExtractor


### PR DESCRIPTION
This is needed to get the `Wabbajack.Downloaders.Dispatcher` installed on the website to generate the file URLs on the status page.
