### PR TITLE
Fixed the automated version number with signed builds

### DIFF
--- a/Wabbajack.App.Wpf/Wabbajack.App.Wpf.csproj
+++ b/Wabbajack.App.Wpf/Wabbajack.App.Wpf.csproj
@@ -6,6 +6,7 @@
     <UseWPF>true</UseWPF>
     <Platforms>x64</Platforms>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <VERSION Condition=" '$(VERSION)' == ''">4.0.0.0</VERSION>
     <Version>$(VERSION)</Version>
     <AssemblyVersion>$(VERSION)</AssemblyVersion>
     <FileVersion>$(VERSION)</FileVersion>

--- a/Wabbajack.App.Wpf/Wabbajack.App.Wpf.csproj
+++ b/Wabbajack.App.Wpf/Wabbajack.App.Wpf.csproj
@@ -7,8 +7,8 @@
     <Platforms>x64</Platforms>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <Version>$(VERSION)</Version>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
-    <FileVersion>4.0.0.0</FileVersion>
+    <AssemblyVersion>$(VERSION)</AssemblyVersion>
+    <FileVersion>$(VERSION)</FileVersion>
     <Copyright>Copyright © 2019-2024</Copyright>
     <Description>An automated ModList installer</Description>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/Wabbajack.App.Wpf/Wabbajack.App.Wpf.csproj
+++ b/Wabbajack.App.Wpf/Wabbajack.App.Wpf.csproj
@@ -10,7 +10,7 @@
     <Version>$(VERSION)</Version>
     <AssemblyVersion>$(VERSION)</AssemblyVersion>
     <FileVersion>$(VERSION)</FileVersion>
-    <Copyright>Copyright © 2019-2024</Copyright>
+    <Copyright>Copyright © 2019-$([System.DateTime]::Now.ToString('yyyy'))</Copyright>
     <Description>An automated ModList installer</Description>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
    <!-- <IncludeSymbolsInSingleFile>true</IncludeSymbolsInSingleFile> -->

--- a/Wabbajack.CLI/Wabbajack.CLI.csproj
+++ b/Wabbajack.CLI/Wabbajack.CLI.csproj
@@ -6,6 +6,7 @@
         <TargetFramework Condition=" '$(OS)' != 'Windows_NT'">net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
+        <VERSION Condition=" '$(VERSION)' == ''">4.0.0.0</VERSION>
         <Version>$(VERSION)</Version>
         <AssemblyName>wabbajack-cli</AssemblyName>
         <PublishTrimmed>true</PublishTrimmed>

--- a/Wabbajack.Common/Wabbajack.Common.csproj
+++ b/Wabbajack.Common/Wabbajack.Common.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
+        <VERSION Condition=" '$(VERSION)' == ''">4.0.0.0</VERSION>
         <Version>$(VERSION)</Version>
     </PropertyGroup>
 

--- a/Wabbajack.Compiler/Wabbajack.Compiler.csproj
+++ b/Wabbajack.Compiler/Wabbajack.Compiler.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
+        <VERSION Condition=" '$(VERSION)' == ''">4.0.0.0</VERSION>
         <Version>$(VERSION)</Version>
         <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
     </PropertyGroup>

--- a/Wabbajack.Compression.BSA/Wabbajack.Compression.BSA.csproj
+++ b/Wabbajack.Compression.BSA/Wabbajack.Compression.BSA.csproj
@@ -5,6 +5,7 @@
         <Nullable>enable</Nullable>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
+        <VERSION Condition=" '$(VERSION)' == ''">4.0.0.0</VERSION>
         <Version>$(VERSION)</Version>
     </PropertyGroup>
 

--- a/Wabbajack.DTOs.ConverterGenerators/Wabbajack.DTOs.ConverterGenerators.csproj
+++ b/Wabbajack.DTOs.ConverterGenerators/Wabbajack.DTOs.ConverterGenerators.csproj
@@ -4,6 +4,7 @@
         <OutputType>Exe</OutputType>
         <TargetFramework>net9.0</TargetFramework>
         <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
+        <VERSION Condition=" '$(VERSION)' == ''">4.0.0.0</VERSION>
         <Version>$(VERSION)</Version>
         <NoWarn>CS8600</NoWarn>
         <NoWarn>CS8601</NoWarn>

--- a/Wabbajack.DTOs/Wabbajack.DTOs.csproj
+++ b/Wabbajack.DTOs/Wabbajack.DTOs.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
+        <VERSION Condition=" '$(VERSION)' == ''">4.0.0.0</VERSION>
         <Version>$(VERSION)</Version>
         <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
     </PropertyGroup>

--- a/Wabbajack.Downloaders.Dispatcher/Wabbajack.Downloaders.Dispatcher.csproj
+++ b/Wabbajack.Downloaders.Dispatcher/Wabbajack.Downloaders.Dispatcher.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
+        <VERSION Condition=" '$(VERSION)' == ''">4.0.0.0</VERSION>
         <Version>$(VERSION)</Version>
         <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
     </PropertyGroup>

--- a/Wabbajack.Downloaders.GoogleDrive/Wabbajack.Downloaders.GoogleDrive.csproj
+++ b/Wabbajack.Downloaders.GoogleDrive/Wabbajack.Downloaders.GoogleDrive.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
+        <VERSION Condition=" '$(VERSION)' == ''">4.0.0.0</VERSION>
         <Version>$(VERSION)</Version>
         <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
     </PropertyGroup>

--- a/Wabbajack.Downloaders.Http/Wabbajack.Downloaders.Http.csproj
+++ b/Wabbajack.Downloaders.Http/Wabbajack.Downloaders.Http.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
+        <VERSION Condition=" '$(VERSION)' == ''">4.0.0.0</VERSION>
         <Version>$(VERSION)</Version>
         <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
     </PropertyGroup>

--- a/Wabbajack.Downloaders.Interfaces/Wabbajack.Downloaders.Interfaces.csproj
+++ b/Wabbajack.Downloaders.Interfaces/Wabbajack.Downloaders.Interfaces.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
+        <VERSION Condition=" '$(VERSION)' == ''">4.0.0.0</VERSION>
         <Version>$(VERSION)</Version>
     </PropertyGroup>
 

--- a/Wabbajack.Downloaders.Nexus/Wabbajack.Downloaders.Nexus.csproj
+++ b/Wabbajack.Downloaders.Nexus/Wabbajack.Downloaders.Nexus.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
+        <VERSION Condition=" '$(VERSION)' == ''">4.0.0.0</VERSION>
         <Version>$(VERSION)</Version>
     </PropertyGroup>
 

--- a/Wabbajack.Downloaders.WabbajackCDN/Wabbajack.Downloaders.WabbajackCDN.csproj
+++ b/Wabbajack.Downloaders.WabbajackCDN/Wabbajack.Downloaders.WabbajackCDN.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
+        <VERSION Condition=" '$(VERSION)' == ''">4.0.0.0</VERSION>
         <Version>$(VERSION)</Version>
         <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
     </PropertyGroup>

--- a/Wabbajack.FileExtractor/Wabbajack.FileExtractor.csproj
+++ b/Wabbajack.FileExtractor/Wabbajack.FileExtractor.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
+        <VERSION Condition=" '$(VERSION)' == ''">4.0.0.0</VERSION>
         <Version>$(VERSION)</Version>
         <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
     </PropertyGroup>

--- a/Wabbajack.Hashing.PHash/Wabbajack.Hashing.PHash.csproj
+++ b/Wabbajack.Hashing.PHash/Wabbajack.Hashing.PHash.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
+        <VERSION Condition=" '$(VERSION)' == ''">4.0.0.0</VERSION>
         <Version>$(VERSION)</Version>
         <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
     </PropertyGroup>

--- a/Wabbajack.Hashing.xxHash64/Wabbajack.Hashing.xxHash64.csproj
+++ b/Wabbajack.Hashing.xxHash64/Wabbajack.Hashing.xxHash64.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
+        <VERSION Condition=" '$(VERSION)' == ''">4.0.0.0</VERSION>
         <Version>$(VERSION)</Version>
         <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/Wabbajack.Installer/Wabbajack.Installer.csproj
+++ b/Wabbajack.Installer/Wabbajack.Installer.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
+        <VERSION Condition=" '$(VERSION)' == ''">4.0.0.0</VERSION>
         <Version>$(VERSION)</Version>
         <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
     </PropertyGroup>

--- a/Wabbajack.Networking.Discord/Wabbajack.Networking.Discord.csproj
+++ b/Wabbajack.Networking.Discord/Wabbajack.Networking.Discord.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
+        <VERSION Condition=" '$(VERSION)' == ''">4.0.0.0</VERSION>
         <Version>$(VERSION)</Version>
     </PropertyGroup>
 

--- a/Wabbajack.Networking.GitHub/Wabbajack.Networking.GitHub.csproj
+++ b/Wabbajack.Networking.GitHub/Wabbajack.Networking.GitHub.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
+        <VERSION Condition=" '$(VERSION)' == ''">4.0.0.0</VERSION>
         <Version>$(VERSION)</Version>
     </PropertyGroup>
 

--- a/Wabbajack.Networking.Http.Interfaces/Wabbajack.Networking.Http.Interfaces.csproj
+++ b/Wabbajack.Networking.Http.Interfaces/Wabbajack.Networking.Http.Interfaces.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
+        <VERSION Condition=" '$(VERSION)' == ''">4.0.0.0</VERSION>
         <Version>$(VERSION)</Version>
         <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
     </PropertyGroup>

--- a/Wabbajack.Networking.Http/Wabbajack.Networking.Http.csproj
+++ b/Wabbajack.Networking.Http/Wabbajack.Networking.Http.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
+        <VERSION Condition=" '$(VERSION)' == ''">4.0.0.0</VERSION>
         <Version>$(VERSION)</Version>
     </PropertyGroup>
 

--- a/Wabbajack.Networking.NexusApi/Wabbajack.Networking.NexusApi.csproj
+++ b/Wabbajack.Networking.NexusApi/Wabbajack.Networking.NexusApi.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
+        <VERSION Condition=" '$(VERSION)' == ''">4.0.0.0</VERSION>
         <Version>$(VERSION)</Version>
     </PropertyGroup>
     

--- a/Wabbajack.Networking.WabbajackClientApi/Wabbajack.Networking.WabbajackClientApi.csproj
+++ b/Wabbajack.Networking.WabbajackClientApi/Wabbajack.Networking.WabbajackClientApi.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
+        <VERSION Condition=" '$(VERSION)' == ''">4.0.0.0</VERSION>
         <Version>$(VERSION)</Version>
         <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
     </PropertyGroup>

--- a/Wabbajack.Paths.IO/Wabbajack.Paths.IO.csproj
+++ b/Wabbajack.Paths.IO/Wabbajack.Paths.IO.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
+        <VERSION Condition=" '$(VERSION)' == ''">4.0.0.0</VERSION>
         <Version>$(VERSION)</Version>
     </PropertyGroup>
 

--- a/Wabbajack.Paths/Wabbajack.Paths.csproj
+++ b/Wabbajack.Paths/Wabbajack.Paths.csproj
@@ -3,6 +3,7 @@
         <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
+        <VERSION Condition=" '$(VERSION)' == ''">4.0.0.0</VERSION>
         <Version>$(VERSION)</Version>
     </PropertyGroup>
     <PropertyGroup Condition="'$(IsWindows)'=='true'">

--- a/Wabbajack.Services.OSIntegrated/Wabbajack.Services.OSIntegrated.csproj
+++ b/Wabbajack.Services.OSIntegrated/Wabbajack.Services.OSIntegrated.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
+        <VERSION Condition=" '$(VERSION)' == ''">4.0.0.0</VERSION>
         <Version>$(VERSION)</Version>
         <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
     </PropertyGroup>

--- a/Wabbajack.VFS/Wabbajack.VFS.csproj
+++ b/Wabbajack.VFS/Wabbajack.VFS.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
+        <VERSION Condition=" '$(VERSION)' == ''">4.0.0.0</VERSION>
         <Version>$(VERSION)</Version>
         <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
     </PropertyGroup>


### PR DESCRIPTION
Changed the configs to use the `VERSION` environment variable again that is found via the `CHANGELOG.md` file by the `build_all.bat` build script that is used for making the signed release builds.    

I also added a fallback for debug builds to use `4.0.0.0` as their version number if the environment variable is not set on the current system.