### PR TITLE
Add additonal checks to GetGPUName() to avoid issues with virtual GPUs

### DIFF
--- a/Wabbajack.App.Wpf/Util/SystemParametersConstructor.cs
+++ b/Wabbajack.App.Wpf/Util/SystemParametersConstructor.cs
@@ -124,7 +124,7 @@ namespace Wabbajack.Util
 
         private string GetGPUName()
         {
-            var gpuManufacturers = new [] {"amd", "intel", "nvidia"};
+            HashSet<string> gpuManufacturers = ["amd", "intel", "nvidia"];
             string gpuName = "";
             uint gpuRefreshRate = 0;
             
@@ -134,13 +134,16 @@ namespace Wabbajack.Util
             
                 foreach (ManagementObject obj in videoControllers.Get())
                 {
-                    if(obj["CurrentRefreshRate"] != null && obj["Description"] != null) {
+                    if (obj["CurrentRefreshRate"] != null && obj["Description"] != null)
+                    {
                         var currentRefreshRate = (uint)obj["CurrentRefreshRate"];
                         var currentName = obj["Description"].ToString();
                         
                         if (gpuManufacturers.Any(s => currentName.Contains(s, StringComparison.OrdinalIgnoreCase)) && currentRefreshRate > gpuRefreshRate)
+                        {
                             gpuName = currentName;
                             gpuRefreshRate = currentRefreshRate;
+                        }
                     }
                 }
             }

--- a/Wabbajack.App.Wpf/Util/SystemParametersConstructor.cs
+++ b/Wabbajack.App.Wpf/Util/SystemParametersConstructor.cs
@@ -124,18 +124,24 @@ namespace Wabbajack.Util
 
         private string GetGPUName()
         {
+            var gpuManufacturers = new [] {"amd", "intel", "nvidia"};
             string gpuName = "";
+            uint gpuRefreshRate = 0;
+            
             try
             {
                 ManagementObjectSearcher videoControllers = new ManagementObjectSearcher("SELECT * FROM Win32_VideoController");
-
-                uint gpuRefreshRate = 0;
-
+            
                 foreach (ManagementObject obj in videoControllers.Get())
                 {
-                    var currentRefreshRate = (uint)obj["CurrentRefreshRate"];
-                    if (currentRefreshRate > gpuRefreshRate)
-                        gpuName = obj["Description"].ToString();
+                    if(obj["CurrentRefreshRate"] != null && obj["Description"] != null) {
+                        var currentRefreshRate = (uint)obj["CurrentRefreshRate"];
+                        var currentName = obj["Description"].ToString();
+                        
+                        if (gpuManufacturers.Any(s => currentName.Contains(s, StringComparison.OrdinalIgnoreCase)) && currentRefreshRate > gpuRefreshRate)
+                            gpuName = currentName;
+                            gpuRefreshRate = currentRefreshRate;
+                    }
                 }
             }
             catch(Exception ex)


### PR DESCRIPTION
As discussed on discord (https://discord.com/channels/605449136870916175/640958797820461082/1350043639228928000), this should fix the following issues in `Wabbajack.Util.GetGPUName()`:
 - Exceptions with (virtual) GPUs that have no refresh rate or description by validating the objects before casting them
 - Returning virtual GPUs by filtering on common manufacturers
 - Always returning the last GPU instead of the one with the highest refresh rate