### PR TITLE
Fix image error spam and more general imagecache fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### Changelog
 
+#### Version - 4.1.0.1 - 3/17/2026
+* HOTFIX: Properly handle "invalid file" responses from Nexus Mods when uploading a collection
+
 #### Version - 4.1.0.0 - 3/11/2026
 * Automated conversion of Wabbajack lists to NexusMods Collection pages by @januarysnow
   - After compilation you can convert your wabbajack list to a format that is understood by Nexusmods as a pseudo-collection, and will create a webpage on their collections section for this list, it will be tagged as a Wabbajack list on there.

--- a/Wabbajack.Compiler/NexusCollectionUploader.cs
+++ b/Wabbajack.Compiler/NexusCollectionUploader.cs
@@ -553,6 +553,7 @@ namespace Wabbajack.Compiler
             string responseBody, ref List<ManifestMod> manifestMods)
         {
             var badModIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var badFileIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             try
             {
@@ -569,16 +570,24 @@ namespace Wabbajack.Compiler
 
                         if (msg.StartsWith("Mod ", StringComparison.OrdinalIgnoreCase))
                         {
-                            var afterMod = msg[4..]; // strip "Mod "
+                            var afterMod = msg[4..];
                             var commaIdx = afterMod.IndexOf(',');
-                            var modIdStr = commaIdx > 0
-                                ? afterMod[..commaIdx].Trim()
-                                : afterMod.Trim();
-
+                            var modIdStr = commaIdx > 0 ? afterMod[..commaIdx].Trim() : afterMod.Trim();
                             if (!string.IsNullOrWhiteSpace(modIdStr))
                             {
                                 badModIds.Add(modIdStr);
                                 _logger.LogWarning("Nexus flagged invalid mod_id={id}: {msg}", modIdStr, msg);
+                            }
+                        }
+                        else if (msg.StartsWith("File ", StringComparison.OrdinalIgnoreCase))
+                        {
+                            var afterFile = msg[5..];
+                            var commaIdx = afterFile.IndexOf(',');
+                            var fileIdStr = commaIdx > 0 ? afterFile[..commaIdx].Trim() : afterFile.Trim();
+                            if (!string.IsNullOrWhiteSpace(fileIdStr))
+                            {
+                                badFileIds.Add(fileIdStr);
+                                _logger.LogWarning("Nexus flagged invalid file_id={id}: {msg}", fileIdStr, msg);
                             }
                         }
                     }
@@ -586,32 +595,37 @@ namespace Wabbajack.Compiler
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "Could not parse 422 details for invalid mod stripping");
+                _logger.LogWarning(ex, "Could not parse 422 error body for invalid mod stripping");
             }
 
-            if (badModIds.Count == 0)
+            if (badModIds.Count == 0 && badFileIds.Count == 0)
             {
                 _logger.LogWarning(
-                    "Received 422 but could not extract any mod ids from response body: {body}",
+                    "Received 422 but could not extract any mod/file ids from response body: {body}",
                     responseBody);
                 return false;
             }
 
             var before = manifestMods.Count;
             manifestMods = manifestMods
-                .Where(m => !badModIds.Contains(m.source.mod_id))
+                .Where(m => !badModIds.Contains(m.source.mod_id) &&
+                            !badFileIds.Contains(m.source.file_id))
                 .ToList();
 
             var removed = before - manifestMods.Count;
             if (removed > 0)
                 _logger.LogWarning(
-                    "Removed {count} invalid mod(s) from manifest (mod_ids: [{ids}]); will retry",
-                    removed, string.Join(", ", badModIds));
+                    "Removed {count} invalid mod(s) from manifest " +
+                    "(mod_ids: [{mids}], file_ids: [{fids}]); will retry",
+                    removed,
+                    string.Join(", ", badModIds),
+                    string.Join(", ", badFileIds));
             else
                 _logger.LogWarning(
-                    "Nexus reported invalid mod_ids [{ids}] but none matched manifest entries — " +
-                    "mod_ids in manifest may differ from those in the error. Cannot strip.",
-                    string.Join(", ", badModIds));
+                    "Nexus reported invalid refs (mod_ids: [{mids}], file_ids: [{fids}]) " +
+                    "but none matched manifest entries. Cannot strip.",
+                    string.Join(", ", badModIds),
+                    string.Join(", ", badFileIds));
 
             return removed > 0;
         }


### PR DESCRIPTION
there was lots of image errors in the log spamming it up

caused by image byte reading already being at EOF or when WPF struggled to read it, like legacy formats. 

lots of “No imaging component found”

also some attempts to read or fetch urls concurrently in reactive updates

Fixed by normalizing to png bytes, resetting stream position, and doing some threading with semaphores for async locking etc

should reduce the error spam and make the cache more reliable and gallery faster to display

Tested and it displayed the images for certain modlists much faster wheras before theyd spin a bit more loading, before refetching from url.

