### PR TITLE
Actually allow WJ to source from other games, SkyrimAE to SkyrimVR and F4 to F4VR

### DIFF
--- a/Wabbajack.App.Wpf/ViewModels/Installers/InstallationVM.cs
+++ b/Wabbajack.App.Wpf/ViewModels/Installers/InstallationVM.cs
@@ -619,9 +619,11 @@ public class InstallationVM : ProgressViewModel, ICpuStatusVM
 
             try
             {
+                var canSource = GameRegistry.Games[ModList.GameType].CanSourceFrom ?? Array.Empty<Game>();
                 var cfg = new InstallerConfiguration
                 {
                     Game = ModList.GameType,
+                    OtherGames = canSource,
                     Downloads = Installer.DownloadLocation.TargetPath,
                     Install = Installer.Location.TargetPath,
                     ModList = ModList,

--- a/Wabbajack.Installer/AInstaller.cs
+++ b/Wabbajack.Installer/AInstaller.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -455,32 +455,45 @@ public abstract class AInstaller<T>
         NextStep(Consts.StepHashing, "Hashing Archives", 0);
         _logger.LogInformation("Looking for files to hash");
 
+        // Collect all game folders – primary plus other games
+        var gameFolders = new HashSet<AbsolutePath>();
+
+        void AddIfValid(AbsolutePath p)
+        {
+            if (p != default && p != AbsolutePath.Empty)
+                gameFolders.Add(p);
+        }
+
+        AddIfValid(_gameLocator.GameLocation(_configuration.Game));
+
+        foreach (var g in _configuration.OtherGames ?? Array.Empty<Game>())
+            AddIfValid(_gameLocator.GameLocation(g));
+
+        // Enumerate downloads + every game folder
         var allFiles = _configuration.Downloads.EnumerateFiles()
-            .Concat(_gameLocator.GameLocation(_configuration.Game).EnumerateFiles())
+            .Concat(gameFolders.SelectMany(p => p.EnumerateFiles()))
             .ToList();
 
         _logger.LogInformation("Getting archive sizes");
-        var hashDict = (await allFiles.PMapAllBatched(_limiter, x => (x, x.Size())).ToList())
+        var hashDict = (await allFiles.PMapAllBatched(_limiter,
+                                                      x => (x, x.Size())).ToList())
             .GroupBy(f => f.Item2)
             .ToDictionary(g => g.Key, g => g.Select(v => v.x));
 
         _logger.LogInformation("Linking archives to downloads");
         var toHash = ModList.Archives.Where(a => hashDict.ContainsKey(a.Size))
-            .SelectMany(a => hashDict[a.Size]).ToList();
+            .SelectMany(a => hashDict[a.Size])
+            .ToList();
 
         MaxStepProgress = toHash.Count;
+        _logger.LogInformation("Found {count} total files, {hashedCount} matching filesize",
+                               allFiles.Count, toHash.Count);
 
-        _logger.LogInformation("Found {count} total files, {hashedCount} matching filesize", allFiles.Count,
-            toHash.Count);
-
-        var hashResults = await
-            toHash
-                .PMapAll(async e =>
-                {
-                    UpdateProgress(1);
-                    return (await FileHashCache.FileHashCachedAsync(e, token), e);
-                })
-                .ToList();
+        var hashResults = await toHash.PMapAll(async e =>
+        {
+            UpdateProgress(1);
+            return (await FileHashCache.FileHashCachedAsync(e, token), e);
+        }).ToList();
 
         HashedArchives = hashResults
             .OrderByDescending(e => e.Item2.LastModified())
@@ -489,6 +502,8 @@ public abstract class AInstaller<T>
             .Where(x => x.Item1 != default)
             .ToDictionary(kv => kv.Item1, kv => kv.e);
     }
+
+
 
 
     /// <summary>

--- a/Wabbajack.Installer/InstallerConfiguration.cs
+++ b/Wabbajack.Installer/InstallerConfiguration.cs
@@ -1,3 +1,4 @@
+using System;
 using Wabbajack.DTOs;
 using Wabbajack.Paths;
 
@@ -11,6 +12,7 @@ public class InstallerConfiguration
     public AbsolutePath Downloads { get; set; }
     public SystemParameters? SystemParameters { get; set; }
     public Game Game { get; set; }
+    public Game[]? OtherGames { get; set; } = Array.Empty<Game>();
     public AbsolutePath GameFolder { get; set; }
 
     public ModlistMetadata? Metadata { get; set; }


### PR DESCRIPTION
Half of the functionality is already there in WJ, this fixes the other half

I can add "othergames" in compiler settings text file, this allows the compiler to source from the other games game directory, and the VR list with AE DLC compiles fine.

But on the installer end, WJ never added the other games directory to its list of directories to hash existing files from, ive hooked that up and it seems to work when I try and install Tempus VR , it scans the users SkyrimAE directory and finds the DLC there.  

