### PR TITLE
Add S.T.A.L.K.E.R. 2: Heart of Chornobyl support

### DIFF
--- a/Wabbajack.DTOs/Game/Game.cs
+++ b/Wabbajack.DTOs/Game/Game.cs
@@ -50,4 +50,5 @@ public enum Game
     [Description("Kingdom Come: Deliverance II")] KingdomComeDeliverance2,
     [Description("Dragon's Dogma 2")] DragonsDogma2,
     [Description("NieR:Automata")] NieRAutomata,
+    [Description("S.T.A.L.K.E.R. 2: Heart of Chornobyl")] Stalker2,
 }

--- a/Wabbajack.DTOs/Game/GameRegistry.cs
+++ b/Wabbajack.DTOs/Game/GameRegistry.cs
@@ -853,8 +853,8 @@ public static class GameRegistry
                 },
                 MainExecutable = @"Stalker2.exe".ToRelativePath(),
                 IconSource = "https://cdn2.steamgriddb.com/icon/a34609d742cf51368e2b466ad10ca6a8/32/256x256.png",    
-        }
-    }, 
+            }
+        }, 
         {
             Game.ModdingTools, new GameMetaData
             {

--- a/Wabbajack.DTOs/Game/GameRegistry.cs
+++ b/Wabbajack.DTOs/Game/GameRegistry.cs
@@ -852,6 +852,7 @@ public static class GameRegistry
                     @"Stalker2.exe".ToRelativePath(),
                 },
                 MainExecutable = @"Stalker2.exe".ToRelativePath()
+                IconSource = "https://cdn2.steamgriddb.com/icon/a34609d742cf51368e2b466ad10ca6a8/32/256x256.png",    
         }
     }, 
         {

--- a/Wabbajack.DTOs/Game/GameRegistry.cs
+++ b/Wabbajack.DTOs/Game/GameRegistry.cs
@@ -851,7 +851,7 @@ public static class GameRegistry
                 {
                     @"Stalker2.exe".ToRelativePath(),
                 },
-                MainExecutable = @"Stalker2.exe".ToRelativePath()
+                MainExecutable = @"Stalker2.exe".ToRelativePath(),
                 IconSource = "https://cdn2.steamgriddb.com/icon/a34609d742cf51368e2b466ad10ca6a8/32/256x256.png",    
         }
     }, 

--- a/Wabbajack.DTOs/Game/GameRegistry.cs
+++ b/Wabbajack.DTOs/Game/GameRegistry.cs
@@ -839,6 +839,22 @@ public static class GameRegistry
             }
         },
         {
+            Game.Stalker2, new GameMetaData
+            {
+                Game = Game.Stalker2,
+                MO2Name = "Stalker 2: Heart of Chornobyl",
+                NexusName = "stalker2heartofchornobyl",
+                NexusGameId = 6944,
+                MO2ArchiveName = "stalker2heartofchornobyl",
+                SteamIDs = [1643320],
+                RequiredFiles = new []
+                {
+                    @"Stalker2.exe".ToRelativePath(),
+                },
+                MainExecutable = @"Stalker2.exe".ToRelativePath()
+        }
+    }, 
+        {
             Game.ModdingTools, new GameMetaData
             {
                 Game = Game.ModdingTools,


### PR DESCRIPTION
Adds initial Wabbajack support for S.T.A.L.K.E.R. 2: Heart of Chornobyl.

Includes:
- Game enum entry
- MO2 game metadata
- Nexus game ID/name
- Steam App ID
- Required executable
- Game icon

Metadata was sourced from the existing MO2 Basic Games plugin for STALKER 2:
https://www.nexusmods.com/stalker2heartofchornobyl/mods/1424