### PR TITLE
Skip LoverslabUrls during list validation

### DIFF
--- a/Wabbajack.CLI/Verbs/ValidateLists.cs
+++ b/Wabbajack.CLI/Verbs/ValidateLists.cs
@@ -611,7 +611,9 @@ public class ValidateLists
                 return (ArchiveStatus.InValid, archive);
         }
 
-        if (archive.State is Http http && http.Url.Host.EndsWith("github.com"))
+        if (archive.State is Http http && (http.Url.Host.EndsWith("github.com")
+                                           //TODO: Find a better solution for the list validation of LoversLab files.
+                                           || http.Url.Host.EndsWith("loverslab.com")))
             return (ArchiveStatus.Valid, archive);
         
         try


### PR DESCRIPTION
The site has been unstable in the past and the way to login is currently running via a workaround that is not ideal to replicate in a cli context without a GUI login. 

Also the up until now used method of `manualURL` for LoversLab (which still is used on at least one file to get WJ to the login screen of the "old" internal browser login) was also skipped in the validation. So assuming all `directURL` links for LL to be up and running will in practice keep the up until now behavior of validation going while actually improving the comfort of users by automating the file downloads with the use of `directURL`.