### PR TITLE
Allow storing more information in the downloaded archive metas so mods can be reinstalled and retain their meta-info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### Changelog
 
+#### Version - TBD
+* Wabbajack will now put modfile Titles, Description and Version into the `.meta` file.
+
 #### Version - 3.7.2.1 - 9/1/2024
 * Fixed a bug with the html reports when in a folder with a space in the name
 

--- a/Wabbajack.Downloaders.Nexus/NexusDownloader.cs
+++ b/Wabbajack.Downloaders.Nexus/NexusDownloader.cs
@@ -237,9 +237,14 @@ public class NexusDownloader : ADownloader<Nexus>, IUrlDownloader
     public override IEnumerable<string> MetaIni(Archive a, Nexus state)
     {
         var meta = state.Game.MetaData();
+        // modid, fileid and gamename are givens - they will always be there even if manually constructed metas
+        // the others may not - they should if queried from Nexus, but not guaranteed
+        var NameNull = (state.Name is not null) ? state.Name : string.Empty;
+        var DescriptionNull = (state.Description is not null) ? state.Description : string.Empty;
+        var VersionNull = (state.Version is not null) ? state.Version : string.Empty;
         return new[]
         {
-            $"gameName={meta.MO2ArchiveName ?? meta.NexusName}", $"modID={state.ModID}", $"fileID={state.FileID}"
+            $"gameName={meta.MO2ArchiveName ?? meta.NexusName}", $"modID={state.ModID}",$"modName={NameNull}",$"description={DescriptionNull}",$"version={VersionNull}", $"fileID={state.FileID}"
         };
     }
 }


### PR DESCRIPTION
Currently when WJ writes a meta next to the downloaded Nexus archive, it just does modid, fileid and gamename

Thats basically all that is needed, but when it first reads the meta for that nexus download it stores a lot more info - version, description mod name etc.

The problem with the current behavior is that if you were to uninstall a mod in a downloaded WJ list, then reinstall it from Mo2s download pane, it would have no version or description information assigned to it as you no longer have a nexus meta, you have a shortened WJ meta.

But this info is parsed by Wabbajack, so ive enabled it to be written to the meta if it is present ( incase for some reason there is a manually constructed nexus meta by the author that dosnt have those fields)

Tested that it works - meta now has version, modname, and description fields, and can be reinstalled and retain this information.

I cant forsee this breaking anything else, and SME install went smoothly with this change, no other problems, but there is a nonzero chance someone will say "but Januarysnow, what about this edgecase!" and hereby I open myself up to that possibility.