### PR TITLE
robust slug handling and case sensitivity handling for collection page export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 #### Version - 4.2.1.0 - TBD
 * Fixed Nexus Collections Publishing not setting the correct Game Version  
   & Fixed WJ opening the wrong Collection revision on Nexus Mods after a publish ([@januarysnow](https://github.com/januarysnow)) PR #2907  
-  & Fixed Issues with the publish button not reporting success or failure correctly ([@januarysnow](https://github.com/januarysnow)) PR # 2913
+  & Fixed Issues with the publish button not reporting success or failure correctly ([@januarysnow](https://github.com/januarysnow)) PR # 2913  
   & Fixed Collection Page Creation and Pre-Validation failing in some cases ([@januarysnow](https://github.com/januarysnow)) PR # 2915
 * Fixed BSA order of operations
 * Fixed Gallery Title and Metadata not being displayed when hovering over modlists ([@Lartza](https://github.com/Lartza))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Fixed Nexus Collections Publishing not setting the correct Game Version  
   & Fixed WJ opening the wrong Collection revision on Nexus Mods after a publish ([@januarysnow](https://github.com/januarysnow)) PR #2907  
   & Fixed Issues with the publish button not reporting success or failure correctly ([@januarysnow](https://github.com/januarysnow)) PR # 2913
+  & Fixed Collection Page Creation and Pre-Validation failing in some cases ([@januarysnow](https://github.com/januarysnow)) PR # 2915
 * Fixed BSA order of operations
 * Fixed Gallery Title and Metadata not being displayed when hovering over modlists ([@Lartza](https://github.com/Lartza))
 * Fixed Gallery Game filter ComboBox not working reliably

--- a/Wabbajack.App.Wpf/ViewModels/Compiler/CompilerMainVM.cs
+++ b/Wabbajack.App.Wpf/ViewModels/Compiler/CompilerMainVM.cs
@@ -607,7 +607,7 @@ public class CompilerMainVM : BaseCompilerVM, ICanGetHelpVM, ICpuStatusVM
                         CancellationToken.None);
 
                     _logger.LogInformation("Persisted Nexus mapping to modlists.json: collectionId={id} slug={slug} domain={domain} rev={rev}",
-                        result.CollectionId, result.Slug, listDomain, result.RevisionNumber);
+                        result.CollectionId, slugToPersist, listDomain, result.RevisionNumber);
                 }
                 catch (Exception ex)
                 {

--- a/Wabbajack.App.Wpf/ViewModels/Compiler/CompilerMainVM.cs
+++ b/Wabbajack.App.Wpf/ViewModels/Compiler/CompilerMainVM.cs
@@ -582,6 +582,7 @@ public class CompilerMainVM : BaseCompilerVM, ICanGetHelpVM, ICpuStatusVM
                 collectionJsonPath,
                 Settings.OutputFile,
                 existingCollectionId: existingCollectionId,
+                existingSlug: existingSlug,
                 gameVersion: gameVersion,
                 confirmFallbackToCreate: null,
                 token: CancellationToken.None);
@@ -593,10 +594,14 @@ public class CompilerMainVM : BaseCompilerVM, ICanGetHelpVM, ICpuStatusVM
                 // put mapping back to the author modlists.json
                 try
                 {
+                    var slugToPersist = !string.IsNullOrWhiteSpace(result.Slug)
+                        ? result.Slug
+                        : existingSlug ?? "";
+
                     await _wjClient.SetNexusCollectionMapping(
                         Settings.MachineUrl,
                         result.CollectionId,
-                        result.Slug,
+                        slugToPersist,
                         listDomain,
                         expectedNewRevisionNumber,
                         CancellationToken.None);

--- a/Wabbajack.Compiler/NexusCollectionUploader.cs
+++ b/Wabbajack.Compiler/NexusCollectionUploader.cs
@@ -86,6 +86,7 @@ namespace Wabbajack.Compiler
             AbsolutePath collectionJsonPath,
             AbsolutePath archivePath,
             string? existingCollectionId = null,
+            string? existingSlug = null,
             string? gameVersion = null,
             Func<Task<bool>>? confirmFallbackToCreate = null,
             CancellationToken token = default)
@@ -170,7 +171,7 @@ namespace Wabbajack.Compiler
                 {
                     result = await CreateCollectionRevision(
                         collectionPayload, uploadUuid, existingCollectionId,
-                        modList.IsNSFW, authState.OAuth.AccessToken, collectionJsonPath, token);
+                        modList.IsNSFW, authState.OAuth.AccessToken, collectionJsonPath, existingSlug, token);
 
                     if (result == null)
                         _logger.LogWarning(
@@ -191,7 +192,7 @@ namespace Wabbajack.Compiler
 
                     result = await CreateCollection(
                         collectionPayload, uploadUuid, modList.IsNSFW,
-                        authState.OAuth.AccessToken, collectionJsonPath, token);
+                        authState.OAuth.AccessToken, collectionJsonPath, null,token);
                 }
 
                 if (result != null && result.Success)
@@ -479,21 +480,23 @@ namespace Wabbajack.Compiler
 
         private Task<CollectionUploadResult?> CreateCollection(
             VortexCollection collectionPayload, string uploadUuid, bool adultContent,
-            string accessToken, AbsolutePath collectionJsonPath, CancellationToken token)
+            string accessToken, AbsolutePath collectionJsonPath, string? knownSlug, CancellationToken token)
             => ExecuteCollectionRestCall(
                 $"{RestBaseUrl}/collections",
                 collectionPayload, uploadUuid, adultContent,
                 accessToken, collectionJsonPath,
+                knownSlug: knownSlug,
                 isRevision: false, collectionId: null, token: token);
 
         private Task<CollectionUploadResult?> CreateCollectionRevision(
             VortexCollection collectionPayload, string uploadUuid, string collectionId,
             bool adultContent, string accessToken, AbsolutePath collectionJsonPath,
-            CancellationToken token)
+            string? knownSlug, CancellationToken token)
             => ExecuteCollectionRestCall(
                 $"{RestBaseUrl}/collections/{collectionId}/revisions",
                 collectionPayload, uploadUuid, adultContent,
                 accessToken, collectionJsonPath,
+                knownSlug: knownSlug,
                 isRevision: true, collectionId: collectionId, token: token);
 
 
@@ -645,6 +648,7 @@ namespace Wabbajack.Compiler
             AbsolutePath collectionJsonPath,
             bool isRevision,
             string? collectionId,
+            string? knownSlug,
             CancellationToken token)
         {
             var info = collectionPayload.Info;
@@ -806,23 +810,37 @@ namespace Wabbajack.Compiler
                         returnedRevisionId = data?["revision_id"]?.GetValue<string>() ?? "";
                     }
 
+                    var returnedSlug = data?["slug"]?.GetValue<string>();
+
                     _logger.LogInformation(
-                        "REST response: collectionId={id} revisionId={rev} revisionNumber={num}",
-                        returnedCollectionId, returnedRevisionId, returnedRevisionNumber?.ToString() ?? "not in response");
+                        "REST response: collectionId={id} revisionId={rev} revisionNumber={num} slug={slug}",
+                        returnedCollectionId, returnedRevisionId,
+                        returnedRevisionNumber?.ToString() ?? "not in response",
+                        returnedSlug ?? "not in response");
 
-                    var found = await FindRecentlyCreatedCollection(
-                        info.Name, info.DomainName, accessToken, token,
-                        preferredCollectionId: returnedCollectionId);
+                    // Determine the slug: prefer REST response, then known slug, then GraphQL lookup
+                    var finalSlug = returnedSlug;
 
-                    // Use the revision number from the REST response
-                    // Only fall back to the GraphQL draftRevisionNumber if the REST response didn't include it.
+                    if (string.IsNullOrWhiteSpace(finalSlug))
+                        finalSlug = knownSlug;
+
+                    CollectionUploadResult? found = null;
+                    if (string.IsNullOrWhiteSpace(finalSlug))
+                    {
+                        // Only do the slow GraphQL poll if we truly have no slug
+                        found = await FindRecentlyCreatedCollection(
+                            info.Name, info.DomainName, accessToken, token,
+                            preferredCollectionId: returnedCollectionId);
+                        finalSlug = found?.Slug;
+                    }
+
                     var revisionNumber = returnedRevisionNumber ?? found?.RevisionNumber ?? 1;
 
                     return new CollectionUploadResult
                     {
                         CollectionId = returnedCollectionId,
                         RevisionId = returnedRevisionId,
-                        Slug = found?.Slug ?? "",
+                        Slug = finalSlug ?? "",
                         RevisionNumber = revisionNumber,
                         Success = true
                     };

--- a/Wabbajack.Networking.WabbajackClientApi/Client.cs
+++ b/Wabbajack.Networking.WabbajackClientApi/Client.cs
@@ -544,7 +544,10 @@ public class Client
         var pair = namespacedName.Split("/");
         var wjRepoName = pair[0];
 
-        var repoUrl = (await LoadRepositories())[wjRepoName];
+        var repositories = await LoadRepositories();
+        var repoKey = repositories.Keys.FirstOrDefault(k => k.Equals(wjRepoName, StringComparison.OrdinalIgnoreCase))
+            ?? wjRepoName;
+        var repoUrl = repositories[repoKey];
         var decomposed = repoUrl.LocalPath.Split("/");
         var owner = decomposed[1];
         var repoName = decomposed[2];


### PR DESCRIPTION
There was an edge case where:

preflight checks passed because the normal machineurl WJ handling , handled case sensitivity in the machineurl
But my collection export code did not
preflight checks allowed nexus publish, but did not store the mapping in the modlist.json

duplicate collections where then created with the same name

Subsequent compiles with a corrected capitalized machineurl, made a new collection, stored the mapping correctly
BUT then when pushing a revision, it used the graphql lookup to find the slug, failed due to those duplicate collections with the same name ( the checking for slug is not robust due to the api not returning slug ) - I think this only would fail if there were more than say 2 other collections of the same name, I couldnt replicate on my end, it might also have been made worse by the fact this one author also had a vortex collection named the same.

Then it clobbered over the existing modlist.json mapping with a null slug, causing the same problem to occur again on subsequent pushes.

This change will stop this happening in the first instance due to handling case sensitivity when storing the mapping, AND is more robust with using the existing stored slug from the json when re-storing the mapping after attempting to push a revision, instead of relying on the brittle graphql lookup of existing collections, that can get confused by multiple previous failed attempts that remain in the users collections.

A very complex and rare set of circumstances, but hey, may as well fix it. 

