### PR TITLE
Filter Logs in ModList intaller view

### DIFF
--- a/Wabbajack.App.Wpf/Models/LogStream.cs
+++ b/Wabbajack.App.Wpf/Models/LogStream.cs
@@ -68,6 +68,7 @@ public class LogStream : TargetWithLayout
         string ShortMessage { get; }
         DateTime TimeStamp { get; }
         string LongMessage { get; }
+        LogLevel Level { get; }
     }
 
     private record LogMessage(LogEventInfo info) : ILogMessage
@@ -76,6 +77,7 @@ public class LogStream : TargetWithLayout
         public string ShortMessage => info.FormattedMessage;
         public DateTime TimeStamp => info.TimeStamp;
         public string LongMessage => info.FormattedMessage;
+        public LogLevel Level => info.Level;
     }
     
 }

--- a/Wabbajack.App.Wpf/Views/Common/LogView.xaml
+++ b/Wabbajack.App.Wpf/Views/Common/LogView.xaml
@@ -9,6 +9,11 @@
     d:DesignWidth="800"
     mc:Ignorable="d">
     <Grid>
+        <Grid.Resources>
+            <CollectionViewSource x:Key="FilteredItems" 
+                        Source="{Binding LoggerProvider.MessageLog}"
+                        Filter="FilteredItems_OnFilter" />
+        </Grid.Resources>
         <Rectangle Fill="{StaticResource HeatedBorderBrush}" Opacity="{Binding ProgressPercent, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}}" />
         <ListBox
             local:AutoScrollBehavior.ScrollOnNewItem="True"
@@ -22,10 +27,5 @@
                 </DataTemplate>
             </ListBox.ItemTemplate>
         </ListBox>
-        <Grid.Resources>
-            <CollectionViewSource x:Key="FilteredItems" 
-                        Source="{Binding LoggerProvider.MessageLog}"
-                        Filter="FilteredItems_OnFilter" />
-        </Grid.Resources>
     </Grid>
 </UserControl>

--- a/Wabbajack.App.Wpf/Views/Common/LogView.xaml
+++ b/Wabbajack.App.Wpf/Views/Common/LogView.xaml
@@ -14,7 +14,7 @@
             local:AutoScrollBehavior.ScrollOnNewItem="True"
             BorderBrush="Transparent"
             BorderThickness="1"
-            ItemsSource="{Binding LoggerProvider.MessageLog}"
+            ItemsSource="{Binding Source={StaticResource FilteredItems}}"
             ScrollViewer.HorizontalScrollBarVisibility="Disabled">
             <ListBox.ItemTemplate>
                 <DataTemplate>
@@ -22,5 +22,10 @@
                 </DataTemplate>
             </ListBox.ItemTemplate>
         </ListBox>
+        <Grid.Resources>
+            <CollectionViewSource x:Key="FilteredItems" 
+                        Source="{Binding LoggerProvider.MessageLog}"
+                        Filter="FilteredItems_OnFilter" />
+        </Grid.Resources>
     </Grid>
 </UserControl>

--- a/Wabbajack.App.Wpf/Views/Common/LogView.xaml.cs
+++ b/Wabbajack.App.Wpf/Views/Common/LogView.xaml.cs
@@ -22,7 +22,7 @@ namespace Wabbajack
         private void FilteredItems_OnFilter(object sender, FilterEventArgs e)
         {
             var item = e.Item as ILogMessage;
-            e.Accepted = item.Level.Ordinal > 4;
+            e.Accepted = item.Level.Ordinal > 3;
         }
 
         public LogView()

--- a/Wabbajack.App.Wpf/Views/Common/LogView.xaml.cs
+++ b/Wabbajack.App.Wpf/Views/Common/LogView.xaml.cs
@@ -1,5 +1,8 @@
-﻿using System.Windows;
+﻿using Microsoft.Extensions.Logging;
+using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Data;
+using static Wabbajack.Models.LogStream;
 
 namespace Wabbajack
 {
@@ -15,6 +18,12 @@ namespace Wabbajack
         }
         public static readonly DependencyProperty ProgressPercentProperty = DependencyProperty.Register(nameof(ProgressPercent), typeof(double), typeof(LogView),
              new FrameworkPropertyMetadata(default(double)));
+
+        private void FilteredItems_OnFilter(object sender, FilterEventArgs e)
+        {
+            var item = e.Item as ILogMessage;
+            e.Accepted = item.Level.Ordinal > 4;
+        }
 
         public LogView()
         {


### PR DESCRIPTION
Currently all logs get displayed in the ModList installer. This causes some significant decreases in responsiveness. It also means that more meaningful messages like download failure are lost behind logs that aren't meaningful to most users.

This filters to warnings and above to reduce the noise and improve UI performance.