### PR TITLE
Add STALKER 2 support and Steam build ID fallback

### DIFF
--- a/Wabbajack.CLI/Verbs/HashGameFiles.cs
+++ b/Wabbajack.CLI/Verbs/HashGameFiles.cs
@@ -68,16 +68,37 @@ public class HashGameFiles
         }
 
         var version = "0.0.0.0";
+
         if (gameMeta.MainExecutable == null)
         {
             _logger.LogError("Could not find Main Executable for {Game}", gameEnum);
             return 1;
         }
+
         try
         {
             var mainExe = gameLocation.Combine(gameMeta.MainExecutable);
             var info = FileVersionInfo.GetVersionInfo(mainExe.ToString());
-            version = info.ProductVersion ?? info.FileVersion ?? version;
+
+            var productVersion = info.ProductVersion?.Trim();
+            var fileVersion = info.FileVersion?.Trim();
+
+            // Some Unreal Engine games expose the engine changelist as ProductVersion
+            // instead of an actual game version (for example "UE5-CL-0").
+            var isUnrealEngineVersion =
+                !string.IsNullOrWhiteSpace(productVersion) &&
+                productVersion.StartsWith("UE", StringComparison.OrdinalIgnoreCase) &&
+                productVersion.Contains("-CL-", StringComparison.OrdinalIgnoreCase);
+
+            if (isUnrealEngineVersion &&
+                _gameLocator.TryGetSteamBuildId(gameEnum, out var steamBuildId))
+            {
+                version = steamBuildId;
+            }
+            else
+            {
+                version = productVersion ?? fileVersion ?? version;
+            }
         }
         catch
         {

--- a/Wabbajack.Compiler/ACompiler.cs
+++ b/Wabbajack.Compiler/ACompiler.cs
@@ -265,8 +265,31 @@ public abstract class ACompiler
                         _logger.LogWarning("Main file {file} for {game} does not exist", mainFile, ag);
 
                     var versionInfo = FileVersionInfo.GetVersionInfo(mainFile.ToString());
+                    var gameVersion = versionInfo.FileVersion ?? "0.0.0.0";
 
-                    var files = await _wjClient.GetGameArchives(ag, versionInfo.FileVersion ?? "0.0.0.0");
+                    // Some Unreal Engine games expose the engine changelist as their executable
+                    // version rather than a useful game version. For Steam installs, use the
+                    // Steam build ID as a fallback.
+                    var productVersion = versionInfo.ProductVersion?.Trim();
+
+                    var isUnrealEngineVersion =
+                        !string.IsNullOrWhiteSpace(productVersion) &&
+                        productVersion.StartsWith("UE", StringComparison.OrdinalIgnoreCase) &&
+                        productVersion.Contains("-CL-", StringComparison.OrdinalIgnoreCase);
+
+                    if (isUnrealEngineVersion &&
+                        _locator.TryGetSteamBuildId(ag, out var steamBuildId))
+                    {
+                        _logger.LogInformation(
+                            "Using Steam build ID {BuildId} for {Game} instead of Unreal Engine version {Version}",
+                            steamBuildId,
+                            ag,
+                            productVersion);
+
+                        gameVersion = steamBuildId;
+                    }
+
+                    var files = await _wjClient.GetGameArchives(ag, gameVersion);
                     gameFiles.AddRange(files);
 
                     _logger.LogInformation($"Including {files.Length} stock game files from {ag} as download sources");

--- a/Wabbajack.DTOs/Game/Game.cs
+++ b/Wabbajack.DTOs/Game/Game.cs
@@ -40,6 +40,7 @@ public enum Game
     [Description("Final Fantasy VII Remake")] FinalFantasy7Remake,
     [Description("Baldur's Gate 3")] BaldursGate3,
     [Description("Starfield")] Starfield,
+    [Description("S.T.A.L.K.E.R. 2: Heart of Chornobyl")] Stalker2,
     [Description("7 Days to Die")] SevenDaysToDie,
     [Description("Oblivion Remastered")] OblivionRemastered,
     [Description("Fallout 76")] Fallout76,

--- a/Wabbajack.DTOs/Game/GameRegistry.cs
+++ b/Wabbajack.DTOs/Game/GameRegistry.cs
@@ -656,6 +656,22 @@ public static class GameRegistry
             }
         },
         {
+            Game.Stalker2, new GameMetaData
+            {
+                Game = Game.Stalker2,
+                NexusName = "stalker2heartofchornobyl",
+                NexusGameId = 6944,
+                MO2Name = "Stalker2",
+                MO2ArchiveName = "Stalker2",
+                SteamIDs = [1643320],
+                RequiredFiles = new []
+                {
+                    @"Stalker2\Binaries\Win64\Stalker2-Win64-Shipping.exe".ToRelativePath()
+                },
+                MainExecutable = @"Stalker2\Binaries\Win64\Stalker2-Win64-Shipping.exe".ToRelativePath(),
+            }
+        },
+        {
             Game.SevenDaysToDie, new GameMetaData
             {
                 Game = Game.SevenDaysToDie,

--- a/Wabbajack.Downloaders.GameFile/GameLocator.cs
+++ b/Wabbajack.Downloaders.GameFile/GameLocator.cs
@@ -24,7 +24,7 @@ public class GameLocator : IGameLocator
     private readonly OriginHandler? _origin;
     private readonly EADesktopHandler? _eaDesktop;
 
-    private readonly Dictionary<AppId, AbsolutePath> _steamGames = new();
+    private readonly Dictionary<AppId, SteamGame> _steamGames = new();
     private readonly Dictionary<GOGGameId, AbsolutePath> _gogGames = new();
     private readonly Dictionary<EGSGameId, AbsolutePath> _egsGames = new();
     private readonly Dictionary<OriginGameId, AbsolutePath> _originGames = new();
@@ -62,7 +62,33 @@ public class GameLocator : IGameLocator
     {
         try
         {
-            FindStoreGames(_steam, _steamGames, game => (AbsolutePath)game.Path.GetFullPath());
+            var games = _steam.FindAllGamesById(out var errors);
+
+            foreach (var (id, game) in games)
+            {
+                try
+                {
+                    var path = (AbsolutePath)game.Path.GetFullPath();
+
+                    if (!path.DirectoryExists())
+                    {
+                        _logger.LogError("Game does not exist: {Game}", game);
+                        continue;
+                    }
+
+                    _steamGames[id] = game;
+                    _logger.LogInformation("Found {Game}", game);
+                }
+                catch (Exception e)
+                {
+                    _logger.LogError(e, "While locating {Game}", game);
+                }
+            }
+
+            foreach (var error in errors)
+            {
+                _logger.LogError("{Error}", error);
+            }
         }
         catch (Exception e)
         {
@@ -178,7 +204,7 @@ public class GameLocator : IGameLocator
         foreach (var id in metaData.SteamIDs)
         {
             if (!_steamGames.TryGetValue(AppId.From((uint)id), out var found)) continue;
-            path = found;
+            path = (AbsolutePath)found.Path.GetFullPath();
             return true;
         }
 
@@ -211,6 +237,27 @@ public class GameLocator : IGameLocator
         }
 
         path = default;
+        return false;
+    }
+    public bool TryGetSteamBuildId(Game game, out string buildId)
+    {
+        var metaData = game.MetaData();
+
+        foreach (var id in metaData.SteamIDs)
+        {
+            if (!_steamGames.TryGetValue(AppId.From((uint)id), out var steamGame))
+                continue;
+
+            var value = steamGame.AppManifest.BuildId.ToString();
+
+            if (string.IsNullOrWhiteSpace(value) || value == "0")
+                continue;
+
+            buildId = value;
+            return true;
+        }
+
+        buildId = string.Empty;
         return false;
     }
 }

--- a/Wabbajack.Downloaders.GameFile/IGameLocator.cs
+++ b/Wabbajack.Downloaders.GameFile/IGameLocator.cs
@@ -8,4 +8,5 @@ public interface IGameLocator
     public AbsolutePath GameLocation(Game game);
     public bool IsInstalled(Game game);
     public bool TryFindLocation(Game game, out AbsolutePath path);
+    public bool TryGetSteamBuildId(Game game, out string buildId);
 }

--- a/Wabbajack.Services.OSIntegrated/StubbedGameLocator.cs
+++ b/Wabbajack.Services.OSIntegrated/StubbedGameLocator.cs
@@ -31,4 +31,9 @@ public class StubbedGameLocator : IGameLocator
         path = _location.Path;
         return true;
     }
+    public bool TryGetSteamBuildId(Game game, out string buildId)
+    {
+        buildId = string.Empty;
+        return false;
+    }
 }


### PR DESCRIPTION
## Summary

Adds initial S.T.A.L.K.E.R. 2: Heart of Chornobyl support and handles Unreal Engine executables that expose an engine changelist as their product version instead of a useful game version.

S.T.A.L.K.E.R. 2 currently reports `UE5-CL-0` as `ProductVersion`. This prevents Wabbajack from selecting a useful indexed game-file version. For Steam installs, this PR falls back to the Steam app manifest's Build ID when an Unreal Engine changelist-style product version is detected.

## Changes

- Adds S.T.A.L.K.E.R. 2 to the Wabbajack game registry.
  - Steam App ID: `1643320`
  - Nexus Game ID: `6944`
  - MO2 game name: `Stalker2`
- Retains the full `SteamGame` metadata during Steam game discovery so the app manifest Build ID is available.
- Adds `TryGetSteamBuildId()` to `IGameLocator`.
- Detects Unreal Engine changelist-style product versions such as `UE5-CL-0`.
- Uses the Steam Build ID as the indexed game-file version when that condition is encountered.
- Preserves the existing ProductVersion/FileVersion behavior for other games and when a Steam Build ID is unavailable.
- Applies the fallback to both the game-file hashing CLI and compiler archive lookup.

## Testing

Tested against a clean Steam installation of S.T.A.L.K.E.R. 2: Heart of Chornobyl.

Wabbajack successfully:

1. Detected the game through Steam App ID `1643320`.
2. Located the installation outside the default Steam library.
3. Detected the executable's `UE5-CL-0` ProductVersion.
4. Resolved Steam Build ID `24914692`.
5. Generated the indexed game-file data for that Build ID.
6. Retrieved the corresponding `Stalker2/24914692.json` archive data during compilation.
7. Successfully compiled a test S.T.A.L.K.E.R. 2 modlist using the indexed stock game files.

A final Release build of the Wabbajack solution completed with 0 errors.

## Rationale

The Steam Build ID fallback is intentionally limited to executables whose ProductVersion resembles an Unreal Engine changelist (`UE...-CL-...`). Normal game version detection remains unchanged.