### PR TITLE
UI changes to allow verification and modlist folder recognition

### DIFF
--- a/Wabbajack.App.Wpf/View Models/Installers/InstallerVM.cs
+++ b/Wabbajack.App.Wpf/View Models/Installers/InstallerVM.cs
@@ -38,9 +38,7 @@ using System.Windows.Forms;
 using Microsoft.Extensions.DependencyInjection;
 using Wabbajack.CLI.Verbs;
 using Wabbajack.VFS;
-using SteamKit2.GC.Underlords.Internal;
 using Wabbajack.Compiler;
-using System.Windows.Controls.Primitives;
 
 namespace Wabbajack;
 
@@ -327,16 +325,11 @@ public class InstallerVM : BackNavigatingVM, IBackNavigatingVM, ICpuStatusVM
             yield return ErrorResponse.Fail("Mod list source does not exist");
 
         var downloadPath = Installer.DownloadLocation.TargetPath;
-
-
         if (downloadPath.Depth <= 1)
         {
             yield return ErrorResponse.Fail("Download path isn't set to a folder");
         }
-        
         var installPath = Installer.Location.TargetPath;
-
-
         if (installPath.Depth <= 1)
         {
             yield return ErrorResponse.Fail("Install path isn't set to a folder");

--- a/Wabbajack.App.Wpf/View Models/Installers/InstallerVM.cs
+++ b/Wabbajack.App.Wpf/View Models/Installers/InstallerVM.cs
@@ -135,7 +135,13 @@ public class InstallerVM : BackNavigatingVM, IBackNavigatingVM, ICpuStatusVM
     
     [Reactive]
     public bool ShowNSFWSlides { get; set; }
-    
+
+    [Reactive]
+    public bool UnrecognisedFilesPresent { get; set; }
+
+    [Reactive]
+    public bool IsShiftKeyPressed { get; set; }
+
     public LogStream LoggerProvider { get; }
 
     private AbsolutePath LastInstallPath { get; set; }
@@ -155,20 +161,6 @@ public class InstallerVM : BackNavigatingVM, IBackNavigatingVM, ICpuStatusVM
     
     public ReactiveCommand<Unit, Unit> VerifyCommand { get; }
 
-
-    private bool _isKeyPressed;
-    public bool IsKeyPressed
-    {
-        get => _isKeyPressed;
-        set => this.RaiseAndSetIfChanged(ref _isKeyPressed, value);
-    }
-
-    private bool _UnrecognisedFilesPresent;
-    public bool UnrecognisedFilesPresent
-    {
-        get => _UnrecognisedFilesPresent;
-        set => this.RaiseAndSetIfChanged(ref _UnrecognisedFilesPresent, value);
-    }
 
     private string UnrecognisedFilesFoundErrorMessage = "Files found in the install folder, please choose a different folder, or if you are CERTAIN you want to install here " +
                                                     Environment.NewLine + " then hold down shift to enable the button. This will delete any unrecognised files in the folder!";
@@ -290,14 +282,16 @@ public class InstallerVM : BackNavigatingVM, IBackNavigatingVM, ICpuStatusVM
                     {
                         UnrecognisedFilesPresent = false;
                         return ErrorResponse.Success;
-                    } else
+                    } 
+                    else
                     {
                         if(errors.Length == 1)
                         {
                             if(errors[0].Reason == UnrecognisedFilesFoundErrorMessage)
                             {
                                 UnrecognisedFilesPresent = true;
-                            } else
+                            } 
+                            else
                             {
                                 UnrecognisedFilesPresent = false;
                                 if (errors[0].Succeeded)
@@ -305,7 +299,8 @@ public class InstallerVM : BackNavigatingVM, IBackNavigatingVM, ICpuStatusVM
                                     return ErrorResponse.Succeed(errors[0].Reason);
                                 }
                             }
-                        } else
+                        } 
+                        else
                         {
                             //other errors too, not just this one particular error we want to handle for
                             UnrecognisedFilesPresent = false;
@@ -373,22 +368,22 @@ public class InstallerVM : BackNavigatingVM, IBackNavigatingVM, ICpuStatusVM
         { 
             yield return ErrorResponse.Fail("Installing in this folder may overwrite Wabbajack");
         }
-        bool OnlyDownloadFolderPresent = false;
-        bool UpdatingExisting = false;
+        bool onlyDownloadFolderPresent = false;
+        bool updatingExisting = false;
         if (installPath.ToString().Length != 0 && AreThereFilesInInstallFolder(installPath)){
             if (downloadPath.ToString().Length > 0)
             {
                 if (IsSelectedDownloadFolderTheOnlyThingThere(installPath, downloadPath))
                 {
-                    OnlyDownloadFolderPresent = true;
+                    onlyDownloadFolderPresent = true;
                 }
             }
-            if (OnlyDownloadFolderPresent == false)
+            if (onlyDownloadFolderPresent == false)
             {
                 var listname = IsAModListDirectory(installPath);
                 if (listname == ModList.Name)
                 {
-                    UpdatingExisting = true;
+                    updatingExisting = true;
                     yield return ErrorResponse.Succeed("Existing install of this modlist found, installing to this folder will reset the modlist to its default state");
                 }
                 else
@@ -403,7 +398,7 @@ public class InstallerVM : BackNavigatingVM, IBackNavigatingVM, ICpuStatusVM
         {
             yield return ErrorResponse.Fail("Can't install into Windows locations such as Documents etc, please make a new folder for the modlist - C:\\ModList\\ for example.");
         }
-        if (!UpdatingExisting && !OnlyDownloadFolderPresent && installPath.ToString().Length > 0 && downloadPath.ToString().Length > 0 && !HasEnoughSpace(installPath, downloadPath)){
+        if (!updatingExisting && !onlyDownloadFolderPresent && installPath.ToString().Length > 0 && downloadPath.ToString().Length > 0 && !HasEnoughSpace(installPath, downloadPath)){
             yield return ErrorResponse.Fail("Can't install modlist due to lack of free hard drive space, please read the modlist Readme to learn more.");
         }
     }
@@ -426,7 +421,8 @@ public class InstallerVM : BackNavigatingVM, IBackNavigatingVM, ICpuStatusVM
                 return false;
             }
 
-        } else
+        } 
+        else
         {
             if( spaceInstRemaining < spaceRequiredforInstall || spaceDownRemaining < spaceRequiredforDownload)
             {

--- a/Wabbajack.App.Wpf/Views/Installers/InstallationConfigurationView.xaml
+++ b/Wabbajack.App.Wpf/Views/Installers/InstallationConfigurationView.xaml
@@ -14,23 +14,23 @@
     <Grid Background="{StaticResource WindowBackgroundBrush}">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="20" />
+            <ColumnDefinition Width="10" />
             <ColumnDefinition Width="Auto" />
         </Grid.ColumnDefinitions>
         <Grid Grid.Column="0"
-            Margin="5"
-            VerticalAlignment="Center"
+            Margin="2"
+            VerticalAlignment="Top"
             Background="Transparent">
             <Grid.RowDefinitions>
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
                 <RowDefinition Height="5" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="1" />
                 <RowDefinition Height="*" />
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto" MinWidth="120" />
+                <ColumnDefinition Width="50" MinWidth="120" />
                 <ColumnDefinition Width="20" />
-                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="5*" />
             </Grid.ColumnDefinitions>
             <Rectangle x:Name="InstallConfigSpacer" Grid.Row="0" />
             <TextBlock Grid.Row="1" Grid.Column="0"
@@ -40,12 +40,14 @@
                 Text="Target Modlist"
                 TextAlignment="Center" />
             <TextBlock x:Name="errorTextBox"
+                HorizontalAlignment="Left"
+                VerticalAlignment="Top"
                 Grid.Row="3"
-                FontFamily="Verdana" FontSize="10" FontWeight="ExtraBold"
+                FontFamily="Verdana" FontSize="11" FontWeight="ExtraBold"
                 Background="{StaticResource WindowBackgroundBrush}"
                 Foreground="Red"
                 Text=""
-                TextAlignment="Left" Margin="0,79,0,-45" Grid.ColumnSpan="3" />
+                TextAlignment="Left" Margin="0,79,0,-45" Grid.ColumnSpan="5" />
             <local:FilePicker Grid.Row="1" Grid.Column="2"
                 x:Name="ModListLocationPicker"
                 Height="30"
@@ -104,24 +106,6 @@
                 VerticalAlignment="Top"
                 Foreground="{StaticResource WarningBrush}"
                 Kind="ExclamationTriangleSolid" />
-            <CheckBox Grid.Row="2" Grid.Column="2"
-                      HorizontalAlignment="Center"
-                      VerticalAlignment="Bottom"
-                      x:Name="OverwriteCheckBox"
-                      Content="Overwrite Installation"
-                      IsChecked="False"
-                      ToolTip="Confirm to overwrite files in install folder.">
-                <CheckBox.Style>
-                    <Style TargetType="CheckBox">
-                        <Setter Property="Opacity" Value="0.6" />
-                        <Style.Triggers>
-                            <DataTrigger Binding="{Binding IsMouseOver, RelativeSource={RelativeSource Self}}" Value="True">
-                                <Setter Property="Opacity" Value="1" />
-                            </DataTrigger>
-                        </Style.Triggers>
-                    </Style>
-                </CheckBox.Style>
-            </CheckBox>
             <Button Grid.Row="3" Grid.Column="2"
                       HorizontalAlignment="Center"
                       VerticalAlignment="Bottom"

--- a/Wabbajack.App.Wpf/Views/Installers/InstallationConfigurationView.xaml.cs
+++ b/Wabbajack.App.Wpf/Views/Installers/InstallationConfigurationView.xaml.cs
@@ -12,7 +12,6 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
-using Catel;
 using ReactiveUI;
 
 namespace Wabbajack

--- a/Wabbajack.App.Wpf/Views/Installers/InstallationConfigurationView.xaml.cs
+++ b/Wabbajack.App.Wpf/Views/Installers/InstallationConfigurationView.xaml.cs
@@ -43,7 +43,7 @@ namespace Wabbajack
                     .BindToStrict(this, x => x.VerifyButton.Command)
                     .DisposeWith(dispose);
 
-                this.WhenAnyValue(x => x.ViewModel.ErrorState, x => x.ViewModel.IsKeyPressed, x => x.ViewModel.UnrecognisedFilesPresent)
+                this.WhenAnyValue(x => x.ViewModel.ErrorState, x => x.ViewModel.IsShiftKeyPressed, x => x.ViewModel.UnrecognisedFilesPresent)
                     .Select(v => (!v.Item1.Failed || v.Item1.Succeeded ) || (v.Item1.Failed && v.Item2 && v.Item3))
                     .BindToStrict(this, view => view.BeginButton.IsEnabled)
                     .DisposeWith(dispose);
@@ -90,7 +90,7 @@ namespace Wabbajack
             {
                 if (DataContext is InstallerVM viewModel)
                 {
-                    viewModel.IsKeyPressed = true;
+                    viewModel.IsShiftKeyPressed = true;
                 }
             }
         }
@@ -101,7 +101,7 @@ namespace Wabbajack
             {
                 if (DataContext is InstallerVM viewModel)
                 {
-                    viewModel.IsKeyPressed = false;
+                    viewModel.IsShiftKeyPressed = false;
                 }
             }
         }

--- a/Wabbajack.App.Wpf/Views/Installers/InstallationView.xaml
+++ b/Wabbajack.App.Wpf/Views/Installers/InstallationView.xaml
@@ -29,7 +29,7 @@
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="47" />
-            <RowDefinition Height="4*" />
+            <RowDefinition Height="3*" />
             <RowDefinition Height="*" MinHeight="175" />
         </Grid.RowDefinitions>
         <Rectangle Grid.Row="1" Grid.RowSpan="2"
@@ -209,8 +209,8 @@
             ClipToBounds="True">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="4" />
-                <ColumnDefinition Width="2*" />
+                <ColumnDefinition Width="10" />
+                <ColumnDefinition Width="6*" />
             </Grid.ColumnDefinitions>
             <Grid Grid.Column="0" Margin="0">
                 <Grid.RowDefinitions>
@@ -221,7 +221,7 @@
                 </Grid.RowDefinitions>
                 <Button Grid.Row="0"
                         x:Name="OpenDiscordPreInstallButton"
-                        Margin="30,2"
+                        Margin="2,2"
                         FontSize="20"
                         Style="{StaticResource LargeButtonStyle}"
                         ToolTip="Open the Discord for the Modlist">
@@ -243,7 +243,7 @@
                 </Button>
                 <Button Grid.Row="1"
                         x:Name="OpenReadmePreInstallButton"
-                        Margin="30,2"
+                        Margin="2,2"
                         FontSize="20"
                         Style="{StaticResource LargeButtonStyle}"
                         ToolTip="Open the readme for the modlist">
@@ -265,7 +265,7 @@
                 </Button>
                 <Button Grid.Row="2"
                     x:Name="VisitWebsitePreInstallButton"
-                    Margin="30,2"
+                    Margin="2,2"
                     FontSize="20"
                     Style="{StaticResource LargeButtonStyle}"
                     ToolTip="Open the webpage for the modlist">
@@ -287,7 +287,7 @@
                 </Button>
                 <Button Grid.Row="3"
                     x:Name="ShowManifestPreInstallButton"
-                    Margin="30,2"
+                    Margin="2,2"
                     FontSize="20"
                     Style="{StaticResource LargeButtonStyle}"
                     ToolTip="Open an explicit listing of all archives this modlist contains">


### PR DESCRIPTION
Added checking for when the user selects a folder named "downloads" as the install folder, this is 99% of the time wrong, and is indicative of user not noticing auto populated fields in the file picker and will end up with a downloads folder like /wildlander/downloads/downloads/downloads

Removed overwrite button and its associated logic, it only caused user confusion, and was a blunt instrument, when it is better for WJ to perhaps be a bit smarter about recognising its own previous work in a folder.
Instead now WJ will check the target folder to see if there is a .compiler_settings file present, if there is, it will check the modlist name present in that file, to see if it matches the currently selected modlist, if it does, the user is surely updating an existing modlist install, it will give some benign warning text that this will delete any added mods.

In this scenario WJ will no longer complain that there are files in the target directory because thats to be expected, 

This check will cover 95% of the cases where a user would ask "and I check overwrite or not?"

If there is nothing inside the install folder except a downloads folder ( from a failed install previously ) then WJ will count that as fine to proceed

If it is not recognised as a modlist folder and it contains unrecognised files, and it dosnt just contain a downloads folder, then it is 95% of the time user error that they have chosen this folder to install to, then WJ will block the begin button and give an error text, this error text will say "to unlock the begin button, user must hold down the shift key", and on their own head be it when it deletes everything.

This makes more sense than an overwrite tickbox because the times you are asked to tick overwrite are the times when you shouldnt really have to, and then there are times when people do tick it when they really shouldnt.

There are edge cases - such as when there is an existing modlist folder that has had its .compiler_settings file deleted , or installation cancelled during the install phase before that file is written, so WJ no longer recognises it, where it will be required to hold down shift to force the install, but thats gonna be 1% of the time compared to the overwrite checkbox.

So now the verify button dosnt have to rely on the overwrite logic either.

A side benefit is that the free space checking logic is now added back but only in cases where it is not updating an existing folder - because the logic didnt take into account the already existing size of the modlist,  so it only runs when it considers it a fresh install of the list to a fresh folder.

Found two additional things during this that could cause problems and appear to be not related to my changes:

Wabbajack only revalidates the chosen paths when the file picker dialog choice ends up *changing* the target path, if you select the same folder again, and press OK then it dosnt revalidate, this is a problem because you may have deleted some blocking files from that folder to make it valid, but WJ wont pick up that change until you choose a different folder then go back to that one. I dont really know how to fix that.


Wabbajack appears to have issues if the prepopulated paths from last install are no longer present when the install config viewmodel comes into effect, it will think the chosen paths are empty when they are not, even after choosing new ones it wont revalidate.  I cant work out how to fix that.

I hate ReactiveUI stuff.