### PR TITLE
Optimization of UI performance, launch times, and doubling of modlist gallery image loading speed

### DIFF
--- a/Wabbajack.App.Wpf/App.xaml.cs
+++ b/Wabbajack.App.Wpf/App.xaml.cs
@@ -33,6 +33,7 @@ using Wabbajack.Paths.IO;
 using Wabbajack.Services.OSIntegrated;
 using Wabbajack.UserIntervention;
 using Wabbajack.Util;
+using Wabbajack.Common;
 using Ext = Wabbajack.Common.Ext;
 
 namespace Wabbajack;
@@ -43,9 +44,11 @@ namespace Wabbajack;
 public partial class App
 {
     private IHost _host;
+    private TimerResolution? _timerRes;
 
     private void OnStartup(object sender, StartupEventArgs e)
     {
+        _timerRes = new TimerResolution(1);
         if (IsAdmin())
         {
             var messageBox = MessageBox.Show("Don't run Wabbajack as Admin!", "Error", MessageBoxButton.OK, MessageBoxImage.Error, MessageBoxResult.OK, MessageBoxOptions.DefaultDesktopOnly);
@@ -191,6 +194,7 @@ public partial class App
 
     protected override void OnExit(ExitEventArgs e)
     {
+        _timerRes?.Dispose();
         base.OnExit(e);
     }
 

--- a/Wabbajack.App.Wpf/Util/ImageCacheManager.cs
+++ b/Wabbajack.App.Wpf/Util/ImageCacheManager.cs
@@ -26,8 +26,9 @@ public class ImageCacheManager
     private async Task SaveImage(Hash hash, MemoryStream ms)
     {
         var path = _imageCachePath.Combine(hash.ToHex());
+        ms.Position = 0;
         await using var fs = new FileStream(path.ToString(), FileMode.Create, FileAccess.Write);
-        ms.WriteTo(fs);
+        await ms.CopyToAsync(fs);
     }
     private async Task<(bool, MemoryStream)> LoadImage(Hash hash)
     {
@@ -105,6 +106,6 @@ public class CachedImage(BitmapImage image)
     private readonly TimeSpan _cacheDuration = TimeSpan.FromMinutes(5);
     
     public BitmapImage Image { get; } = image;
-    
-    public bool IsExpired() => _cachedAt - DateTime.Now > _cacheDuration;
+
+    public bool IsExpired() => DateTime.Now - _cachedAt > _cacheDuration;
 }

--- a/Wabbajack.App.Wpf/Util/ImageCacheManager.cs
+++ b/Wabbajack.App.Wpf/Util/ImageCacheManager.cs
@@ -25,25 +25,24 @@ public class ImageCacheManager
 
     private async Task SaveImage(Hash hash, MemoryStream ms)
     {
-        var path = _imageCachePath.Combine(hash.ToHex());
+        var path = PathFor(hash);
         ms.Position = 0;
-        await using var fs = new FileStream(path.ToString(), FileMode.Create, FileAccess.Write);
+        await using var fs = new FileStream(path.ToString(), FileMode.Create, FileAccess.Write, FileShare.Read);
         await ms.CopyToAsync(fs);
     }
-    private async Task<(bool, MemoryStream)> LoadImage(Hash hash)
-    {
-        MemoryStream imageStream = null;
-        var path = _imageCachePath.Combine(hash.ToHex());
-        if (!path.FileExists())
-        {
-            return (false, imageStream);
-        }
 
-        imageStream = new MemoryStream();
-        await using var fs = new FileStream(path.ToString(), FileMode.Open, FileAccess.Read);
-        await fs.CopyToAsync(imageStream);
-        return (true, imageStream);
+    private async Task<(bool ok, MemoryStream stream)> LoadImage(Hash hash)
+    {
+        var path = PathFor(hash);
+        if (!path.FileExists()) return (false, null);
+
+        var ms = new MemoryStream();
+        await using var fs = new FileStream(path.ToString(), FileMode.Open, FileAccess.Read, FileShare.Read);
+        await fs.CopyToAsync(ms);
+        return (true, ms);
     }
+
+    private AbsolutePath PathFor(Hash hash) => _imageCachePath.Combine(hash.ToHex());
 
     public ImageCacheManager(ILogger<ImageCacheManager> logger, Services.OSIntegrated.Configuration configuration)
     {
@@ -51,25 +50,32 @@ public class ImageCacheManager
         _configuration = configuration;
         _imageCachePath = _configuration.ImageCacheLocation;
         _imageCachePath.CreateDirectory();
-        
+
         RxApp.TaskpoolScheduler.ScheduleRecurringAction(_pollInterval, () =>
         {
-            foreach (var (hash, cachedImage) in _cachedImages)
+            foreach (var (hash, cached) in _cachedImages)
             {
-                if (!cachedImage.IsExpired()) continue;
-                
+                if (!cached.IsExpired()) continue;
+
                 try
                 {
                     _cachedImages.TryRemove(hash, out _);
-                    File.Delete(_configuration.ImageCacheLocation.Combine(hash).ToString());
+                    var path = PathFor(hash);
+                    if (path.FileExists())
+                    {
+                        try { File.Delete(path.ToString()); }
+                        catch (IOException) {  }
+                        catch (UnauthorizedAccessException) {  }
+                    }
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError("Failed to delete cached image {b64}", hash);
+                    _logger.LogError(ex, "Failed to delete cached image {hashHex}", hash.ToHex());
                 }
             }
         });
-        
+
+
     }
 
     public async Task<bool> Add(string url, BitmapImage img)

--- a/Wabbajack.Common/TimerResolution.cs
+++ b/Wabbajack.Common/TimerResolution.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Security;
+
+namespace Wabbajack.Common
+{
+    public sealed class TimerResolution : IDisposable
+    {
+        [SuppressUnmanagedCodeSecurity]
+        [DllImport("winmm.dll", EntryPoint = "timeBeginPeriod", SetLastError = true)]
+        private static extern uint TimeBeginPeriod(uint ms);
+
+        [SuppressUnmanagedCodeSecurity]
+        [DllImport("winmm.dll", EntryPoint = "timeEndPeriod", SetLastError = true)]
+        private static extern uint TimeEndPeriod(uint ms);
+
+        private static readonly object Gate = new();
+        private static int _refCount;
+        private readonly uint _ms;
+        private bool _active;
+
+        public TimerResolution(uint milliseconds = 1)
+        {
+            _ms = milliseconds == 0 ? 1u : milliseconds;
+            lock (Gate)
+            {
+                if (_refCount++ == 0) TimeBeginPeriod(_ms);
+                _active = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            lock (Gate)
+            {
+                if (_active && --_refCount == 0) TimeEndPeriod(_ms);
+                _active = false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Attached a profiler and took a look some paths
First thing I noticed was when I attached the profiler, was WJ immediately ran faster, just by having the profiler attached, this was a mystery

Turns out this is a thing : [https://stackoverflow.com/questions/16612236/why-is-my-c-sharp-program-faster-in-a-profiler/38404066#38404066](https://stackoverflow.com/questions/16612236/why-is-my-c-sharp-program-faster-in-a-profiler/38404066#38404066)

When you attach a profiler, it requests a higher resolution of the system timer, which a lot of apps do when they require high performance ( but higher power usage ) , but Wabbajack does not by default.

When I added some code to manually set this request ( and un-set on exit ) then launch times of the app and responsiveness of the UI felt much better ( took a few less seconds to load up the app in my tests )

This would apparently increase battery usage on mobile and netbooks etc but... well I doubt thats a concern is it?

The second optimization was when I was looking at the hot paths during the phase where WJ is loading all the gallery images, I noticed a lot of time was spent re-encoding/compressing pngs, and a LOT of async tasks stepping over each other, also not changing position of byte reads . 

I limited concurrency and changed the flow to not compress the pngs, ( also fixed a bug in the cache timeout code - it was reversed and always returned false erroneously ) , this reduced the time it took to load all modlist images from 30 seconds to 13 seonds in my test, so a doubling of performance there.

