### PR TITLE
exclude mediafire from list validation

### DIFF
--- a/Wabbajack.CLI/Verbs/ValidateLists.cs
+++ b/Wabbajack.CLI/Verbs/ValidateLists.cs
@@ -641,7 +641,9 @@ public class ValidateLists
 
         if (archive.State is Http http && (http.Url.Host.EndsWith("github.com")
                                            //TODO: Find a better solution for the list validation of LoversLab files.
-                                           || http.Url.Host.EndsWith("loverslab.com")))
+                                           || http.Url.Host.EndsWith("loverslab.com")
+                                           //TODO: Find a better solution for the list validation of Mediafire files.
+                                           || http.Url.Host.EndsWith("mediafire.com")))
             return (ArchiveStatus.Valid, archive);
         
         try


### PR DESCRIPTION
Exclude mediafire from list validation as it isn't necessarily reliable so it often brings modlists down when not needed.

Note, with this change that modlist authors will need to keep an eye on Mediafire hosted mods to ensure their availability.