### PR TITLE
Fix FO3 / FNV / Skyrim LE files with special characters in the path corrupting when being packed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Changelog
 
+#### Version - 3.7.1.0 - ?
+* Fixed file paths with special characters corrupting when packed into BSAs
+  * This issue only affected Fallout 3, Fallout NV and Skyrim LE
+* Added logging to determine which downloaded files cannot be hashed
+  * This could occur in the downloading phase when installing a modlist when there are broken/corrupted files in the downloads folder
+
 #### Version - 3.7.0.0 - 6/21/2024
 * Added Starfield support
     * Note: Hashes were added earlier, but the earlier version was not fully compatible due to Wabbajack extracting the BA2 archives incorrectly. This has been fixed.

--- a/Wabbajack.Compression.BSA/BinaryHelperExtensions.cs
+++ b/Wabbajack.Compression.BSA/BinaryHelperExtensions.cs
@@ -23,6 +23,7 @@ public static class BinaryHelperExtensions
         return version switch
         {
             VersionType.TES3 => Encoding.ASCII,
+            VersionType.FO3 => Encoding.UTF8,
             VersionType.SSE => Windows1252,
             _ => Encoding.UTF7
         };

--- a/Wabbajack.Installer/StandardInstaller.cs
+++ b/Wabbajack.Installer/StandardInstaller.cs
@@ -247,7 +247,16 @@ public class StandardInstaller : AInstaller<StandardInstaller>
                 var metaFile = download.WithExtension(Ext.Meta);
 
                 var found = bySize[download.Size()];
-                var hash = await FileHashCache.FileHashCachedAsync(download, token);
+                Hash hash = default;
+                try
+                {
+                    hash = await FileHashCache.FileHashCachedAsync(download, token);
+                }
+                catch(Exception ex)
+                {
+                    _logger.LogError($"Failed to get hash for file {download}!");
+                    throw;
+                }
                 var archive = found.FirstOrDefault(f => f.Hash == hash);
 
                 IEnumerable<string> meta;


### PR DESCRIPTION
Before, the file paths would turn into other characters when there were characters inside like ç.
Also added some extra logging to the hashing logic that should make it a bit easier to see what's going on there when an error occurs