### PR TITLE
Allow FNV modlists to source from F3

### DIFF
--- a/Wabbajack.DTOs/Game/GameRegistry.cs
+++ b/Wabbajack.DTOs/Game/GameRegistry.cs
@@ -83,6 +83,7 @@ public static class GameRegistry
                     "FalloutNV.exe".ToRelativePath()
                 },
                 MainExecutable = "FalloutNV.exe".ToRelativePath(),
+                CanSourceFrom = new[] {Game.Fallout3},
                 IconSource = "https://cdn2.steamgriddb.com/icon/c706723a17a2b2acec4f9ebc9f572e31.png"
             }
         },


### PR DESCRIPTION
Allow FNV modlists to source from F3.
I thought this was added years ago but apparently not.