### PR TITLE
support passing .compiler_settings file as CLI input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### Changelog
 
+#### Version -4.2.2.0 -TBD
+* Added support for passing .compiler_settings file as CLI for compiling lists
+
 #### Version - 4.2.1.4 - 4/21/2026
 * HOTFIX: changed REST variable naming for the Nexus API
 

--- a/Wabbajack.CLI/Verbs/Compile.cs
+++ b/Wabbajack.CLI/Verbs/Compile.cs
@@ -1,10 +1,10 @@
 using System;
-using System.CommandLine;
-using System.CommandLine.NamingConventionBinder;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Wabbajack.CLI.Builder;
+using Wabbajack.Common;
 using Wabbajack.Compiler;
 using Wabbajack.Downloaders;
 using Wabbajack.Downloaders.GameFile;
@@ -49,23 +49,34 @@ public class Compile
     public async Task<int> Run(AbsolutePath installPath, AbsolutePath outputPath,
         CancellationToken token)
     {
-        _logger.LogInformation("Inferring settings");
-        var inferredSettings = await _inferencer.InferFromRootPath(installPath);
-        if (inferredSettings == null)
+        CompilerSettings settings;
+        if (installPath.FileName.Extension == Ext.CompilerSettings)
         {
-            _logger.LogInformation("Error inferencing settings");
-            return 2;
+            _logger.LogInformation("Using specified settings file");
+            await using var fs = installPath.Open(FileMode.Open, FileAccess.Read, FileShare.Read);
+            settings = (await _dtos.DeserializeAsync<CompilerSettings>(fs))!;
+        }
+        else
+        {
+            _logger.LogInformation("Inferring settings");
+            var inferredSettings = await _inferencer.InferFromRootPath(installPath);
+            if (inferredSettings == null)
+            {
+                _logger.LogInformation("Error inferencing settings");
+                return 2;
+            }
+
+            inferredSettings.UseGamePaths = true;
+            settings = inferredSettings;
         }
 
-        inferredSettings.UseGamePaths = true;
-        
         if(outputPath.DirectoryExists())
         {
-            inferredSettings.OutputFile = outputPath.Combine(inferredSettings.OutputFile.FileName);
-            _logger.LogInformation("Output file will be in: {outputPath}", inferredSettings.OutputFile);
+            settings.OutputFile = outputPath.Combine(settings.OutputFile.FileName);
+            _logger.LogInformation("Output file will be in: {outputPath}", settings.OutputFile);
         }
 
-        var compiler = MO2Compiler.Create(_serviceProvider, inferredSettings);
+        var compiler = MO2Compiler.Create(_serviceProvider, settings);
         var result = await compiler.Begin(token);
         if (!result)
             return result ? 0 : 3;


### PR DESCRIPTION
Hey, this PR will allow passing the path to the `.compiler_settings` file as an `-i` argument for the `compile` command of Wabbajack CLI, making it load the settings instead of inferring them.

Not sure if it's the right call to just overload the "installPath" argument, but it seems rather straightforward.