### PR TITLE
Enable Unit Tests to Pass on PR Submissions from Forked Repos

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,12 +30,12 @@ jobs:
           dotnet-version: '9.0.x'
           include-prerelease: true
 
-        if: ${{ github.ref == 'refs/heads/main' }}
       - name: Test
+        if: ${{ github.ref == 'refs/heads/main' }}
         run: dotnet test /p:EnableWindowsTargeting=true
 
-        if: ${{ github.ref != 'refs/heads/main' }}
       - name: Test
+        if: ${{ github.ref != 'refs/heads/main' }}
         run: dotnet test /p:EnableWindowsTargeting=true --filter "Category!=RequiresOAuth"
         
       #- name: Upload Test Folder on Failure

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,7 +2,9 @@ name: Tests
 
 on:
   push:
+    branches: [ main ]
   pull_request:
+    branches: [ main ]
 
 env:
   VERSION: 3.7.5.1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,7 +15,7 @@ jobs:
     
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [windows-latest]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,7 @@ jobs:
     
     strategy:
       matrix:
-        os: [windows-latest]
+        os: [ubuntu-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,7 +2,6 @@ name: Tests
 
 on:
   push:
-    branches: [ main ]
   pull_request:
 
 env:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,6 +14,12 @@ jobs:
     
     name: Test ${{ matrix.project }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+
+    env:
+      NEXUS_API_KEY: ${{ secrets.NEXUS_API_KEY }}
+      NEXUS_LOGIN: ${{ secrets.NEXUS_LOGIN }}
+      VECTOR_PLEXUS: ${{ secrets.VECTOR_PLEXUS }}
+      LOVERS_LAB: ${{ secrets.LOVERS_LAB }}
     
     strategy:
       matrix:

--- a/Wabbajack.Downloaders.Dispatcher.Test/DownloaderTests.cs
+++ b/Wabbajack.Downloaders.Dispatcher.Test/DownloaderTests.cs
@@ -219,51 +219,6 @@ public class DownloaderTests
     */
         };
 
-    private bool AutoPassTest(Archive archive)
-    {
-        return false;
-    }
-
-    [Theory]
-    [Trait("Category", "FlakeyNetwork")]
-    [MemberData(nameof(TestStates))]
-    public async Task TestDownloadingFile(Archive archive, Archive badArchive)
-    {
-        if (AutoPassTest(archive)) return;
-        await using var tempFile = _temp.CreateFile();
-        var hash = await _dispatcher.Download(archive, tempFile.Path, CancellationToken.None);
-        Assert.Equal(archive.Hash, hash);
-    }
-
-    [Theory]
-    [Trait("Category", "FlakeyNetwork")]
-    [MemberData(nameof(TestStates))]
-    public async Task TestFileVerification(Archive goodArchive, Archive badArchive)
-    {
-        if (AutoPassTest(goodArchive)) return;
-        Assert.True(await _dispatcher.Verify(goodArchive, CancellationToken.None));
-        Assert.False(await _dispatcher.Verify(badArchive, CancellationToken.None));
-    }
-
-    [Theory]
-    [Trait("Category", "FlakeyNetwork")]
-    [MemberData(nameof(TestStates))]
-    public async Task CanParseAndUnParseUrls(Archive goodArchive, Archive badArchive)
-    {
-        if (AutoPassTest(goodArchive)) return;
-        var downloader = _dispatcher.Downloader(goodArchive);
-        if (downloader is IUrlDownloader urlDownloader)
-        {
-            var unparsed = urlDownloader.UnParse(goodArchive.State);
-
-            var parsed = urlDownloader.Parse(unparsed);
-            Assert.NotNull(parsed);
-
-            Assert.Equal(goodArchive.State.GetType(), parsed.GetType());
-            Assert.True(await _dispatcher.Verify(new Archive {State = parsed, Hash = goodArchive.Hash}, CancellationToken.None));
-        }
-    }
-
     [Theory]
     [MemberData(nameof(TestStates))]
     public async Task CanParseAndUnParseMetaInis(Archive goodArchive, Archive badArchive)

--- a/Wabbajack.Installer.Test/StandardInstallerTest.cs
+++ b/Wabbajack.Installer.Test/StandardInstallerTest.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Wabbajack.DTOs.JsonConverters;
+using Wabbajack.Networking.WabbajackClientApi;
 using Wabbajack.Paths;
 using Wabbajack.Paths.IO;
 using Xunit;
@@ -51,6 +52,9 @@ public class StandardInstallerTest
             SystemPageSize = 8L * 1024 * 1024 * 1024,
             VideoMemorySize = 8L * 1024 * 1024 * 1024
         };
+
+        var configuration = _provider.GetService<Client>();
+        configuration.IgnoreMirrorList = true;
 
         var installer = _provider.GetService<StandardInstaller>();
         Assert.True(await installer.Begin(CancellationToken.None));

--- a/Wabbajack.Networking.NexusApi.Test/NexusApiTests.cs
+++ b/Wabbajack.Networking.NexusApi.Test/NexusApiTests.cs
@@ -14,6 +14,7 @@ public class NexusApiTests
     }
 
     [Fact]
+    [Trait("Category", "RequiresOAuth")]
     public async Task CanValidateUser()
     {
         var (info, headers) = await _api.Validate();
@@ -21,6 +22,7 @@ public class NexusApiTests
     }
 
     [Fact]
+    [Trait("Category", "RequiresOAuth")]
     public async Task CanGetModInfo()
     {
         var (_, originalHeaders) = await _api.Validate();

--- a/Wabbajack.Networking.WabbajackClientApi/Client.cs
+++ b/Wabbajack.Networking.WabbajackClientApi/Client.cs
@@ -50,6 +50,7 @@ public class Client
     private readonly ITokenProvider<WabbajackApiState> _token;
     private bool _inited;
 
+    public bool IgnoreMirrorList { get; set; } = false;
 
     public Client(ILogger<Client> logger, HttpClient client, ITokenProvider<WabbajackApiState> token,
         DTOSerializer dtos,
@@ -108,6 +109,9 @@ public class Client
 
     public async Task<Archive[]> LoadMirrors()
     {
+        if (IgnoreMirrorList)
+            return Array.Empty<Archive>();
+
         var str = await _client.GetStringAsync(_configuration.MirrorList);
         return JsonSerializer.Deserialize<Archive[]>(str, _dtos.Options) ?? [];
     }


### PR DESCRIPTION
Currently unit tests are unable to complete successfully due to 
1. Unreliable tests in DownloaderTests
2. Tests in StandardInstallerTests and NexusApiTests that require an OAuth token be available

This PR fixes the first by removing the offending tests; they did not complete reliably and we're being filtered out in the test action's yaml definition

StandardInstallerTests needed a nexus api token because it was resolving the SKSE download to a mirror on the nexus. This is desirable in most cases but during unit testing it creates an unexpected dependency on Nexus auth. So this adds a flag to Client that retrieves the mirror list that when set to true simply returns an empty list instead. 

A more preferable solution there would involve mocking or otherwise supplying a different implementation but making that possible would require a larger refactor that is outside the scope of the goal here of getting unit tests going for PRs.

NexusApiTests requires OAuth as its testing the Nexus API. This is expected so I've added a category to those tests indicating as much. This category is then excluded for runs on branchs that are not main.