### PR TITLE
Use the default file manager when opening a folder.

### DIFF
--- a/Wabbajack.App.Wpf/Util/UIUtils.cs
+++ b/Wabbajack.App.Wpf/Util/UIUtils.cs
@@ -56,7 +56,6 @@ namespace Wabbajack
             }
         }
         
-        
         public static void OpenWebsite(Uri url)
         {
             Process.Start(new ProcessStartInfo("cmd.exe", $"/c start {url}")
@@ -64,15 +63,16 @@ namespace Wabbajack
                 CreateNoWindow = true,
             });
         }
-        
+
         public static void OpenFolder(AbsolutePath path)
         {
-            Process.Start(new ProcessStartInfo(KnownFolders.Windows.Combine("explorer.exe").ToString(), path.ToString())
+            Process.Start(new ProcessStartInfo()
             {
-                CreateNoWindow = true,
+                FileName = path.ToString(),
+                UseShellExecute = true,
+                Verb = "open"
             });
         }
-
 
         public static AbsolutePath OpenFileDialog(string filter, string initialDirectory = null)
         {

--- a/Wabbajack.App.Wpf/Util/UIUtils.cs
+++ b/Wabbajack.App.Wpf/Util/UIUtils.cs
@@ -19,7 +19,6 @@ using Wabbajack.Extensions;
 using Wabbajack.Models;
 using Wabbajack.Paths;
 using Wabbajack.Paths.IO;
-using System.Linq;
 
 namespace Wabbajack
 {

--- a/Wabbajack.App.Wpf/Util/UIUtils.cs
+++ b/Wabbajack.App.Wpf/Util/UIUtils.cs
@@ -66,7 +66,7 @@ namespace Wabbajack
 
         public static void OpenFolder(AbsolutePath path)
         {
-            String folderPath = path.ToString();
+            string folderPath = path.ToString();
             if (!folderPath.EndsWith(Path.DirectorySeparatorChar.ToString()))
             {
                 folderPath += Path.DirectorySeparatorChar.ToString();

--- a/Wabbajack.App.Wpf/Util/UIUtils.cs
+++ b/Wabbajack.App.Wpf/Util/UIUtils.cs
@@ -19,6 +19,7 @@ using Wabbajack.Extensions;
 using Wabbajack.Models;
 using Wabbajack.Paths;
 using Wabbajack.Paths.IO;
+using System.Linq;
 
 namespace Wabbajack
 {
@@ -66,9 +67,15 @@ namespace Wabbajack
 
         public static void OpenFolder(AbsolutePath path)
         {
+            String folderPath = path.ToString();
+            if (!folderPath.EndsWith(Path.DirectorySeparatorChar.ToString()))
+            {
+                folderPath += Path.DirectorySeparatorChar.ToString();
+            }
+
             Process.Start(new ProcessStartInfo()
             {
-                FileName = path.ToString(),
+                FileName = folderPath,
                 UseShellExecute = true,
                 Verb = "open"
             });

--- a/Wabbajack.App.Wpf/View Models/Installers/MO2InstallerVM.cs
+++ b/Wabbajack.App.Wpf/View Models/Installers/MO2InstallerVM.cs
@@ -77,7 +77,7 @@ namespace Wabbajack
 
         public void AfterInstallNavigation()
         {
-            Process.Start("explorer.exe", Location.TargetPath.ToString());
+            UIUtils.OpenFolder(Location.TargetPath);
         }
 
         public async Task<bool> Install()


### PR DESCRIPTION
Before, WJ manually ran `explorer.exe`, so I've just changed the OpenFolder method to use the default Windows file manager. There can be some edge cases where a file might have the same name as a folder, so I checked and added a `\` at the end to remove the possibility of opening/running a file instead of a folder.