### PR TITLE
Fix CLI login command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### Changelog
 
+#### Version - 3.6.1.1 - TBD
+* Fixed `set-nexus-api-key` CLI command
+
 #### Version - 3.6.1.0 - 5/26/2024
 * Fixed a race condition on renewing Nexus Mods OAuth2 tokens
 * Added `set-nexus-api-key` CLI command

--- a/Wabbajack.CLI/Verbs/SetNexusApiKey.cs
+++ b/Wabbajack.CLI/Verbs/SetNexusApiKey.cs
@@ -1,29 +1,23 @@
-
-using System.CommandLine;
-using System.CommandLine.Invocation;
-using System.CommandLine.NamingConventionBinder;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Wabbajack.CLI.Builder;
 using Wabbajack.DTOs.Logins;
-using Wabbajack.Paths;
-using Wabbajack.Paths.IO;
 using Wabbajack.Services.OSIntegrated;
 
 namespace Wabbajack.CLI.Verbs;
 
 public class SetNexusApiKey
 {
-    private readonly EncryptedJsonTokenProvider<NexusApiState> _tokenProvider;
+    private readonly EncryptedJsonTokenProvider<NexusOAuthState> _tokenProvider;
     private readonly ILogger<SetNexusApiKey> _logger;
 
-    public SetNexusApiKey(EncryptedJsonTokenProvider<NexusApiState> tokenProvider, ILogger<SetNexusApiKey> logger)
+    public SetNexusApiKey(EncryptedJsonTokenProvider<NexusOAuthState> tokenProvider, ILogger<SetNexusApiKey> logger)
     {
         _tokenProvider = tokenProvider;
         _logger = logger;
     }
 
-    public static VerbDefinition Definition = new VerbDefinition("set-nexus-api-key",
+    public static VerbDefinition Definition = new("set-nexus-api-key",
         "Sets the Nexus API key to the specified value",
         [
             new OptionDefinition(typeof(string), "k", "key", "The Nexus API key")
@@ -38,7 +32,7 @@ public class SetNexusApiKey
         }
         else
         {
-            await _tokenProvider.SetToken(new NexusApiState { ApiKey = key });
+            await _tokenProvider.SetToken(new() { ApiKey = key });
             _logger.LogInformation("Set Nexus API Key to {key}", key);
             return 0;
         }

--- a/Wabbajack.CLI/Wabbajack.CLI.csproj
+++ b/Wabbajack.CLI/Wabbajack.CLI.csproj
@@ -25,7 +25,7 @@
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
         <PackageReference Include="NLog" Version="5.2.5" />
         <PackageReference Include="NLog.Extensions.Logging" Version="5.3.5" />
-        <PackageReference Include="SixLabors.ImageSharp" Version="3.0.2" />
+        <PackageReference Include="SixLabors.ImageSharp" Version="3.1.4" />
         <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
         <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />
     </ItemGroup>

--- a/Wabbajack.Hashing.PHash.Test/Wabbajack.Hashing.PHash.Test.csproj
+++ b/Wabbajack.Hashing.PHash.Test/Wabbajack.Hashing.PHash.Test.csproj
@@ -14,7 +14,7 @@
         <PackageReference Include="FluentAssertions" Version="6.12.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
         <PackageReference Include="Shipwreck.Phash" Version="0.5.0" />
-        <PackageReference Include="SixLabors.ImageSharp" Version="3.0.2" />
+        <PackageReference Include="SixLabors.ImageSharp" Version="3.1.4" />
         <PackageReference Include="xunit" Version="2.6.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Wabbajack.Networking.NexusApi/AuthInfo.cs
+++ b/Wabbajack.Networking.NexusApi/AuthInfo.cs
@@ -3,6 +3,6 @@ using Wabbajack.Networking.Http.Interfaces;
 
 namespace Wabbajack.Networking.NexusApi;
 
-public interface AuthInfo : ITokenProvider<NexusOAuthState>
+public interface IAuthInfo : ITokenProvider<NexusOAuthState>
 {
 }

--- a/Wabbajack.Services.OSIntegrated/TokenProviders/NexusApiTokenProvider.cs
+++ b/Wabbajack.Services.OSIntegrated/TokenProviders/NexusApiTokenProvider.cs
@@ -5,7 +5,7 @@ using Wabbajack.Networking.NexusApi;
 
 namespace Wabbajack.Services.OSIntegrated.TokenProviders;
 
-public class NexusApiTokenProvider : EncryptedJsonTokenProvider<NexusOAuthState>, AuthInfo
+public class NexusApiTokenProvider : EncryptedJsonTokenProvider<NexusOAuthState>, IAuthInfo
 {
     public NexusApiTokenProvider(ILogger<NexusApiTokenProvider> logger, DTOSerializer dtos) : base(logger, dtos,
         "nexus-oauth-info")


### PR DESCRIPTION
The CLI command was not working because the class containing the API Key got renamed for the OAuth2 changes. This fixes that oversight.