### PR TITLE
removed the vector plexus login from the settings UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Wabbajack will now put modfile Titles, Description and Version into the `.meta` file.
 * Fix for CLI not working on certain commands due to required assemblies being removed on publish
 * Improved Wabbajack CLI inline-report: now automatically tries to open the report in the browser on running the command
+* Removed Vector Plexus Login from the UI cause with the only file being used from the having an official off-site mirror it isn't needed.
 
 #### Version - 3.7.4.0 - 10/15/2024
 * Fix for gallery not properly showing lists that are in maintenance.

--- a/Wabbajack.App.Wpf/App.xaml.cs
+++ b/Wabbajack.App.Wpf/App.xaml.cs
@@ -186,7 +186,8 @@ namespace Wabbajack
             //Disabled LL because it is currently not used and broken due to the way LL butchers their API
             //services.AddAllSingleton<INeedsLogin, LoversLabLoginManager>();
             services.AddAllSingleton<INeedsLogin, NexusLoginManager>();
-            services.AddAllSingleton<INeedsLogin, VectorPlexusLoginManager>();
+            //Disabled VP due to frequent login issues & because the only file that really got downloaded there has a mirror
+            //services.AddAllSingleton<INeedsLogin, VectorPlexusLoginManager>();
             services.AddSingleton<ManualDownloadHandler>();
             services.AddSingleton<ManualBlobDownloadHandler>();
 


### PR DESCRIPTION
the only file really used from there has a mirror that doesn't require a login and new users finding old guides often get hung up with that login.