### PR TITLE
Support NXM links using Nexus game IDs (#2625)

### DIFF
--- a/Wabbajack.Downloaders.Nexus/NexusDownloader.cs
+++ b/Wabbajack.Downloaders.Nexus/NexusDownloader.cs
@@ -103,12 +103,15 @@ public class NexusDownloader : ADownloader<Nexus>, IUrlDownloader
             !string.IsNullOrWhiteSpace(gameName) &&
             !string.IsNullOrWhiteSpace(modId) &&
             !string.IsNullOrWhiteSpace(fileId))
+        {
+            var gameMetaData = GameRegistry.GetByMO2ArchiveName(gameName) ?? GameRegistry.GetByNexusName(gameName);
             return new Nexus
             {
-                Game = GameRegistry.GetByMO2ArchiveName(gameName)!.Game,
+                Game = gameMetaData!.Game,
                 ModID = long.Parse(modId),
                 FileID = long.Parse(fileId)
             };
+        }
 
         return null;
     }


### PR DESCRIPTION
When handling NXM links, games are now also looked up by Nexus game ID as a fallback instead of only by MO2 archive name to address #2625. When this change is actually implemented by Nexus, the lookup by MO2 archive name should probably be removed altogether.