### PR TITLE
Remove content length validation on HTTP responses from the CDN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Version -
 * Compilation failures are now logged as an ERR type instead of INFO. Thanks to Thamous ([@AlexDickerson](https://github.com/AlexDickerson))
+* Fix for the Wabbajack CDN not downloading parts correctly anymore after it switched to chunked HTTP responses. Suspected change by Cloudflare.
 
 #### Version - 3.7.5.2 - 1/12/2025 
 * Fix for Wabbajack not fully utilizing saturating network speed because a download library added for resumable downloads was poorly optimized. Thanks to Thamous ([@AlexDickerson](https://github.com/AlexDickerson)).

--- a/Wabbajack.Downloaders.WabbajackCDN/WabbajackCDNDownloader.cs
+++ b/Wabbajack.Downloaders.WabbajackCDN/WabbajackCDNDownloader.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Net.Http;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;

--- a/Wabbajack.Downloaders.WabbajackCDN/WabbajackCDNDownloader.cs
+++ b/Wabbajack.Downloaders.WabbajackCDN/WabbajackCDNDownloader.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Net.Http;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -92,11 +93,6 @@ public class WabbajackCDNDownloader : ADownloader<WabbajackCDN>, IUrlDownloader,
                 if (!response.IsSuccessStatusCode)
                     throw new InvalidDataException($"Bad response for part request for part {part.Index}");
 
-                var length = response.Content.Headers.ContentLength;
-                if (length != part.Size)
-                    throw new InvalidDataException(
-                        $"Bad part size, expected {part.Size} got {length} for part {part.Index}");
-
                 await using var data = await response.Content.ReadAsStreamAsync(token);
 
                 var ms = new MemoryStream();
@@ -174,11 +170,6 @@ public class WabbajackCDNDownloader : ADownloader<WabbajackCDN>, IUrlDownloader,
         using var response = await _client.SendAsync(msg, HttpCompletionOption.ResponseHeadersRead, token);
         if (!response.IsSuccessStatusCode)
             throw new InvalidDataException($"Bad response for part request for part {part.Index}");
-
-        var length = response.Content.Headers.ContentLength;
-        if (length != part.Size)
-            throw new InvalidDataException(
-                $"Bad part size, expected {part.Size} got {length} for part {part.Index}");
 
         return await response.Content.ReadAsByteArrayAsync(token);
     }


### PR DESCRIPTION
Due to new Cloudflare chunked responses missing a Content-Length header.