### PR TITLE
 fix to publish button logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### Changelog
 
 #### Version - 4.2.1.0 - TBD
-* Fixed Nexus Collections Publishing not setting the correct Game Version
+* Fixed Nexus Collections Publishing not setting the correct Game Version  
   & Fixed WJ opening the wrong Collection revision on Nexus Mods after a publish ([@januarysnow](https://github.com/januarysnow)) PR #2907  
   & Fixed Issues with the publish button not reporting success or failure correctly ([@januarysnow](https://github.com/januarysnow)) PR # 2913
 * Fixed Gallery Title and Metadata not being displayed when hovering over modlists ([@Lartza](https://github.com/Lartza))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Version - 4.2.1.0 - TBD
 * Fixed Nexus Collections Publishing not setting the correct Game Version
   & Fixed WJ opening the wrong Collection revision on Nexus Mods after a publish ([@januarysnow](https://github.com/januarysnow)) PR #2907
+  & Fixed Issues with the publish button not reporting success or failure correctly ([@januarysnow](https://github.com/januarysnow)) PR # 2913
 * Fixed Gallery Title and Metadata not being displayed when hovering over modlists ([@Lartza](https://github.com/Lartza))
 * Fixed Gallery Game filter ComboBox not working reliably
   & Filters not always applying when switching back to the Gallery Tab ([@EzioTheDeadPoet](https://github.com/EzioTheDeadPoet)) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### Version - 4.2.1.0 - TBD
 * Fixed Nexus Collections Publishing not setting the correct Game Version
-  & Fixed WJ opening the wrong Collection revision on Nexus Mods after a publish ([@januarysnow](https://github.com/januarysnow)) PR #2907
+  & Fixed WJ opening the wrong Collection revision on Nexus Mods after a publish ([@januarysnow](https://github.com/januarysnow)) PR #2907  
   & Fixed Issues with the publish button not reporting success or failure correctly ([@januarysnow](https://github.com/januarysnow)) PR # 2913
 * Fixed Gallery Title and Metadata not being displayed when hovering over modlists ([@Lartza](https://github.com/Lartza))
 * Fixed Gallery Game filter ComboBox not working reliably

--- a/Wabbajack.App.Wpf/ViewModels/Compiler/CompilerMainVM.cs
+++ b/Wabbajack.App.Wpf/ViewModels/Compiler/CompilerMainVM.cs
@@ -62,9 +62,10 @@ public class CompilerMainVM : BaseCompilerVM, ICanGetHelpVM, ICpuStatusVM
     public ICommand OpenFolderCommand { get; }
     public ICommand PublishCommand { get; }
     public ICommand PublishCollectionCommand { get; }
-
     public ICommand RefreshPreflightChecksCommand { get; }
+    public enum PublishResult { None, Success, Failed }
 
+    [Reactive] public PublishResult PublishLastResult { get; set; } = PublishResult.None;
     [Reactive] public bool IsPublishing { get; set; }
     [Reactive] public bool IsPublishingCollection { get; set; }
     [Reactive] public Percent PublishingPercentage { get; set; } = Percent.One;
@@ -183,10 +184,10 @@ public class CompilerMainVM : BaseCompilerVM, ICanGetHelpVM, ICpuStatusVM
                 CurrentStep = Step.Configuration;
                 State = CompilerState.Configuration;
                 ProgressState = ProgressState.Normal;
-                // Reset collection publishing state when entering configuration
                 CollectionPublishingPercentage = Percent.One;
                 CollectionPublishingStage = "";
                 PublishCollectionLastResult = PublishCollectionResult.None;
+                PublishLastResult = PublishResult.None;
             }
 
             this.WhenAnyValue(x => x.CompilerDetailsVM.Settings)
@@ -235,6 +236,7 @@ public class CompilerMainVM : BaseCompilerVM, ICanGetHelpVM, ICpuStatusVM
         try
         {
             BusyStatusText = "Publishing modlist...";
+            PublishLastResult = PublishResult.None;
             IsPublishing = true;
             PublishingPercentage = Percent.Zero;
 
@@ -248,10 +250,12 @@ public class CompilerMainVM : BaseCompilerVM, ICanGetHelpVM, ICpuStatusVM
 
             using var progressSubscription = progress.Subscribe(p => PublishingPercentage = p.PercentDone);
             await publishTask;
+            PublishLastResult = PublishResult.Success;
         }
         catch (Exception ex)
         {
             _logger.LogError("While publishing: {ex}", ex);
+            PublishLastResult = PublishResult.Failed;
         }
         finally
         {

--- a/Wabbajack.App.Wpf/Views/Compiler/CompilerMainView.xaml.cs
+++ b/Wabbajack.App.Wpf/Views/Compiler/CompilerMainView.xaml.cs
@@ -149,12 +149,13 @@ public partial class CompilerMainView : ReactiveUserControl<CompilerMainVM>
                 .BindToStrict(this, v => v.PreflightStatusText.Visibility)
                 .DisposeWith(disposables);
 
-            ViewModel.WhenAnyValue(vm => vm.PublishingPercentage, vm => vm.PreflightChecksPassed)
+            ViewModel.WhenAnyValue(vm => vm.PublishingPercentage, vm => vm.PreflightChecksPassed, vm => vm.PublishLastResult)
                 .ObserveOnGuiThread()
                 .Subscribe(x =>
                 {
                     var pct = x.Item1;
                     var preflightPassed = x.Item2;
+                    var lastResult = x.Item3;
 
                     if (pct != RateLimiter.Percent.One) _ClickedPublish = true;
 
@@ -167,6 +168,10 @@ public partial class CompilerMainView : ReactiveUserControl<CompilerMainVM>
                     else if (pct.Value >= 0 && pct.Value < 1)
                     {
                         PublishButton.Text = "Publishing...";
+                    }
+                    else if (lastResult == CompilerMainVM.PublishResult.Failed)
+                    {
+                        PublishButton.Text = "Publish Failed";
                     }
                     else
                     {


### PR DESCRIPTION
Adding the new attributes for the nexus collection publish button, broke the existing logic for the wabbajack publish button so it didnt display when a publish had failed. This fixes that.

<img width="1927" height="733" alt="image" src="https://github.com/user-attachments/assets/b6952a13-457c-4dce-a99e-9a33a5399896" />
