### PR TITLE
allow wabbajack to use both versions of curios file in installations

### DIFF
--- a/Wabbajack.Installer/AInstaller.cs
+++ b/Wabbajack.Installer/AInstaller.cs
@@ -68,6 +68,7 @@ public abstract class AInstaller<T>
     protected readonly IResource<IInstaller> _limiter;
     private Func<long, string> _statusFormatter = x => x.ToString();
 
+
     private static readonly Dictionary<Hash, Hash[]> EquivalentHashes = new()
     {
         // Curios ESL Steam vs Creation Store versions
@@ -88,7 +89,6 @@ public abstract class AInstaller<T>
             new[] { Hash.FromBase64("DG3YZQj7xwk="), Hash.FromBase64("FQbA20bA5Dw=") }
         }
     };
-
 
     public AInstaller(ILogger<T> logger, InstallerConfiguration config, IGameLocator gameLocator,
         FileExtractor.FileExtractor extractor,
@@ -249,7 +249,7 @@ public abstract class AInstaller<T>
                 {
                     return new { VF = _vfs.Index.FileForArchiveHashPath(a.ArchiveHashPath), Directive = a };
                 }
-                catch (Exception)
+                catch(Exception)
                 {
                     _logger.LogError("Failed to look up file {file} by hash {hash}", a.To.FileName.ToString(), a.Hash.ToString());
                     throw;
@@ -275,27 +275,27 @@ public abstract class AInstaller<T>
                 switch (file)
                 {
                     case PatchedFromArchive pfa:
+                    {
+                        await using var s = await sf.GetStream();
+                        s.Position = 0;
+                        await using var patchDataStream = await InlinedFileStream(pfa.PatchID);
                         {
-                            await using var s = await sf.GetStream();
-                            s.Position = 0;
-                            await using var patchDataStream = await InlinedFileStream(pfa.PatchID);
-                            {
-                                await using var os = destPath.Open(FileMode.Create, FileAccess.ReadWrite, FileShare.None);
-                                var hash = await BinaryPatching.ApplyPatch(s, patchDataStream, os);
-                                ThrowOnNonMatchingHash(file, hash);
-                            }
+                            await using var os = destPath.Open(FileMode.Create, FileAccess.ReadWrite, FileShare.None);
+                            var hash = await BinaryPatching.ApplyPatch(s, patchDataStream, os);
+                            ThrowOnNonMatchingHash(file, hash);
                         }
+                    }
                         break;
 
 
                     case TransformedTexture tt:
-                        {
-                            await using var s = await sf.GetStream();
-                            await using var of = destPath.Open(FileMode.Create, FileAccess.Write);
-                            _logger.LogInformation("Recompressing {Filename}", tt.To.FileName);
-                            await ImageLoader.Recompress(s, tt.ImageState.Width, tt.ImageState.Height, tt.ImageState.MipLevels, tt.ImageState.Format,
-                                of, token);
-                        }
+                    {
+                        await using var s = await sf.GetStream();
+                        await using var of = destPath.Open(FileMode.Create, FileAccess.Write);
+                        _logger.LogInformation("Recompressing {Filename}", tt.To.FileName);
+                        await ImageLoader.Recompress(s, tt.ImageState.Width, tt.ImageState.Height, tt.ImageState.MipLevels, tt.ImageState.Format,
+                            of, token);
+                    }
                         break;
 
 
@@ -318,7 +318,7 @@ public abstract class AInstaller<T>
                 }
                 await FileHashCache.FileHashWriteCache(destPath, file.Hash);
 
-                await job.Report((int)directive.VF.Size, token);
+                await job.Report((int) directive.VF.Size, token);
             }
         }, token);
     }
@@ -333,8 +333,8 @@ public abstract class AInstaller<T>
         _logger.LogError("Hashes for {Path} did not match, expected {Expected} got {Got}", file.To, file.Hash, gotHash);
         throw new Exception($"Hashes for {file.To} did not match, expected {file.Hash} got {gotHash}");
     }
-
-
+    
+    
     protected void ThrowOnNonMatchingHash(CreateBSA bsa, Directive directive, AFile state, Hash hash)
     {
         if (hash == directive.Hash) return;
@@ -363,14 +363,14 @@ public abstract class AInstaller<T>
         {
             var matches = mirrors[archive.Hash].ToArray();
             if (!matches.Any()) continue;
-
+            
             archive.State = matches.First().State;
             _ = _wjClient.SendMetric("rerouted", archive.Hash.ToString());
             _logger.LogInformation("Rerouted {Archive} to {Mirror}", archive.Name,
                 matches.First().State.PrimaryKeyString);
         }
-
-
+        
+        
         foreach (var archive in missing.Where(archive =>
                      !_downloadDispatcher.Downloader(archive).IsAllowed(validationData, archive.State)))
         {
@@ -487,7 +487,7 @@ public abstract class AInstaller<T>
 
         AddIfValid(_gameLocator.GameLocation(_configuration.Game));
 
-
+        
         // .othergames should only be non-null if the compiled list specifically named othergames
         foreach (var g in _configuration.OtherGames ?? Array.Empty<Game>())
         {
@@ -528,7 +528,6 @@ public abstract class AInstaller<T>
             .Where(x => x.Item1 != default)
             .ToDictionary(kv => kv.Item1, kv => kv.e);
 
-        // include equivalent hashes
         HashedArchives = new Dictionary<Hash, AbsolutePath>(baseHashedArchives);
         foreach (var (hash, path) in baseHashedArchives)
         {
@@ -548,6 +547,8 @@ public abstract class AInstaller<T>
     }
 
 
+
+
     /// <summary>
     ///     The user may already have some files in the _configuration.Install. If so we can go through these and
     ///     figure out which need to be updated, deleted, or left alone
@@ -557,7 +558,7 @@ public abstract class AInstaller<T>
         _logger.LogInformation("Optimizing ModList directives");
         UnoptimizedArchives = ModList.Archives;
         UnoptimizedDirectives = ModList.Directives;
-
+        
         var indexed = ModList.Directives.ToDictionary(d => d.To);
 
         var bsasToBuild = await ModList.Directives
@@ -592,11 +593,11 @@ public abstract class AInstaller<T>
 
 
         var profileFolder = _configuration.Install.Combine("profiles");
-        var savePath = (RelativePath)"saves";
+        var savePath = (RelativePath) "saves";
 
         NextStep(Consts.StepPreparing, "Looking for files to delete", 0);
         await _configuration.Install.EnumerateFiles()
-            .PMapAllBatched(_limiter, f =>
+            .PMapAllBatched(_limiter,  f =>
             {
                 var relativeTo = f.RelativeTo(_configuration.Install);
                 if (indexed.ContainsKey(relativeTo) || f.InFolder(_configuration.Downloads))
@@ -625,7 +626,7 @@ public abstract class AInstaller<T>
             {
                 // Get all the folders and all the folder parents
                 // so for foo\bar\baz\qux.txt this emits ["foo", "foo\\bar", "foo\\bar\\baz"]
-                var split = ((string)path.RelativeTo(_configuration.Install)).Split('\\');
+                var split = ((string) path.RelativeTo(_configuration.Install)).Split('\\');
                 return Enumerable.Range(1, split.Length - 1).Select(t => string.Join("\\", split.Take(t)));
             })
             .Distinct()
@@ -653,15 +654,15 @@ public abstract class AInstaller<T>
 
         NextStep(Consts.StepPreparing, "Looking for unmodified files", 0);
         await indexed.Values.PMapAllBatchedAsync(_limiter, async d =>
-        {
-            // Bit backwards, but we want to return null for 
-            // all files we *want* installed. We return the files
-            // to remove from the install list.
-            var path = _configuration.Install.Combine(d.To);
-            if (!existingfiles.Contains(path)) return null;
+            {
+                // Bit backwards, but we want to return null for 
+                // all files we *want* installed. We return the files
+                // to remove from the install list.
+                var path = _configuration.Install.Combine(d.To);
+                if (!existingfiles.Contains(path)) return null;
 
-            return await FileHashCache.FileHashCachedAsync(path, token) == d.Hash ? d : null;
-        })
+                return await FileHashCache.FileHashCachedAsync(path, token) == d.Hash ? d : null;
+            })
             .Do(d =>
             {
                 if (d != null)
@@ -676,7 +677,7 @@ public abstract class AInstaller<T>
             .GroupBy(d => d.ArchiveHashPath.Hash)
             .Select(d => d.Key)
             .ToHashSet();
-
+        
         ModList.Archives = ModList.Archives.Where(a => requiredArchives.Contains(a.Hash)).ToArray();
         ModList.Directives = indexed.Values.ToArray();
     }


### PR DESCRIPTION
Bit of a brute force fix, but for the potential support burden it saves, I consider it worth it

Adds hash equivalent dict to ainstaller, so that when WJ has one hash in the modlist, but user has the other, WJ still proceeds as we know they are the same file.

Currently only has curios hashes. 

