### PR TITLE
Revert #2614

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### Changelog
 
+#### Version - 3.7.5.1 - 11/23/2024
+* Reverted "Wabbajack will now put modfile Titles, Description and Version into the `.meta` file." as it didnt account for formatting in descriptions that could confuse the iniparser
+
 #### Version - 3.7.5.0 - 11/23/2024
 * Fix for Wabbajack trying to work with an expired OAuth token.
 * Added pre-compile login check.

--- a/Wabbajack.Downloaders.Nexus/NexusDownloader.cs
+++ b/Wabbajack.Downloaders.Nexus/NexusDownloader.cs
@@ -240,14 +240,9 @@ public class NexusDownloader : ADownloader<Nexus>, IUrlDownloader
     public override IEnumerable<string> MetaIni(Archive a, Nexus state)
     {
         var meta = state.Game.MetaData();
-        // modid, fileid and gamename are givens - they will always be there even if manually constructed metas
-        // the others may not - they should if queried from Nexus, but not guaranteed
-        var NameNull = (state.Name is not null) ? state.Name : string.Empty;
-        var DescriptionNull = (state.Description is not null) ? state.Description : string.Empty;
-        var VersionNull = (state.Version is not null) ? state.Version : string.Empty;
         return new[]
         {
-            $"gameName={meta.MO2ArchiveName ?? meta.NexusName}", $"modID={state.ModID}",$"modName={NameNull}",$"description={DescriptionNull}",$"version={VersionNull}", $"fileID={state.FileID}"
+            $"gameName={meta.MO2ArchiveName ?? meta.NexusName}", $"modID={state.ModID}", $"fileID={state.FileID}"
         };
     }
 }


### PR DESCRIPTION
Revert #2614 

Nexus descriptions in the meta can get messy with formatting and line-breaks, the reverted PR just sent all that info to WJ to write to the ini, but the iniparser assumed one key/value per line - that was fine with name and version info, but it wasnt ready for formatted descriptions.

This caused mod descriptions with linebreaks to fail compilation - such as an existing Cyberpunk list for example

Instead of messing around with changing around a lot more in the iniparser or string sanitizing, its easier to just revert, for such a niche benefit.