### PR TITLE
Fix for retry button nuking the modlist

### DIFF
--- a/Wabbajack.App.Wpf/ViewModels/Installers/InstallationVM.cs
+++ b/Wabbajack.App.Wpf/ViewModels/Installers/InstallationVM.cs
@@ -619,25 +619,31 @@ public class InstallationVM : ProgressViewModel, ICpuStatusVM
 
             try
             {
-                var canSource = GameRegistry.Games[ModList.GameType].CanSourceFrom ?? Array.Empty<Game>();
-                var namedgames = ModList.OtherGames;
+                // Always reload the modlist, incase of retrying , so it gets fresh directives and archives
+                var freshModList = await StandardInstaller.LoadFromFile(
+                    _dtos, WabbajackFileLocation.TargetPath);
+
+                var canSource = GameRegistry.Games[freshModList.GameType].CanSourceFrom ?? Array.Empty<Game>();
+                var namedgames = freshModList.OtherGames;
                 var validgames = Array.Empty<Game>();
                 foreach (var g in namedgames)
                 {
                     if (canSource.Contains(g) && GameRegistry.Games.ContainsKey(g))
                         validgames.Add(g);
                 }
+
                 var cfg = new InstallerConfiguration
                 {
-                    Game = ModList.GameType,
+                    Game = freshModList.GameType,
                     OtherGames = validgames,
                     Downloads = Installer.DownloadLocation.TargetPath,
                     Install = Installer.Location.TargetPath,
-                    ModList = ModList,
+                    ModList = freshModList,
                     ModlistArchive = WabbajackFileLocation.TargetPath,
                     SystemParameters = _parametersConstructor.Create(),
-                    GameFolder = _gameLocator.GameLocation(ModList.GameType)
+                    GameFolder = _gameLocator.GameLocation(freshModList.GameType)
                 };
+
                 StandardInstaller = StandardInstaller.Create(_serviceProvider, cfg);
 
 


### PR DESCRIPTION
closes #2778 
closes #2745 

Wabbajack didnt re-initialize the modlist directives on pressing the retry button, it just called begininstall() again, but the modlist directives are modified during an install - instead of operating on copies, therefore the directives are empty or reduced when the install fails and it remains in that state - pressing retry then will have a much smaller list of operations so it thinks that everything in the modlist folder dosnt belong to the modlist and nukes them

This forces begininstall() to re-initialize the modlist object from the configuration

Probably not the cleanest way to do it, but the least invasive.