### PR TITLE
Update GameFinder to the latest version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### Changelog
 
+#### Version - 3.6.2.0 - TBD
+* Update GameFinder dependency
+
 #### Version - 3.6.1.1 - 5/30/2024
 * Fixed `set-nexus-api-key` CLI command
 * Fixed other issues related to OAuth

--- a/Wabbajack.CLI.Builder/Wabbajack.CLI.Builder.csproj
+++ b/Wabbajack.CLI.Builder/Wabbajack.CLI.Builder.csproj
@@ -8,7 +8,7 @@
     
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />

--- a/Wabbajack.CLI/Wabbajack.CLI.csproj
+++ b/Wabbajack.CLI/Wabbajack.CLI.csproj
@@ -18,7 +18,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />

--- a/Wabbajack.Downloaders.Dispatcher.Test/Wabbajack.Downloaders.Dispatcher.Test.csproj
+++ b/Wabbajack.Downloaders.Dispatcher.Test/Wabbajack.Downloaders.Dispatcher.Test.csproj
@@ -11,7 +11,7 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
           <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
         <PackageReference Include="xunit" Version="2.6.1" />
         <PackageReference Include="Xunit.DependencyInjection.Logging" Version="8.1.0" />

--- a/Wabbajack.Downloaders.GameFile/Wabbajack.Downloaders.GameFile.csproj
+++ b/Wabbajack.Downloaders.GameFile/Wabbajack.Downloaders.GameFile.csproj
@@ -18,11 +18,11 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="GameFinder.StoreHandlers.EADesktop" Version="4.1.0" />
-        <PackageReference Include="GameFinder.StoreHandlers.EGS" Version="4.1.0" />
-        <PackageReference Include="GameFinder.StoreHandlers.GOG" Version="4.1.0" />
-        <PackageReference Include="GameFinder.StoreHandlers.Origin" Version="4.1.0" />
-        <PackageReference Include="GameFinder.StoreHandlers.Steam" Version="4.1.0" />
+        <PackageReference Include="GameFinder.StoreHandlers.EADesktop" Version="4.2.2" />
+        <PackageReference Include="GameFinder.StoreHandlers.EGS" Version="4.2.2" />
+        <PackageReference Include="GameFinder.StoreHandlers.GOG" Version="4.2.2" />
+        <PackageReference Include="GameFinder.StoreHandlers.Origin" Version="4.2.2" />
+        <PackageReference Include="GameFinder.StoreHandlers.Steam" Version="4.2.2" />
     </ItemGroup>
 
 </Project>

--- a/Wabbajack.Downloaders.MediaFire/Wabbajack.Downloaders.MediaFire.csproj
+++ b/Wabbajack.Downloaders.MediaFire/Wabbajack.Downloaders.MediaFire.csproj
@@ -7,7 +7,7 @@
 
     <ItemGroup>
         <PackageReference Include="HtmlAgilityPack" Version="1.11.54" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
     </ItemGroup>
 

--- a/Wabbajack.FileExtractor.Test/Wabbajack.FileExtractor.Test.csproj
+++ b/Wabbajack.FileExtractor.Test/Wabbajack.FileExtractor.Test.csproj
@@ -11,7 +11,7 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
           <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
         <PackageReference Include="xunit" Version="2.6.1" />

--- a/Wabbajack.Installer.Test/Wabbajack.Installer.Test.csproj
+++ b/Wabbajack.Installer.Test/Wabbajack.Installer.Test.csproj
@@ -11,7 +11,7 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
           <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
         <PackageReference Include="xunit" Version="2.6.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">

--- a/Wabbajack.Networking.NexusApi/Wabbajack.Networking.NexusApi.csproj
+++ b/Wabbajack.Networking.NexusApi/Wabbajack.Networking.NexusApi.csproj
@@ -12,7 +12,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
     </ItemGroup>
 

--- a/Wabbajack.Networking.Steam.Test/Wabbajack.Networking.Steam.Test.csproj
+++ b/Wabbajack.Networking.Steam.Test/Wabbajack.Networking.Steam.Test.csproj
@@ -12,7 +12,7 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
           <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
         <PackageReference Include="xunit" Version="2.6.1" />
         <PackageReference Include="Xunit.DependencyInjection" Version="8.9.0" />

--- a/Wabbajack.Services.OSIntegrated/Wabbajack.Services.OSIntegrated.csproj
+++ b/Wabbajack.Services.OSIntegrated/Wabbajack.Services.OSIntegrated.csproj
@@ -17,7 +17,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Wabbajack.VFS.Test/Wabbajack.VFS.Test.csproj
+++ b/Wabbajack.VFS.Test/Wabbajack.VFS.Test.csproj
@@ -11,7 +11,7 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
           <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
         <PackageReference Include="System.Data.SQLite.Core" Version="1.0.118" />
         <PackageReference Include="Xunit.DependencyInjection" Version="8.9.0" />


### PR DESCRIPTION
Gamefinder updated to fix issues with missing, removed or misconfigured steam libraries.