### PR TITLE
Fix for crash when right clicking or doubler clicking browser url or window bar.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   * This issue only affected Fallout 3, Fallout NV and Skyrim LE
 * Added logging to determine which downloaded files cannot be hashed
   * This could occur in the downloading phase when installing a modlist when there are broken/corrupted files in the downloads folder
+* Fixed Wabbajack crashing when double-clicking the browser window titlebar or URL
 
 #### Version - 3.7.0.0 - 6/21/2024
 * Added Starfield support

--- a/Wabbajack.App.Wpf/Views/BrowserWindow.xaml.cs
+++ b/Wabbajack.App.Wpf/Views/BrowserWindow.xaml.cs
@@ -9,7 +9,6 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using MahApps.Metro.Controls;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Microsoft.Web.WebView2.Wpf;
 using ReactiveUI;
 using Wabbajack.Common;

--- a/Wabbajack.App.Wpf/Views/BrowserWindow.xaml.cs
+++ b/Wabbajack.App.Wpf/Views/BrowserWindow.xaml.cs
@@ -9,6 +9,7 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using MahApps.Metro.Controls;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Web.WebView2.Wpf;
 using ReactiveUI;
 using Wabbajack.Common;
@@ -24,7 +25,6 @@ public partial class BrowserWindow : MetroWindow
     public BrowserWindow(IServiceProvider serviceProvider)
     {
         InitializeComponent();
-
 
         _disposable = new CompositeDisposable();
         _serviceProvider = serviceProvider;
@@ -43,7 +43,10 @@ public partial class BrowserWindow : MetroWindow
 
     private void UIElement_OnMouseDown(object sender, MouseButtonEventArgs e)
     {
-        base.DragMove();
+        if (e.LeftButton == MouseButtonState.Pressed)
+        {
+            base.DragMove();
+        }
     }
 
     private void BrowserWindow_OnActivated(object sender, EventArgs e)

--- a/Wabbajack.App.Wpf/Views/MainWindow.xaml.cs
+++ b/Wabbajack.App.Wpf/Views/MainWindow.xaml.cs
@@ -8,7 +8,6 @@ using System.Windows.Input;
 using DynamicData.Binding;
 using MahApps.Metro.Controls;
 using Microsoft.Extensions.Logging;
-using NLog;
 using ReactiveUI;
 using Wabbajack.Common;
 using Wabbajack.Messages;

--- a/Wabbajack.App.Wpf/Views/MainWindow.xaml.cs
+++ b/Wabbajack.App.Wpf/Views/MainWindow.xaml.cs
@@ -8,6 +8,7 @@ using System.Windows.Input;
 using DynamicData.Binding;
 using MahApps.Metro.Controls;
 using Microsoft.Extensions.Logging;
+using NLog;
 using ReactiveUI;
 using Wabbajack.Common;
 using Wabbajack.Messages;
@@ -144,7 +145,10 @@ namespace Wabbajack
 
         private void UIElement_OnMouseDown(object sender, MouseButtonEventArgs e)
         {
-            this.DragMove();
+            if (e.LeftButton == MouseButtonState.Pressed)
+            {
+                this.DragMove();
+            }
         }
 
     }


### PR DESCRIPTION
Fixes #2571 

The current code ran Dragmove when any mousebutton event was fired, even right click, and Dragmove crashes when left button isnt held down when it is called.

Added just a guard to check left button is pressed before calling dragmove.

The crashing on double click couldve been caused by unlucky timing or threaded crap causing the function to be called when the button had already been released.

Confirmed crashing behavior prior to change, and confirmed no longer present afterwards