### PR TITLE
Fixing incorrect log level

### DIFF
--- a/Wabbajack.App.Wpf/View Models/Compilers/CompilerVM.cs
+++ b/Wabbajack.App.Wpf/View Models/Compilers/CompilerVM.cs
@@ -381,7 +381,7 @@ namespace Wabbajack
                         StatusProgress = Percent.Zero;
 
                         State = CompilerState.Errored;
-                        _logger.LogInformation(ex, "Failed Compilation : {Message}", ex.Message);
+                        _logger.LogError(ex, "Failed Compilation : {Message}", ex.Message);
                         return Disposable.Empty;
                     });
                 }


### PR DESCRIPTION
Compilation failures are being logged out as information instead of error. This adjusts that log to an error.