### PR TITLE
Return of the changelog CLI command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### Changelog
 
-#### Version - 4.0.1.0 - Unreleased
+#### Version - 4.0.1.0 - 4/18/2025
 * Fixed subfolders of profiles showing up under additional profiles within compiler settings
 * Fixed Nexus login not taking cancellation token into account while waiting for authorization (closing the Nexus login prompt did not work)
 * Added 2FA support for MEGA login, added some extra logging for MEGA logins

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### Changelog
 
+#### Version - 4.0.2.0 - Unreleased
+* Added back the changelog CLI command to allow for Wabbajack to create changelogs when given two different Wabbajack files.
+
 #### Version - 4.0.1.0 - 4/18/2025
 * Fixed subfolders of profiles showing up under additional profiles within compiler settings
 * Fixed Nexus login not taking cancellation token into account while waiting for authorization (closing the Nexus login prompt did not work)

--- a/Wabbajack.CLI/Verbs/Changelog.cs
+++ b/Wabbajack.CLI/Verbs/Changelog.cs
@@ -387,6 +387,7 @@ public class Changelog
         }
         return text;
     }
+    
     private static string ToTocLink(string header)
     {
         return header.Trim().Replace(" ", "").Replace(".", "");

--- a/Wabbajack.CLI/Verbs/Changelog.cs
+++ b/Wabbajack.CLI/Verbs/Changelog.cs
@@ -193,7 +193,7 @@ public class Changelog
         
         removedArchives.Do(a =>
         {
-            mdBuilder.AppendLine($"- Removed [{GetModName(a)}]({GetManifestUrl(a)})");
+            mdBuilder.AppendLine($"- Removed [{GetModName(a)}{GetModVersion(a)}]({GetManifestUrl(a)})");
         });
 
         // Blank line for presentation

--- a/Wabbajack.Launcher/ViewModels/MainWindowViewModel.cs
+++ b/Wabbajack.Launcher/ViewModels/MainWindowViewModel.cs
@@ -249,7 +249,7 @@ public class MainWindowViewModel : ViewModelBase
         try
         {
             var entryPoint = KnownFolders.EntryPoint;
-            if (KnownFolders.IsInSpecialFolder(entryPoint) || entryPoint.Depth <= 1)
+            if (KnownFolders.IsInSpecialFolder(entryPoint, out var _) || entryPoint.Depth <= 1)
             {
                 var msg = MsBox.Avalonia.MessageBoxManager
                     .GetMessageBoxStandard(new MessageBoxStandardParams()

--- a/buildall.bat
+++ b/buildall.bat
@@ -10,13 +10,13 @@ dotnet publish Wabbajack.App.Wpf\Wabbajack.App.Wpf.csproj --framework "net9.0-wi
 dotnet publish Wabbajack.Launcher\Wabbajack.Launcher.csproj --framework "net9.0-windows" --runtime win-x64 --configuration Release /p:Platform=x64 -o c:\tmp\publish-wj\launcher /p:PublishSingleFile=true /p:PublishSingleFile=true /p:IncludeNativeLibrariesForSelfExtract=true --self-contained  /p:DebugType=embedded
 dotnet publish Wabbajack.CLI\Wabbajack.CLI.csproj --framework "net9.0" --runtime win-x64 --configuration Release /p:Platform=x64 -o c:\tmp\publish-wj\app\cli  /p:IncludeNativeLibrariesForSelfExtract=true --self-contained  /p:DebugType=embedded
 
-c:
-cd C:\tmp\CodeSignTool-v1.3.2-windows\
+t:
+cd t:\oss\CodeSignTool\
 call CodeSignTool.bat sign -input_file_path c:\tmp\publish-wj\app\Wabbajack.exe -username=%CODE_SIGN_USER% -password=%CODE_SIGN_PASS%
 call CodeSignTool.bat sign -input_file_path c:\tmp\publish-wj\launcher\Wabbajack.exe -username=%CODE_SIGN_USER% -password=%CODE_SIGN_PASS%
 call CodeSignTool.bat sign -input_file_path c:\tmp\publish-wj\app\cli\wabbajack-cli.exe -username=%CODE_SIGN_USER% -password=%CODE_SIGN_PASS%
-e:
-cd e:\oss\Wabbajack
+t:
+cd t:\oss\Wabbajack
 
 REM "C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x64\signtool.exe" sign /fd sha256 /tr http://ts.ssl.com /td sha256 /sha1 4f60ccdc98d879537ee3cabda8da56e068f79d3b c:\tmp\publish-wj\app\Wabbajack.exe
 REM "C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x64\signtool.exe" sign /fd sha256 /tr http://ts.ssl.com /td sha256 /sha1 4f60ccdc98d879537ee3cabda8da56e068f79d3b c:\tmp\publish-wj\launcher\Wabbajack.exe


### PR DESCRIPTION
Changelog CLI command added (restored) that takes in 2 `*.wabbajack` files and compares them. It outputs a Markdown file detailing all changes including:
- download/install size changes
- download archive changes (new/updated/removed)
- load order changes (where applicable)
- mod changes (ie you remove an installed mod but keep the download to use some of its files elsewhere)

The changelog file will also be updated with new versions, if you specify the same output file.

Useage is: 
`.\wabbajack-cli.exe changelog -or {path to original Wabbajack file} -u {path to updated Wabbajack file} -o {path to changelog markdown file}`

or

`.\wabbajack-cli.exe changelog --original {path to original Wabbajack file} --updated {path to updated Wabbajack file} --output {path to changelog markdown file}`

Sample changelog: [changelog.md](https://github.com/user-attachments/files/19821084/changelog.md)