### PR TITLE
Add File ID to Nexus link in missing files report

### DIFF
--- a/Wabbajack.App.Wpf/ViewModels/Installers/InstallationVM.cs
+++ b/Wabbajack.App.Wpf/ViewModels/Installers/InstallationVM.cs
@@ -767,7 +767,7 @@ public class InstallationVM : ProgressViewModel, ICpuStatusVM
                         IPS4OAuth2 ips4 => ips4.LinkUrl.ToString(),
                         GoogleDrive gd => gd.GetUri().ToString(),
                         Http http => http.Url.ToString(),
-                        Nexus nexus => nexus.LinkUrl.ToString(),
+                        Nexus nexus => $"{nexus.LinkUrl}?tab=files&file_id={nexus.FileID}",
                         _ => string.Empty
                     };
                     writer.Write($"<td><a data-tooltip='{url}' href='{url}' target='_blank'>{stateName}</a></td>");


### PR DESCRIPTION
Simple implementation of feature request #2777

Updated href of missing Nexus archives in the missing files report to include File ID. Link now opens to the specific file needed, instead of the mod page.